### PR TITLE
test: fix installer checks on Linux

### DIFF
--- a/install_test.go
+++ b/install_test.go
@@ -63,7 +63,10 @@ func (fixture *installerFixture) prepareTools() {
 	fixture.t.Helper()
 	// Эти команды не подменяются по смыслу; ссылки лишь не дают тесту случайно
 	// увидеть настоящий plantuml, brew или пакетный менеджер из PATH машины.
-	for _, name := range []string{"awk", "chmod", "cp", "dirname", "grep", "mkdir", "mktemp", "mv", "readlink", "rm", "sed", "tar"} {
+	// GNU tar запускает gzip отдельным процессом при распаковке .tar.gz, поэтому
+	// gzip тоже должен входить в изолированный PATH. BSD tar на macOS распаковывает
+	// тот же архив сам, из-за чего отсутствие ссылки раньше обнаруживалось лишь CI Linux.
+	for _, name := range []string{"awk", "chmod", "cp", "dirname", "grep", "gzip", "mkdir", "mktemp", "mv", "readlink", "rm", "sed", "tar"} {
 		target, err := exec.LookPath(name)
 		if err != nil {
 			fixture.t.Fatalf("для теста установщика нужна команда %s: %v", name, err)


### PR DESCRIPTION
## Что исправлено

- тестовый изолированный PATH теперь включает `gzip`, который GNU tar запускает отдельным процессом при распаковке `.tar.gz`
- добавлен комментарий о различии GNU tar и BSD tar

Это устраняет падение Linux job релизного workflow; production-код установщика не меняется.

## Проверки

- `go test -count=1 -run "^TestInstaller" .`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `git diff --check`

Размер: 5 изменённых строк (4 добавления, 1 удаление).

Follow-up к #20 после первого запуска release workflow.