### PR TITLE
Improve dashboard resilience and status grouping

### DIFF
--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -35,12 +35,21 @@ var pageTemplate = template.Must(template.New("dashboard").Parse(pageHTML))
 type page struct {
 	Title, Refresh string
 	Preview        bool
-	Roots          []*runNode
+	Groups         []runGroup
 	Problems       []problem
 }
 
 // problem — безопасная короткая диагностика одного каталога, не скрывающая дерево.
 type problem struct{ Name, Message string }
+
+// runGroup — сворачиваемая секция корневых workflow с одинаковым итоговым
+// состоянием. Дочерние workflow остаются рядом с родителем: перенос каждого
+// узла в собственную секцию разрушил бы сохранённое дерево связанных запусков.
+type runGroup struct {
+	ID, Title, Tone string
+	Open            bool
+	Roots           []*runNode
+}
 
 // runNode — готовая к HTML структура одного workflow и его потомков. Все URL
 // строит сервер из проверенных ID, поэтому template.URL не содержит сырого ввода.
@@ -86,7 +95,8 @@ type handler struct{ root string }
 // live перечитывает хранилище на каждый polling-запрос.
 func (h handler) live(w http.ResponseWriter, _ *http.Request) {
 	view := page{Title: "Lawa workflows", Refresh: "3"}
-	view.Roots, view.Problems = loadTree(h.root)
+	roots, problems := loadTree(h.root)
+	view.Groups, view.Problems = groupRuns(roots), problems
 	render(w, view)
 }
 
@@ -148,7 +158,7 @@ func loadTree(root string) ([]*runNode, []problem) {
 		if !entry.IsDir() || entry.Name() == "series" {
 			continue
 		}
-		snapshot, loadErr := runstore.Load(root, entry.Name())
+		snapshot, loadErr := runstore.LoadForDashboard(root, entry.Name())
 		if loadErr != nil {
 			problems = append(problems, problem{Name: entry.Name(), Message: diagnostic(loadErr)})
 			continue
@@ -261,6 +271,35 @@ func sortNodes(nodes []*runNode) {
 	}
 }
 
+// groupRuns сохраняет порядок корней внутри каждой секции после sortNodes.
+// Pending относится к работе: workflow ещё не завершён, даже если ни один шаг
+// пока не стартовал. Пустые секции не показываем, чтобы dashboard не занимал
+// место заголовками без запусков.
+func groupRuns(roots []*runNode) []runGroup {
+	groups := []runGroup{
+		{ID: "active", Title: "В работе", Tone: "running", Open: true},
+		{ID: "failed", Title: "Сломавшиеся", Tone: "failed"},
+		{ID: "succeeded", Title: "Успешные", Tone: "succeeded"},
+	}
+	for _, root := range roots {
+		group := 0
+		switch root.State {
+		case "failed":
+			group = 1
+		case "succeeded":
+			group = 2
+		}
+		groups[group].Roots = append(groups[group].Roots, root)
+	}
+	visible := make([]runGroup, 0, len(groups))
+	for _, group := range groups {
+		if len(group.Roots) > 0 {
+			visible = append(visible, group)
+		}
+	}
+	return visible
+}
+
 // tone переводит техническое состояние в ограниченный CSS-словарь.
 func tone(state string) string {
 	switch state {
@@ -363,5 +402,7 @@ func previewPage() page {
 	maintenance := run("preview-maintenance", "nightly-maintenance", "pending",
 		step("collect", "pending", false), step("cleanup-skipped-artifacts", "cancelled", false))
 	maintenance.Open = false
-	return page{Title: "Lawa workflows — preview", Preview: true, Roots: []*runNode{release, maintenance}}
+	failed := run("preview-failed", "failed-nightly-cleanup", "failed", step("cleanup", "failed", true))
+	succeeded := run("preview-succeeded", "previous-release", "succeeded", step("publish", "succeeded", true))
+	return page{Title: "Lawa workflows — preview", Preview: true, Groups: groupRuns([]*runNode{release, maintenance, failed, succeeded})}
 }

--- a/internal/dashboard/dashboard.html
+++ b/internal/dashboard/dashboard.html
@@ -13,6 +13,7 @@
     details{margin:4px 0}summary{display:flex;align-items:center;gap:8px;min-height:30px;cursor:pointer;list-style:none}summary::-webkit-details-marker{display:none}summary:before{content:'›';color:var(--muted);width:9px;transition:transform .12s}details[open]>summary:before{transform:rotate(90deg)}
     .node{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.name{font-weight:600}.id,.updated,.state{color:var(--muted);font-size:12px}.actions{display:flex;gap:10px;margin-left:auto;padding-left:12px;white-space:nowrap}.disabled{color:#555;cursor:not-allowed}
     .dot{display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--muted);flex:0 0 auto}.tone-running{background:var(--link)}.tone-failed{background:var(--red)}.tone-succeeded{background:var(--green)}
+    .groups{display:grid;gap:12px}.status-group{margin:0;border:1px solid var(--line);border-radius:8px;background:var(--surface)}.status-group>summary{min-height:42px;padding:5px 12px}.status-group>.tree{padding:0 12px 10px 28px}.group-title{font:600 14px/1.3 system-ui,sans-serif}
     .step{display:flex;align-items:center;gap:8px;min-height:28px;padding-left:17px}.step .actions{font-size:12px}.problem{border:1px solid #532423;background:#1b0d0d;padding:10px 12px;margin:8px 0;color:#ffb4ae}.empty{border:1px dashed var(--line);color:var(--muted);padding:24px;text-align:center}.badge{color:var(--muted);border:1px solid var(--line);border-radius:999px;padding:2px 7px;font-size:11px}
     @media(max-width:720px){main{padding:20px 12px}.updated,.id{display:none}.actions{gap:7px}.children{margin-left:8px;padding-left:8px}}
   </style>
@@ -21,15 +22,26 @@
   <h1>{{.Title}} {{if .Preview}}<span class="badge">fake data</span>{{end}}</h1>
   <p class="subtitle">Связанные workflow и память кубиков{{if .Refresh}} · обновление каждые {{.Refresh}} сек.{{end}}</p>
   {{range .Problems}}<div class="problem"><strong>{{.Name}}</strong> — {{.Message}}</div>{{end}}
-  {{if .Roots}}<ul class="tree">{{range .Roots}}{{template "run" .}}{{end}}</ul>{{else}}<div class="empty">Запусков пока нет. Создайте workflow командой <code>lawa run</code>.</div>{{end}}
+  {{if .Groups}}<div class="groups">{{range .Groups}}
+    <details class="status-group" data-group="{{.ID}}" {{if .Open}}open{{end}}>
+      <summary>
+        <span class="dot tone-{{.Tone}}" aria-hidden="true"></span>
+        <span class="group-title">{{.Title}}</span>
+        <span class="badge">{{len .Roots}}</span>
+      </summary>
+      <ul class="tree">{{range .Roots}}{{template "run" .}}{{end}}</ul>
+    </details>
+  {{end}}</div>{{else}}<div class="empty">Запусков пока нет. Создайте workflow командой <code>lawa run</code>.</div>{{end}}
 </main>
 <script>
   const key='lawa-dashboard-open:';
-  document.querySelectorAll('details[data-node]').forEach(node=>{
-    const saved=localStorage.getItem(key+node.dataset.node);
+  const remember=(node,id)=>{
+    const saved=localStorage.getItem(key+id);
     if(saved!==null) node.open=saved==='1';
-    node.addEventListener('toggle',()=>localStorage.setItem(key+node.dataset.node,node.open?'1':'0'));
-  });
+    node.addEventListener('toggle',()=>localStorage.setItem(key+id,node.open?'1':'0'));
+  };
+  document.querySelectorAll('details[data-node]').forEach(node=>remember(node,node.dataset.node));
+  document.querySelectorAll('details[data-group]').forEach(node=>remember(node,'group:'+node.dataset.group));
   if(location.pathname==='/preview') document.querySelectorAll('a[href="#preview"]').forEach(a=>a.addEventListener('click',e=>e.preventDefault()));
 </script></body></html>{{end}}
 

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"bytes"
 	"context"
 	"encoding/json/v2"
 	"errors"
@@ -36,6 +37,25 @@ func quoted(value string) string {
 	return string(data)
 }
 
+// addFutureMetadataFields имитирует meta.json, записанный следующей Lawa. Поля
+// добавлены и на верхнем уровне, и внутрь шага — именно второй случай ломал
+// старый dashboard после появления revision.
+func addFutureMetadataFields(t *testing.T, root, runID string) {
+	t.Helper()
+	path := filepath.Join(root, runID, "meta.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := bytes.Replace(data, []byte(`"steps":[{`), []byte(`"futureRunField":true,"steps":[{"futureStepField":"ignored",`), 1)
+	if bytes.Equal(data, updated) {
+		t.Fatal("тест не добавил будущие поля в meta.json")
+	}
+	if err = os.WriteFile(path, updated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func setState(t *testing.T, root string, snapshot runstore.Snapshot, state scheduler.State) {
 	t.Helper()
 	run, err := runstore.OpenLocked(root, snapshot.Meta.RunID)
@@ -61,6 +81,10 @@ func TestDashboard(t *testing.T) {
 	parent := createRun(t, root, `<release>&`, "")
 	setState(t, root, parent, scheduler.Running)
 	child := createRun(t, root, "child-workflow", parent.Meta.RunID)
+	failed := createRun(t, root, "failed-workflow", "")
+	setState(t, root, failed, scheduler.Failed)
+	succeeded := createRun(t, root, "succeeded-workflow", "")
+	setState(t, root, succeeded, scheduler.Succeeded)
 	memory := filepath.Join(root, child.Meta.RunID, "memory", child.Meta.Steps[0].ThreadID+".md")
 	if err := os.WriteFile(memory, []byte(`<script>alert("memory")</script>`), 0o600); err != nil {
 		t.Fatal(err)
@@ -72,6 +96,8 @@ func TestDashboard(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(root, "broken-run"), 0o700); err != nil {
 		t.Fatal(err)
 	}
+	addFutureMetadataFields(t, root, parent.Meta.RunID)
+	addFutureMetadataFields(t, root, child.Meta.RunID)
 
 	dashboard := Handler(root)
 	recorder := httptest.NewRecorder()
@@ -79,6 +105,7 @@ func TestDashboard(t *testing.T) {
 	html := recorder.Body.String()
 	for _, fragment := range []string{
 		"&lt;release&gt;&amp;", "child-workflow", "broken-run", "tone-running", "codex://threads/", "vscode://file/",
+		"failed-workflow", "succeeded-workflow", "В работе", "Сломавшиеся", "Успешные",
 		"/uml/" + parent.Meta.RunID, "/memory/" + child.Meta.RunID + "/" + child.Meta.Steps[0].ThreadID,
 	} {
 		if !strings.Contains(html, fragment) {
@@ -87,6 +114,13 @@ func TestDashboard(t *testing.T) {
 	}
 	if strings.Index(html, parent.Meta.RunID) > strings.Index(html, child.Meta.RunID) {
 		t.Fatal("дочерний workflow показан вне родителя")
+	}
+	active, broken, successful := strings.Index(html, `data-group="active" open`), strings.Index(html, `data-group="failed"`), strings.Index(html, `data-group="succeeded"`)
+	if active < 0 || broken < active || successful < broken {
+		t.Fatalf("секции отсутствуют или нарушен порядок: active=%d failed=%d succeeded=%d", active, broken, successful)
+	}
+	if strings.Contains(html, `data-group="failed" open`) || strings.Contains(html, `data-group="succeeded" open`) {
+		t.Fatal("сломавшиеся или успешные workflow раскрыты по умолчанию")
 	}
 
 	recorder = httptest.NewRecorder()
@@ -129,6 +163,7 @@ func TestPreview(t *testing.T) {
 	for _, fragment := range []string{
 		"fake data", "release-v0.3.0", "repair-failed-macos-build", "nightly-maintenance",
 		"prepare-release-notes-with-a-deliberately-long-name", "tone-running", "tone-failed", "tone-succeeded", "skipped", "#preview",
+		"В работе", "Сломавшиеся", "Успешные", "failed-nightly-cleanup", "previous-release",
 	} {
 		if !strings.Contains(body, fragment) {
 			t.Errorf("preview не показывает %q", fragment)
@@ -141,6 +176,21 @@ func TestPreview(t *testing.T) {
 	Handler(filepath.Join(t.TempDir(), "missing")).ServeHTTP(live, httptest.NewRequest(http.MethodGet, "/", nil))
 	if !strings.Contains(live.Body.String(), "Запусков пока нет") || !strings.Contains(live.Body.String(), `http-equiv="refresh"`) {
 		t.Fatal("пустой live dashboard не показывает подсказку или polling")
+	}
+}
+
+// TestGroupRuns фиксирует продуктовую классификацию и не позволяет случайно
+// перенести ожидающий workflow в завершённые либо изменить порядок секций.
+func TestGroupRuns(t *testing.T) {
+	roots := []*runNode{
+		{ID: "pending", State: "pending"}, {ID: "running", State: "running"},
+		{ID: "failed", State: "failed"}, {ID: "succeeded", State: "succeeded"},
+	}
+	groups := groupRuns(roots)
+	if len(groups) != 3 || groups[0].ID != "active" || !groups[0].Open || len(groups[0].Roots) != 2 ||
+		groups[1].ID != "failed" || groups[1].Open || len(groups[1].Roots) != 1 ||
+		groups[2].ID != "succeeded" || groups[2].Open || len(groups[2].Roots) != 1 {
+		t.Fatalf("неверная группировка workflow: %+v", groups)
 	}
 }
 

--- a/internal/runstore/store.go
+++ b/internal/runstore/store.go
@@ -227,6 +227,25 @@ func Load(root, runID string) (Snapshot, error) {
 	return load(dir, runID)
 }
 
+// LoadForDashboard читает валидный snapshot для read-only интерфейса, но
+// пропускает неизвестные поля JSON. Это позволяет уже запущенному dashboard
+// пережить добавление необязательного поля более новой Lawa: старый интерфейс
+// покажет известную ему часть данных до собственного перезапуска.
+//
+// Послабление относится только к лишним членам JSON. Версия формата, известные
+// поля, связи workflow, состояния и безопасные имена файлов проходят ту же
+// проверку, что и в Load. Координатору этот режим не подходит: при исполнении
+// неизвестное поле может содержать семантику, которую старый процесс обязан не
+// игнорировать, поэтому все изменяющие run операции используют строгий load.
+func LoadForDashboard(root, runID string) (Snapshot, error) {
+	dir, err := openRun(root, runID)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer dir.Close()
+	return loadForDashboard(dir, runID)
+}
+
 // ReadMemory возвращает память только существующего кубика из валидного run.
 // os.Root удерживает чтение внутри каталога даже при конкурентной подмене пути;
 // проверка обычного файла не позволяет использовать симлинк на чужие данные.
@@ -236,7 +255,7 @@ func ReadMemory(root, runID, threadID string) ([]byte, error) {
 		return nil, err
 	}
 	defer dir.Close()
-	snapshot, err := load(dir, runID)
+	snapshot, err := loadForDashboard(dir, runID)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +277,7 @@ func ReadStatusImage(root, runID string) ([]byte, error) {
 		return nil, err
 	}
 	defer dir.Close()
-	if _, err = load(dir, runID); err != nil {
+	if _, err = loadForDashboard(dir, runID); err != nil {
 		return nil, err
 	}
 	return readFile(dir, StatusImageFilename)
@@ -303,15 +322,33 @@ func openRun(root, runID string) (*os.Root, error) {
 	return base.OpenRoot(runID)
 }
 
-// load читает самостоятельный снимок из уже открытого каталога. Координатор
-// вызывает её под блокировкой; обычный Load может увидеть старую или новую meta.
+// load читает самостоятельный снимок из уже открытого каталога и отклоняет
+// неизвестные поля. Координатор вызывает её под блокировкой; обычный Load может
+// увидеть старую или новую атомарно опубликованную meta.
 func load(dir *os.Root, runID string) (Snapshot, error) {
+	return loadSnapshot(dir, runID, true)
+}
+
+// loadForDashboard отличается от load только совместимостью с добавочными
+// полями JSON. Вся содержательная validate ниже остаётся общей и строгой.
+func loadForDashboard(dir *os.Root, runID string) (Snapshot, error) {
+	return loadSnapshot(dir, runID, false)
+}
+
+// loadSnapshot сосредотачивает общий путь чтения, чтобы dashboard не получил
+// упрощённую копию проверок безопасности при поддержке новых полей.
+func loadSnapshot(dir *os.Root, runID string, rejectUnknownMembers bool) (Snapshot, error) {
 	var s Snapshot
 	meta, err := readFile(dir, "meta.json")
 	if err != nil {
 		return Snapshot{}, err
 	}
-	if err = json.Unmarshal(meta, &s.Meta, json.RejectUnknownMembers(true)); err != nil {
+	if rejectUnknownMembers {
+		err = json.Unmarshal(meta, &s.Meta, json.RejectUnknownMembers(true))
+	} else {
+		err = json.Unmarshal(meta, &s.Meta)
+	}
+	if err != nil {
 		return Snapshot{}, fmt.Errorf("meta.json: %w", err)
 	}
 	data, err := readFile(dir, "workflow.json")

--- a/internal/runstore/store_test.go
+++ b/internal/runstore/store_test.go
@@ -196,6 +196,45 @@ func TestLegacyMetadataVersion(t *testing.T) {
 	}
 }
 
+// TestDashboardMetadataCompatibility воспроизводит обновление Lawa при уже
+// запущенном старом dashboard. Read-only интерфейс использует только известные
+// поля, но координатор не должен молча исполнять snapshot с неизвестной ему
+// семантикой. Известные поля при этом остаются обязательными и валидируются.
+func TestDashboardMetadataCompatibility(t *testing.T) {
+	root := t.TempDir()
+	snapshot, err := Create(root, testInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	metaPath := filepath.Join(root, snapshot.Meta.RunID, "meta.json")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withFutureFields := bytes.Replace(data, []byte(`"steps":[{`), []byte(`"futureRunField":true,"steps":[{"futureStepField":{"revision":1},`), 1)
+	if bytes.Equal(data, withFutureFields) {
+		t.Fatal("тест не добавил будущие поля в meta.json")
+	}
+	mustWrite(t, metaPath, withFutureFields)
+
+	if _, err = Load(root, snapshot.Meta.RunID); err == nil {
+		t.Fatal("строгий Load принял неизвестные поля")
+	}
+	loaded, err := LoadForDashboard(root, snapshot.Meta.RunID)
+	if err != nil || !reflect.DeepEqual(loaded.Meta, snapshot.Meta) {
+		t.Fatalf("dashboard не прочитал известную часть новых metadata: %+v, %v", loaded.Meta, err)
+	}
+
+	invalidKnownField := bytes.Replace(withFutureFields, []byte(`"state":"pending"`), []byte(`"state":"future-state"`), 1)
+	if bytes.Equal(withFutureFields, invalidKnownField) {
+		t.Fatal("тест не повредил известное поле state")
+	}
+	mustWrite(t, metaPath, invalidKnownField)
+	if _, err = LoadForDashboard(root, snapshot.Meta.RunID); err == nil {
+		t.Fatal("dashboard проигнорировал неверное известное состояние")
+	}
+}
+
 // TestReadDashboardFiles проверяет узкую read-only границу web-сервера. Доступны
 // только память известного кубика и фиксированный PNG, а симлинк не позволяет
 // прочитать произвольный соседний файл даже внутри временного тестового root.


### PR DESCRIPTION
## Что сделано

- Dashboard игнорирует неизвестные добавочные поля meta.json, но сохраняет строгую проверку известных данных.
- Корневые workflow сгруппированы в секции В работе, Сломавшиеся и Успешные.
- Секции завершённых workflow закрыты по умолчанию, а выбор пользователя сохраняется между автообновлениями.
- Дочерние workflow остаются внутри дерева родителя.

## Почему

Долго работающий dashboard мог быть старее процесса, который записал новое необязательное поле, и переставал показывать такой run. Read-only интерфейс теперь безопасно использует известную часть данных, а координатор остаётся строгим.

## Проверки

- go test -race -count=1 ./...
- go vet ./...
- go build ./cmd/lawa
- визуальная проверка preview и сохранения раскрытой секции после перезагрузки

## Размер

193 добавления, 14 удалений, всего 207 изменённых строк.

## Ограничения

Неизвестная версия формата или неверное известное поле по-прежнему показываются как ошибка: dashboard игнорирует только добавочные JSON-поля.