### PR TITLE
Добавить контракт агентного графа workflow v2

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -64,6 +64,12 @@ func Evaluate(w workflow.Workflow, states map[string]State) (Plan, error) {
 	if err := w.Validate(); err != nil {
 		return Plan{}, fmt.Errorf("планировщик: %w", err)
 	}
+	// Парсер и валидатор v2 поставляются раньше нового visit-aware runtime. Явный
+	// отказ здесь не позволяет runstore.Create записать v2-run в старом формате и
+	// затем ошибочно исполнить after как пустой legacy dependsOn.
+	if w.EffectiveVersion() == workflow.VersionAgentGraph {
+		return Plan{}, fmt.Errorf("планировщик: runtime workflow version=2 пока не поддерживается")
+	}
 	if len(states) != len(w.Steps) {
 		return Plan{}, fmt.Errorf("планировщик: нужен снимок ровно для всех %d шагов; состояний: %d", len(w.Steps), len(states))
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -6,10 +6,28 @@ import (
 	"os"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stray-live-pixel/Lawa/internal/workflow"
 )
+
+// TestEvaluateRejectsAgentGraphV2 не даёт новому валидному контракту попасть в
+// старый DAG-runtime. Без этого барьера пустой DependsOn у v2-кубиков выглядел бы
+// как независимый старт и мог бы запустить все ветки, включая невыбранные.
+func TestEvaluateRejectsAgentGraphV2(t *testing.T) {
+	input := `{"version":2,"id":"decision","start":["checker"],"steps":[` +
+		`{"id":"checker","type":"agent","prompt":"Выбери.","after":[],"decisions":{` +
+		`"done":{"finish":"succeeded"},"fail":{"finish":"failed"}}}]}`
+	w, err := workflow.Decode(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("валидатор v2: %v", err)
+	}
+	got, err := Evaluate(w, map[string]State{"checker": Pending})
+	if err == nil || !strings.Contains(err.Error(), "runtime workflow version=2 пока не поддерживается") || !reflect.DeepEqual(got, Plan{}) {
+		t.Fatalf("старый runtime принял v2: %+v, %v", got, err)
+	}
+}
 
 // reviewWorkflow берёт продуктовый пример: сборщик записан раньше родителей,
 // а два ревью должны выполняться независимо после общих метрик.

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -22,28 +23,173 @@ const (
 	SpeedFast   Speed = "fast"
 )
 
+const (
+	// VersionLegacy — исходный контракт строгого DAG. Отсутствующее поле version
+	// означает именно эту версию, поэтому старые workflow сохраняют прежний JSON и
+	// поведение без неявной миграции.
+	VersionLegacy = 1
+	// VersionAgentGraph описывает граф с явными стартами, агентными решениями и
+	// ограниченными циклами. Его исполнение включается отдельно от парсинга схемы.
+	VersionAgentGraph = 2
+)
+
+// TerminalOutcome — явно выбранный итог workflow. Других значений, в том числе
+// внутренних состояний отдельных turn, в пользовательском контракте нет.
+type TerminalOutcome string
+
+const (
+	OutcomeSucceeded TerminalOutcome = "succeeded"
+	OutcomeFailed    TerminalOutcome = "failed"
+)
+
+// Route — один статически разрешённый результат агентного решения. To запускает
+// перечисленные цели параллельно, а Finish завершает весь workflow. Ровно одна
+// форма обязательна; это проверяет Workflow.Validate после чтения всех ID.
+type Route struct {
+	To     []string         `json:"to,omitzero"`
+	Finish *TerminalOutcome `json:"finish,omitempty"`
+}
+
 // Workflow описывает неизменяемый вход запуска. Model задаёт общую модель для
 // шагов без собственного override; nil оставляет выбор конфигурации Codex. Порядок
-// Steps не задаёт порядок выполнения: зависимости определяются только DependsOn.
+// Steps не задаёт зависимости, но служит стабильным порядком планирования.
 type Workflow struct {
-	ID    string  `json:"id"`
-	Model *string `json:"model,omitempty"`
-	Steps []Step  `json:"steps"`
+	Version *int     `json:"version,omitempty"`
+	ID      string   `json:"id"`
+	Model   *string  `json:"model,omitempty"`
+	Start   []string `json:"start,omitzero"`
+	Steps   []Step   `json:"steps"`
+}
+
+// EffectiveVersion возвращает семантическую версию, не меняя представление
+// отсутствующего поля. Это различие нужно, чтобы повторное JSON-кодирование старого
+// workflow не добавляло version=1 и сохраняло прежний внешний контракт.
+func (w Workflow) EffectiveVersion() int {
+	if w.Version == nil {
+		return VersionLegacy
+	}
+	return *w.Version
 }
 
 // Step — задача агента. ID является ключом графа, а не путём или ID чата Codex.
-// Пустой, но явно заданный DependsOn разрешает старт без ожидания других задач.
+// В v1 пустой DependsOn разрешает старт без ожидания, в v2 входящие технические
+// рёбра задаёт After, а присутствие Decisions превращает запуск в кубик решения.
 // Model, Effort и Speed — указатели, потому что отсутствие поля означает
 // наследование: Model сначала берётся из Workflow, остальные настройки — из Codex.
 // Явное значение попадает в неизменяемый снимок run и используется при продолжении.
 type Step struct {
-	ID        string   `json:"id"`
-	Type      string   `json:"type"`
-	Prompt    string   `json:"prompt"`
-	DependsOn []string `json:"dependsOn"`
-	Model     *string  `json:"model,omitempty"`
-	Effort    *string  `json:"effort,omitempty"`
-	Speed     *Speed   `json:"speed,omitempty"`
+	ID        string           `json:"id"`
+	Type      string           `json:"type"`
+	Prompt    string           `json:"prompt"`
+	DependsOn []string         `json:"dependsOn,omitzero"`
+	After     []string         `json:"after,omitzero"`
+	Decisions map[string]Route `json:"decisions,omitzero"`
+	MaxVisits *int             `json:"maxVisits,omitempty"`
+	OnLimit   *TerminalOutcome `json:"onLimit,omitempty"`
+	Model     *string          `json:"model,omitempty"`
+	Effort    *string          `json:"effort,omitempty"`
+	Speed     *Speed           `json:"speed,omitempty"`
+}
+
+// optionalInteger хранит присутствие целого JSON-поля. Указатель в публичной
+// модели нужен для version и maxVisits, но явный null не должен совпасть с
+// отсутствием поля и незаметно включить legacy/default-семантику.
+type optionalInteger struct {
+	value   int
+	present bool
+}
+
+func (value *optionalInteger) UnmarshalJSONFrom(decoder *jsontext.Decoder) error {
+	if decoder.PeekKind() == 'n' {
+		if _, err := decoder.ReadValue(); err != nil {
+			return err
+		}
+		return fmt.Errorf("явный null недопустим")
+	}
+	if err := json.UnmarshalDecode(decoder, &value.value); err != nil {
+		return err
+	}
+	value.present = true
+	return nil
+}
+
+func (value optionalInteger) pointer() *int {
+	if !value.present {
+		return nil
+	}
+	result := value.value
+	return &result
+}
+
+// optionalTerminalOutcome отделяет отсутствие finish/onLimit от явного null.
+// Значение проверяется позже вместе с остальной семантикой route или лимита.
+type optionalTerminalOutcome struct {
+	value   TerminalOutcome
+	present bool
+}
+
+// UnmarshalJSONFrom принимает только строку и не позволяет null превратиться в
+// отсутствие terminal outcome.
+func (outcome *optionalTerminalOutcome) UnmarshalJSONFrom(decoder *jsontext.Decoder) error {
+	if decoder.PeekKind() == 'n' {
+		if _, err := decoder.ReadValue(); err != nil {
+			return err
+		}
+		return fmt.Errorf("явный null недопустим; нужен terminal outcome")
+	}
+	if err := json.UnmarshalDecode(decoder, &outcome.value); err != nil {
+		return err
+	}
+	outcome.present = true
+	return nil
+}
+
+// pointer возвращает отдельную копию только для присутствовавшего поля.
+func (outcome optionalTerminalOutcome) pointer() *TerminalOutcome {
+	if !outcome.present {
+		return nil
+	}
+	value := outcome.value
+	return &value
+}
+
+// stringList отличает отсутствующее поле от явного пустого массива и отклоняет
+// null на границе декодирования. Это позволяет v1 требовать dependsOn, а v2 —
+// after, не принимая неоднозначное смешение двух контрактов.
+type stringList []string
+
+func (list *stringList) UnmarshalJSONFrom(decoder *jsontext.Decoder) error {
+	if decoder.PeekKind() == 'n' {
+		if _, err := decoder.ReadValue(); err != nil {
+			return err
+		}
+		return fmt.Errorf("явный null недопустим; нужен JSON-массив")
+	}
+	var values []string
+	if err := json.UnmarshalDecode(decoder, &values); err != nil {
+		return err
+	}
+	*list = values
+	return nil
+}
+
+// decisionMap отклоняет null, но сохраняет явный пустой объект: Validate выдаёт
+// для него предметную ошибку вместо молчаливого превращения в обычный кубик.
+type decisionMap map[string]Route
+
+func (decisions *decisionMap) UnmarshalJSONFrom(decoder *jsontext.Decoder) error {
+	if decoder.PeekKind() == 'n' {
+		if _, err := decoder.ReadValue(); err != nil {
+			return err
+		}
+		return fmt.Errorf("явный null недопустим; нужен объект решений")
+	}
+	var values map[string]Route
+	if err := json.UnmarshalDecode(decoder, &values, json.RejectUnknownMembers(true)); err != nil {
+		return err
+	}
+	*decisions = values
+	return nil
 }
 
 // optionalRuntimeSetting используется при чтении Workflow и Step и сохраняет факт
@@ -86,9 +232,11 @@ func (setting optionalRuntimeSetting[T]) pointer() *T {
 // workflowJSON отделяет корневой model от публичной структуры по той же причине,
 // что и настройки Step: отсутствие наследует Codex, а явный null является ошибкой.
 type workflowJSON struct {
-	ID    string                         `json:"id"`
-	Model optionalRuntimeSetting[string] `json:"model"`
-	Steps []Step                         `json:"steps"`
+	Version optionalInteger                `json:"version"`
+	ID      string                         `json:"id"`
+	Model   optionalRuntimeSetting[string] `json:"model"`
+	Start   stringList                     `json:"start"`
+	Steps   []Step                         `json:"steps"`
 }
 
 // UnmarshalJSONFrom собирает публичный Workflow после проверки присутствия model.
@@ -99,7 +247,10 @@ func (workflow *Workflow) UnmarshalJSONFrom(decoder *jsontext.Decoder) error {
 	if err := json.UnmarshalDecode(decoder, &raw, json.RejectUnknownMembers(true)); err != nil {
 		return err
 	}
-	*workflow = Workflow{ID: raw.ID, Model: raw.Model.pointer(), Steps: raw.Steps}
+	*workflow = Workflow{
+		Version: raw.Version.pointer(), ID: raw.ID, Model: raw.Model.pointer(),
+		Start: []string(raw.Start), Steps: raw.Steps,
+	}
 	return nil
 }
 
@@ -109,7 +260,11 @@ type stepJSON struct {
 	ID        string                         `json:"id"`
 	Type      string                         `json:"type"`
 	Prompt    string                         `json:"prompt"`
-	DependsOn []string                       `json:"dependsOn"`
+	DependsOn stringList                     `json:"dependsOn"`
+	After     stringList                     `json:"after"`
+	Decisions decisionMap                    `json:"decisions"`
+	MaxVisits optionalInteger                `json:"maxVisits"`
+	OnLimit   optionalTerminalOutcome        `json:"onLimit"`
 	Model     optionalRuntimeSetting[string] `json:"model"`
 	Effort    optionalRuntimeSetting[string] `json:"effort"`
 	Speed     optionalRuntimeSetting[Speed]  `json:"speed"`
@@ -125,9 +280,36 @@ func (step *Step) UnmarshalJSONFrom(decoder *jsontext.Decoder) error {
 		return err
 	}
 	*step = Step{
-		ID: raw.ID, Type: raw.Type, Prompt: raw.Prompt, DependsOn: raw.DependsOn,
+		ID: raw.ID, Type: raw.Type, Prompt: raw.Prompt,
+		DependsOn: []string(raw.DependsOn), After: []string(raw.After), Decisions: map[string]Route(raw.Decisions),
+		MaxVisits: raw.MaxVisits.pointer(), OnLimit: raw.OnLimit.pointer(),
 		Model: raw.Model.pointer(), Effort: raw.Effort.pointer(), Speed: raw.Speed.pointer(),
 	}
+	return nil
+}
+
+// routeJSON нужен для того же строгого режима, что workflowJSON и stepJSON:
+// неизвестное поле внутри route не должно теряться из-за пользовательского
+// UnmarshalJSONFrom у окружающего Step.
+type routeJSON struct {
+	To     stringList              `json:"to"`
+	Finish optionalTerminalOutcome `json:"finish"`
+}
+
+// UnmarshalJSONFrom отклоняет null и неизвестные поля до семантической проверки
+// взаимоисключающих форм route.
+func (route *Route) UnmarshalJSONFrom(decoder *jsontext.Decoder) error {
+	if decoder.PeekKind() == 'n' {
+		if _, err := decoder.ReadValue(); err != nil {
+			return err
+		}
+		return fmt.Errorf("route не может быть null")
+	}
+	var raw routeJSON
+	if err := json.UnmarshalDecode(decoder, &raw, json.RejectUnknownMembers(true)); err != nil {
+		return err
+	}
+	*route = Route{To: []string(raw.To), Finish: raw.Finish.pointer()}
 	return nil
 }
 
@@ -148,12 +330,17 @@ func Decode(r io.Reader) (Workflow, error) {
 	return w, nil
 }
 
-// Validate проверяет поля, ссылки и ацикличность, не изменяя исходный граф.
-// Nil и [] у DependsOn различаются: только явный массив соответствует схеме.
-// Повторные зависимости отклоняются как неоднозначная запись одного ребра.
+// Validate выбирает один из двух взаимоисключающих контрактов. Legacy сохраняет
+// прежний строгий DAG, а v2 использует start/after/decisions и допускает циклы
+// только через ограниченное агентное решение. Проверка ничего не нормализует и не
+// меняет: порядок Steps и массивов является частью детерминированного исполнения.
 func (w Workflow) Validate() error {
 	if strings.TrimSpace(w.ID) == "" || len(w.Steps) == 0 {
 		return fmt.Errorf("нужны непустой id workflow и непустой массив steps")
+	}
+	version := w.EffectiveVersion()
+	if version != VersionLegacy && version != VersionAgentGraph {
+		return fmt.Errorf("неподдерживаемая версия workflow %d", version)
 	}
 	if err := validateOptionalSetting("workflow", "model", w.Model); err != nil {
 		return err
@@ -167,8 +354,11 @@ func (w Workflow) Validate() error {
 			return fmt.Errorf("повторный id шага %q", s.ID)
 		}
 		indices[s.ID] = i
-		if s.Type != "agent" || strings.TrimSpace(s.Prompt) == "" || s.DependsOn == nil {
+		if version == VersionLegacy && (s.Type != "agent" || strings.TrimSpace(s.Prompt) == "" || s.DependsOn == nil) {
 			return fmt.Errorf("шаг %q: нужны type=agent, непустой prompt и массив dependsOn", s.ID)
+		}
+		if version == VersionAgentGraph && (s.Type != "agent" || strings.TrimSpace(s.Prompt) == "") {
+			return fmt.Errorf("шаг %q: нужны type=agent и непустой prompt", s.ID)
 		}
 		subject := fmt.Sprintf("шаг %q", s.ID)
 		if err := validateOptionalSetting(subject, "model", s.Model); err != nil {
@@ -181,23 +371,183 @@ func (w Workflow) Validate() error {
 			return fmt.Errorf("шаг %q: speed должен быть %q или %q", s.ID, SpeedNormal, SpeedFast)
 		}
 	}
-	remaining := make([]int, len(w.Steps))
-	followers := make([][]int, len(w.Steps))
-	for i, s := range w.Steps {
+	if version == VersionLegacy {
+		return validateLegacy(w, indices)
+	}
+	return validateAgentGraph(w, indices)
+}
+
+// validateLegacy намеренно повторяет прежние правила и диагностику dependsOn.
+// Любое присутствие v2-поля отклоняется, даже если массив или объект пуст.
+func validateLegacy(w Workflow, indices map[string]int) error {
+	if w.Start != nil {
+		return fmt.Errorf("workflow v1: поле start относится только к version=2")
+	}
+	for _, step := range w.Steps {
+		if step.DependsOn == nil {
+			return fmt.Errorf("шаг %q: нужны type=agent, непустой prompt и массив dependsOn", step.ID)
+		}
+		if step.After != nil || step.Decisions != nil || step.MaxVisits != nil || step.OnLimit != nil {
+			return fmt.Errorf("шаг %q: after, decisions, maxVisits и onLimit относятся только к version=2", step.ID)
+		}
+	}
+	remaining, followers, err := dependencyGraph(w.Steps, indices, func(step Step) []string { return step.DependsOn }, "зависимость")
+	if err != nil {
+		return err
+	}
+	if !isDAG(remaining, followers) {
+		return fmt.Errorf("обнаружен цикл зависимостей")
+	}
+	return nil
+}
+
+// validateAgentGraph проверяет v2 в несколько независимых проходов: сначала форму
+// и ссылки, затем статический after-DAG, потенциальную достижимость, возможность
+// завершения и, последней, защиту циклических компонент. Такой порядок даёт одну
+// стабильную и наиболее локальную ошибку для одного и того же JSON.
+func validateAgentGraph(w Workflow, indices map[string]int) error {
+	if len(w.Start) == 0 {
+		return fmt.Errorf("workflow v2: нужен непустой массив start")
+	}
+	if err := validateTargets("workflow start", w.Start, indices); err != nil {
+		return err
+	}
+	for _, step := range w.Steps {
+		if step.DependsOn != nil {
+			return fmt.Errorf("шаг %q: dependsOn нельзя сочетать с workflow version=2; используйте after", step.ID)
+		}
+		if step.After == nil {
+			return fmt.Errorf("шаг %q: workflow v2 требует явный массив after", step.ID)
+		}
+		if err := validateTargets(fmt.Sprintf("шаг %q, after", step.ID), step.After, indices); err != nil {
+			return err
+		}
+		if step.Decisions != nil && len(step.Decisions) == 0 {
+			return fmt.Errorf("шаг %q: decisions должен быть непустым объектом", step.ID)
+		}
+		if step.MaxVisits != nil && *step.MaxVisits <= 0 {
+			return fmt.Errorf("шаг %q: maxVisits должен быть положительным", step.ID)
+		}
+		if step.OnLimit != nil {
+			if step.MaxVisits == nil {
+				return fmt.Errorf("шаг %q: onLimit требует maxVisits", step.ID)
+			}
+			if !validOutcome(*step.OnLimit) {
+				return fmt.Errorf("шаг %q: onLimit должен быть %q или %q", step.ID, OutcomeSucceeded, OutcomeFailed)
+			}
+		}
+		keys := sortedDecisionKeys(step.Decisions)
+		for _, key := range keys {
+			if strings.TrimSpace(key) == "" {
+				return fmt.Errorf("шаг %q: нужен непустой ключ решения", step.ID)
+			}
+			route := step.Decisions[key]
+			hasTargets, hasFinish := route.To != nil, route.Finish != nil
+			if hasTargets == hasFinish || hasTargets && len(route.To) == 0 {
+				return fmt.Errorf("шаг %q, решение %q: нужен ровно один из непустого to или finish", step.ID, key)
+			}
+			if hasFinish && !validOutcome(*route.Finish) {
+				return fmt.Errorf("шаг %q, решение %q: finish должен быть %q или %q", step.ID, key, OutcomeSucceeded, OutcomeFailed)
+			}
+			if hasTargets {
+				if err := validateTargets(fmt.Sprintf("шаг %q, решение %q, to", step.ID, key), route.To, indices); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	remaining, afterFollowers, err := dependencyGraph(w.Steps, indices, func(step Step) []string { return step.After }, "after")
+	if err != nil {
+		return err
+	}
+	if !isDAG(remaining, afterFollowers) {
+		return fmt.Errorf("обнаружен цикл after; цикл допустим только через route агентного решения")
+	}
+	graph := fullGraph(w, indices, afterFollowers)
+	reachable := reachableFrom(w.Start, indices, graph)
+	for index, step := range w.Steps {
+		if !reachable[index] {
+			return fmt.Errorf("шаг %q недостижим из start", step.ID)
+		}
+	}
+	canFinish := nodesWithFinishPath(w, graph)
+	for index, step := range w.Steps {
+		if reachable[index] && !canFinish[index] {
+			return fmt.Errorf("шаг %q не имеет пути к конечному кубику или finish", step.ID)
+		}
+	}
+	cyclic := cyclicNodes(graph)
+	for index, step := range w.Steps {
+		if cyclic[index] && len(step.Decisions) != 0 && step.MaxVisits == nil {
+			return fmt.Errorf("шаг решения %q входит в цикл и требует положительный maxVisits", step.ID)
+		}
+	}
+	return nil
+}
+
+func validOutcome(outcome TerminalOutcome) bool {
+	return outcome == OutcomeSucceeded || outcome == OutcomeFailed
+}
+
+// validateTargets сохраняет порядок пользовательского массива в диагностике и
+// отклоняет повтор как неоднозначную запись одного и того же перехода.
+func validateTargets(subject string, targets []string, indices map[string]int) error {
+	seen := make(map[string]bool, len(targets))
+	for _, target := range targets {
+		if _, exists := indices[target]; !exists {
+			return fmt.Errorf("%s: неизвестная цель %q", subject, target)
+		}
+		if seen[target] {
+			return fmt.Errorf("%s: повторная цель %q", subject, target)
+		}
+		seen[target] = true
+	}
+	return nil
+}
+
+func sortedDecisionKeys(decisions map[string]Route) []string {
+	keys := make([]string, 0, len(decisions))
+	for key := range decisions {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// dependencyGraph строит входные счётчики и исходящие рёбра в порядке Steps.
+// Вызывающий код заранее собрал indices, поэтому неизвестные ссылки здесь всё же
+// проверяются как защита общей helper-функции и для прежней legacy-диагностики.
+func dependencyGraph(steps []Step, indices map[string]int, dependencies func(Step) []string, label string) ([]int, [][]int, error) {
+	remaining := make([]int, len(steps))
+	followers := make([][]int, len(steps))
+	for i, s := range steps {
 		seen := make(map[string]bool)
-		for _, dependency := range s.DependsOn {
+		for _, dependency := range dependencies(s) {
 			parent, exists := indices[dependency]
 			if !exists {
-				return fmt.Errorf("шаг %q: неизвестная зависимость %q", s.ID, dependency)
+				if label == "зависимость" {
+					return nil, nil, fmt.Errorf("шаг %q: неизвестная зависимость %q", s.ID, dependency)
+				}
+				return nil, nil, fmt.Errorf("шаг %q: неизвестный %s %q", s.ID, label, dependency)
 			}
 			if seen[dependency] {
-				return fmt.Errorf("шаг %q: повторная зависимость %q", s.ID, dependency)
+				if label == "зависимость" {
+					return nil, nil, fmt.Errorf("шаг %q: повторная зависимость %q", s.ID, dependency)
+				}
+				return nil, nil, fmt.Errorf("шаг %q: повторный %s %q", s.ID, label, dependency)
 			}
 			seen[dependency] = true
 			remaining[i]++
 			followers[parent] = append(followers[parent], i)
 		}
 	}
+	return remaining, followers, nil
+}
+
+// isDAG использует алгоритм Кана и не меняет переданный снимок счётчиков.
+func isDAG(input []int, followers [][]int) bool {
+	remaining := append([]int(nil), input...)
 	// Алгоритм Кана обрабатывает каждую вершину и ребро один раз: O(V + E).
 	// Очередь содержит только вершины без оставшихся входящих рёбер. Если после
 	// обхода остались вершины, есть цикл. Рекурсии нет даже у очень длинной цепочки.
@@ -215,10 +565,146 @@ func (w Workflow) Validate() error {
 			}
 		}
 	}
-	if len(queue) != len(w.Steps) {
-		return fmt.Errorf("обнаружен цикл зависимостей")
+	return len(queue) == len(remaining)
+}
+
+// fullGraph объединяет безусловные after-рёбра и все потенциальные decision-route.
+// Повтор одного ребра в разных решениях не дублируется: за один visit выбирается
+// ровно один ключ, а для достижимости и SCC важен только факт возможного перехода.
+func fullGraph(w Workflow, indices map[string]int, afterFollowers [][]int) [][]int {
+	graph := make([][]int, len(w.Steps))
+	for source := range graph {
+		seen := make(map[int]bool)
+		for _, target := range afterFollowers[source] {
+			if !seen[target] {
+				graph[source] = append(graph[source], target)
+				seen[target] = true
+			}
+		}
+		for _, key := range sortedDecisionKeys(w.Steps[source].Decisions) {
+			for _, targetID := range w.Steps[source].Decisions[key].To {
+				target := indices[targetID]
+				if !seen[target] {
+					graph[source] = append(graph[source], target)
+					seen[target] = true
+				}
+			}
+		}
 	}
-	return nil
+	return graph
+}
+
+func reachableFrom(start []string, indices map[string]int, graph [][]int) []bool {
+	reachable := make([]bool, len(graph))
+	queue := make([]int, 0, len(start))
+	for _, id := range start {
+		index := indices[id]
+		if !reachable[index] {
+			reachable[index] = true
+			queue = append(queue, index)
+		}
+	}
+	for head := 0; head < len(queue); head++ {
+		for _, next := range graph[queue[head]] {
+			if !reachable[next] {
+				reachable[next] = true
+				queue = append(queue, next)
+			}
+		}
+	}
+	return reachable
+}
+
+// nodesWithFinishPath идёт по обратному графу от естественных листьев и явных
+// finish/onLimit. Один maxVisits без выхода остаётся только аварийным предохранителем
+// и не заменяет статически достижимое безопасное завершение workflow.
+func nodesWithFinishPath(w Workflow, graph [][]int) []bool {
+	reverse := make([][]int, len(graph))
+	canFinish := make([]bool, len(graph))
+	queue := make([]int, 0, len(graph))
+	for source, targets := range graph {
+		for _, target := range targets {
+			reverse[target] = append(reverse[target], source)
+		}
+		hasFinish := w.Steps[source].OnLimit != nil
+		for _, route := range w.Steps[source].Decisions {
+			hasFinish = hasFinish || route.Finish != nil
+		}
+		if len(targets) == 0 || hasFinish {
+			canFinish[source] = true
+			queue = append(queue, source)
+		}
+	}
+	for head := 0; head < len(queue); head++ {
+		for _, previous := range reverse[queue[head]] {
+			if !canFinish[previous] {
+				canFinish[previous] = true
+				queue = append(queue, previous)
+			}
+		}
+	}
+	return canFinish
+}
+
+// cyclicNodes находит strongly connected components алгоритмом Тарьяна. Результат
+// нужен только как множество, а итоговая ошибка выбирается позднее в порядке Steps,
+// поэтому обход не делает диагностику зависимой от map или порядка decisions.
+func cyclicNodes(graph [][]int) []bool {
+	indices := make([]int, len(graph))
+	low := make([]int, len(graph))
+	onStack := make([]bool, len(graph))
+	for index := range indices {
+		indices[index] = -1
+	}
+	stack := make([]int, 0, len(graph))
+	cyclic := make([]bool, len(graph))
+	nextIndex := 0
+	var visit func(int)
+	visit = func(node int) {
+		indices[node], low[node] = nextIndex, nextIndex
+		nextIndex++
+		stack = append(stack, node)
+		onStack[node] = true
+		for _, target := range graph[node] {
+			if indices[target] == -1 {
+				visit(target)
+				low[node] = min(low[node], low[target])
+			} else if onStack[target] {
+				low[node] = min(low[node], indices[target])
+			}
+		}
+		if low[node] != indices[node] {
+			return
+		}
+		component := make([]int, 0, 1)
+		for {
+			last := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			onStack[last] = false
+			component = append(component, last)
+			if last == node {
+				break
+			}
+		}
+		if len(component) > 1 {
+			for _, member := range component {
+				cyclic[member] = true
+			}
+			return
+		}
+		for _, target := range graph[node] {
+			if target == node {
+				cyclic[node] = true
+				break
+			}
+		}
+	}
+	for node := range graph {
+		if indices[node] == -1 {
+			visit(node)
+		}
+	}
+	return cyclic
 }
 
 // validateOptionalSetting проверяет только устойчивый контракт Lawa: значение

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -14,6 +14,13 @@ import (
 
 const valid = `{"id":"flow","steps":[{"id":"a","type":"agent","prompt":"  задача\n","dependsOn":[]}]}`
 
+const validV2 = `{"version":2,"id":"risk","model":"gpt-5.6-luna","start":["checker"],"steps":[` +
+	`{"id":"checker","type":"agent","prompt":"Оцени риск.","after":[],"decisions":{` +
+	`"risk":{"to":["audit","notify"]},"safe":{"finish":"succeeded"},"fail":{"finish":"failed"}},` +
+	`"maxVisits":3,"onLimit":"failed","effort":"high","speed":"fast"},` +
+	`{"id":"audit","type":"agent","prompt":"Проведи аудит.","after":[]},` +
+	`{"id":"notify","type":"agent","prompt":"Подготовь уведомление.","after":[]}]} `
+
 // TestDecode защищает точное сохранение входа: пробелы промпта и порядок шагов
 // не исправляются валидатором, а пример содержит обратный порядок зависимостей.
 func TestDecode(t *testing.T) {
@@ -29,6 +36,233 @@ func TestDecode(t *testing.T) {
 	w, err = Decode(f)
 	if err != nil || len(w.Steps) != 4 || w.Steps[0].ID != "summary" {
 		t.Fatalf("пример с параллельными ветками отклонён: %+v, %v", w, err)
+	}
+}
+
+// TestLegacyVersionCompatibility фиксирует обе записи прежнего контракта:
+// исторический JSON без version не получает новое поле при кодировании, а явная
+// version=1 сохраняется. Срез dependsOn=[] также нельзя потерять через omitzero,
+// иначе повторное чтение ошибочно решит, что обязательного поля не было.
+func TestLegacyVersionCompatibility(t *testing.T) {
+	inputs := []string{
+		valid,
+		strings.Replace(valid, `{"id":"flow"`, `{"version":1,"id":"flow"`, 1),
+	}
+	for _, input := range inputs {
+		w, err := Decode(strings.NewReader(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if w.EffectiveVersion() != VersionLegacy || (w.Version == nil) != !strings.Contains(input, `"version"`) {
+			t.Fatalf("потеряно различие отсутствующей и явной legacy-версии: %+v", w.Version)
+		}
+		encoded, err := json.Marshal(w)
+		if err != nil || string(encoded) != input {
+			t.Fatalf("legacy JSON изменился: %s, %v; ожидался %s", encoded, err, input)
+		}
+	}
+}
+
+// TestDecodeAgentGraph проверяет основной if/else-контракт и fan-out одного
+// решения. Порядок to сохраняется, потому что будущий runtime обязан планировать
+// параллельную волну воспроизводимо, не обходя map решений.
+func TestDecodeAgentGraph(t *testing.T) {
+	w, err := Decode(strings.NewReader(strings.TrimSpace(validV2)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w.EffectiveVersion() != VersionAgentGraph || !reflect.DeepEqual(w.Start, []string{"checker"}) || len(w.Steps) != 3 {
+		t.Fatalf("искажён корень v2: %+v", w)
+	}
+	checker := w.Steps[0]
+	if !reflect.DeepEqual(checker.Decisions["risk"].To, []string{"audit", "notify"}) ||
+		checker.MaxVisits == nil || *checker.MaxVisits != 3 || checker.OnLimit == nil || *checker.OnLimit != OutcomeFailed ||
+		checker.Effort == nil || *checker.Effort != "high" || checker.Speed == nil || *checker.Speed != SpeedFast {
+		t.Fatalf("решения, лимит или runtime-настройки потеряны: %+v", checker)
+	}
+	encoded, err := json.Marshal(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := Decode(bytes.NewReader(encoded))
+	if err != nil || !reflect.DeepEqual(w, again) {
+		t.Fatalf("v2 не пережил повторное кодирование: %+v, %v", again, err)
+	}
+}
+
+// TestAgentGraphAllowsBoundedDecisionCycle воспроизводит цикл из issue: start
+// даёт первое посещение test, terminal fix удовлетворяет его after при повторах,
+// а checker выбирает возврат либо явное успешное завершение.
+func TestAgentGraphAllowsBoundedDecisionCycle(t *testing.T) {
+	input := `{"version":2,"id":"repair","start":["test"],"steps":[` +
+		`{"id":"test","type":"agent","prompt":"Тестируй.","after":["fix"]},` +
+		`{"id":"checker","type":"agent","prompt":"Проверь.","after":["test"],"maxVisits":4,"decisions":{` +
+		`"repeat":{"to":["fix"]},"done":{"finish":"succeeded"},"fail":{"finish":"failed"}}},` +
+		`{"id":"fix","type":"agent","prompt":"Исправь.","after":[]}]}`
+	if _, err := Decode(strings.NewReader(input)); err != nil {
+		t.Fatalf("ограниченный decision-цикл отклонён: %v", err)
+	}
+}
+
+// TestAgentGraphRejectsStaticAfterCycle подтверждает важную границу контракта:
+// start не превращает обычный after-цикл в допустимый; замыкать его может только
+// route агентного решения с отдельным maxVisits.
+func TestAgentGraphRejectsStaticAfterCycle(t *testing.T) {
+	input := `{"version":2,"id":"bad","start":["a"],"steps":[` +
+		`{"id":"a","type":"agent","prompt":"A","after":["b"]},` +
+		`{"id":"b","type":"agent","prompt":"B","after":["a"]}]}`
+	if _, err := Decode(strings.NewReader(input)); err == nil || !strings.Contains(err.Error(), "цикл after") {
+		t.Fatalf("обычный after-цикл принят или плохо объяснён: %v", err)
+	}
+}
+
+// TestWorkflowVersionsCannotBeMixed проверяет запрет неоднозначных полей в обе
+// стороны. Даже пустой массив явно принадлежит своему контракту и не игнорируется.
+func TestWorkflowVersionsCannotBeMixed(t *testing.T) {
+	cases := map[string]string{
+		"неизвестная версия": `{"version":3,"id":"bad","steps":[{"id":"a","type":"agent","prompt":"A","dependsOn":[]}]}`,
+		"dependsOn в v2":     `{"version":2,"id":"bad","start":["a"],"steps":[{"id":"a","type":"agent","prompt":"A","after":[],"dependsOn":[]}]}`,
+		"after без version":  `{"id":"bad","steps":[{"id":"a","type":"agent","prompt":"A","dependsOn":[],"after":[]}]}`,
+		"start в v1":         `{"version":1,"id":"bad","start":[],"steps":[{"id":"a","type":"agent","prompt":"A","dependsOn":[]}]}`,
+		"decisions в v1":     `{"version":1,"id":"bad","steps":[{"id":"a","type":"agent","prompt":"A","dependsOn":[],"decisions":{}}]}`,
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Decode(strings.NewReader(input)); err == nil {
+				t.Fatal("смешанный контракт принят")
+			}
+		})
+	}
+}
+
+// TestAgentGraphReferences проверяет каждый вид ссылки и повторов. Ошибка должна
+// возникнуть до анализа достижимости, чтобы автор видел локальную опечатку.
+func TestAgentGraphReferences(t *testing.T) {
+	base := `{"version":2,"id":"refs","start":["a"],"steps":[` +
+		`{"id":"a","type":"agent","prompt":"A","after":[],"decisions":{"go":{"to":["b"]}}},` +
+		`{"id":"b","type":"agent","prompt":"B","after":[]}]}`
+	cases := map[string]string{
+		"неизвестный start": strings.Replace(base, `"start":["a"]`, `"start":["missing"]`, 1),
+		"повторный start":   strings.Replace(base, `"start":["a"]`, `"start":["a","a"]`, 1),
+		"неизвестный after": strings.Replace(base, `"after":[]}]}`, `"after":["missing"]}]}`, 1),
+		"повторный after":   strings.Replace(base, `"after":[]}]}`, `"after":["a","a"]}]}`, 1),
+		"неизвестный to":    strings.Replace(base, `"to":["b"]`, `"to":["missing"]`, 1),
+		"повторный to":      strings.Replace(base, `"to":["b"]`, `"to":["b","b"]`, 1),
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Decode(strings.NewReader(input)); err == nil {
+				t.Fatal("некорректная ссылка принята")
+			}
+		})
+	}
+}
+
+// TestAgentGraphReachabilityAndExit не разрешает молча хранить никогда не
+// активируемый кубик и цикл, у которого нет ни естественного листа, ни явного
+// finish/onLimit. maxVisits остаётся предохранителем, а не маршрутом завершения.
+func TestAgentGraphReachabilityAndExit(t *testing.T) {
+	unreachable := `{"version":2,"id":"unreachable","start":["a"],"steps":[` +
+		`{"id":"a","type":"agent","prompt":"A","after":[]},` +
+		`{"id":"orphan","type":"agent","prompt":"X","after":[]}]}`
+	if _, err := Decode(strings.NewReader(unreachable)); err == nil || !strings.Contains(err.Error(), "недостижим") {
+		t.Fatalf("недостижимый шаг принят или плохо объяснён: %v", err)
+	}
+	unsafe := `{"version":2,"id":"unsafe","start":["loop"],"steps":[` +
+		`{"id":"loop","type":"agent","prompt":"Повтори.","after":[],"maxVisits":2,"decisions":{"again":{"to":["loop"]}}}]}`
+	if _, err := Decode(strings.NewReader(unsafe)); err == nil || !strings.Contains(err.Error(), "не имеет пути") {
+		t.Fatalf("граф без безопасного выхода принят или плохо объяснён: %v", err)
+	}
+	withLimitOutcome := strings.Replace(unsafe, `"maxVisits":2`, `"maxVisits":2,"onLimit":"failed"`, 1)
+	if _, err := Decode(strings.NewReader(withLimitOutcome)); err != nil {
+		t.Fatalf("явный terminal onLimit не признан безопасным выходом: %v", err)
+	}
+}
+
+// TestAgentGraphRejectsInvalidRoutesAndLimits покрывает семантику, которую нельзя
+// выразить одними Go-типами: пустые формы, два исхода сразу и несвязанный onLimit.
+func TestAgentGraphRejectsInvalidRoutesAndLimits(t *testing.T) {
+	step := func(extra string) string {
+		return `{"version":2,"id":"invalid","start":["a"],"steps":[{"id":"a","type":"agent","prompt":"A","after":[]` + extra + `}]}`
+	}
+	cases := map[string]string{
+		"нет start":               `{"version":2,"id":"invalid","steps":[{"id":"a","type":"agent","prompt":"A","after":[]}]}`,
+		"пустой start":            `{"version":2,"id":"invalid","start":[],"steps":[{"id":"a","type":"agent","prompt":"A","after":[]}]}`,
+		"нет after":               `{"version":2,"id":"invalid","start":["a"],"steps":[{"id":"a","type":"agent","prompt":"A"}]}`,
+		"пустые decisions":        step(`,"decisions":{}`),
+		"пустой ключ":             step(`,"decisions":{" ":{"finish":"failed"}}`),
+		"нет формы route":         step(`,"decisions":{"bad":{}}`),
+		"пустой to":               step(`,"decisions":{"bad":{"to":[]}}`),
+		"две формы route":         step(`,"decisions":{"bad":{"to":["a"],"finish":"failed"}},"maxVisits":1,"onLimit":"failed"`),
+		"неверный finish":         step(`,"decisions":{"bad":{"finish":"cancelled"}}`),
+		"нулевой maxVisits":       step(`,"maxVisits":0`),
+		"отрицательный maxVisits": step(`,"maxVisits":-1`),
+		"onLimit без лимита":      step(`,"onLimit":"failed"`),
+		"неверный onLimit":        step(`,"maxVisits":1,"onLimit":"cancelled"`),
+		"цикл без лимита":         step(`,"decisions":{"repeat":{"to":["a"]},"stop":{"finish":"failed"}}`),
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Decode(strings.NewReader(input)); err == nil {
+				t.Fatal("некорректный route или лимит принят")
+			}
+		})
+	}
+}
+
+// TestEveryCyclicDecisionRequiresLimit строит одну SCC с двумя агентными
+// решениями. Лимит только на одном из них недостаточен: другой decision обязан
+// иметь собственный статический предохранитель независимо от выбранного route.
+func TestEveryCyclicDecisionRequiresLimit(t *testing.T) {
+	input := `{"version":2,"id":"limits","start":["first"],"steps":[` +
+		`{"id":"first","type":"agent","prompt":"Первый.","after":[],"maxVisits":2,"decisions":{` +
+		`"next":{"to":["second"]},"stop":{"finish":"failed"}}},` +
+		`{"id":"second","type":"agent","prompt":"Второй.","after":[],"decisions":{` +
+		`"back":{"to":["first"]},"stop":{"finish":"succeeded"}}}]}`
+	if _, err := Decode(strings.NewReader(input)); err == nil || !strings.Contains(err.Error(), `"second"`) || !strings.Contains(err.Error(), "maxVisits") {
+		t.Fatalf("decision без собственного лимита принят или плохо объяснён: %v", err)
+	}
+}
+
+// TestAgentGraphStrictJSON распространяет прежний строгий JSON-контракт на все
+// новые уровни. null не равен отсутствию, а повторный ключ решения не выбирается
+// библиотекой произвольно.
+func TestAgentGraphStrictJSON(t *testing.T) {
+	base := `{"version":2,"id":"strict","start":["a"],"steps":[{"id":"a","type":"agent","prompt":"A","after":[]}]}`
+	cases := map[string]string{
+		"null version":        strings.Replace(base, `"version":2`, `"version":null`, 1),
+		"null start":          strings.Replace(base, `"start":["a"]`, `"start":null`, 1),
+		"null after":          strings.Replace(base, `"after":[]`, `"after":null`, 1),
+		"null decisions":      strings.Replace(base, `"after":[]`, `"after":[],"decisions":null`, 1),
+		"null maxVisits":      strings.Replace(base, `"after":[]`, `"after":[],"maxVisits":null`, 1),
+		"null onLimit":        strings.Replace(base, `"after":[]`, `"after":[],"onLimit":null`, 1),
+		"null route":          strings.Replace(base, `"after":[]`, `"after":[],"decisions":{"x":null}`, 1),
+		"null route to":       strings.Replace(base, `"after":[]`, `"after":[],"decisions":{"x":{"to":null}}`, 1),
+		"null route finish":   strings.Replace(base, `"after":[]`, `"after":[],"decisions":{"x":{"finish":null}}`, 1),
+		"unknown route field": strings.Replace(base, `"after":[]`, `"after":[],"decisions":{"x":{"other":true}}`, 1),
+		"duplicate decision":  strings.Replace(base, `"after":[]`, `"after":[],"decisions":{"x":{"finish":"failed"},"x":{"finish":"succeeded"}}`, 1),
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			w, err := Decode(strings.NewReader(input))
+			if err == nil || !reflect.DeepEqual(w, Workflow{}) {
+				t.Fatalf("нестрогий JSON принят: %+v, %v", w, err)
+			}
+		})
+	}
+}
+
+// TestDecisionDiagnosticsAreDeterministic доказывает, что случайный порядок map
+// не меняет первую ошибку: ключи решений проверяются лексикографически.
+func TestDecisionDiagnosticsAreDeterministic(t *testing.T) {
+	prefix := `{"version":2,"id":"order","start":["a"],"steps":[{"id":"a","type":"agent","prompt":"A","after":[],"decisions":`
+	suffix := `}]}`
+	first := prefix + `{"z":{"to":["missing-z"]},"a":{"to":["missing-a"]}}` + suffix
+	second := prefix + `{"a":{"to":["missing-a"]},"z":{"to":["missing-z"]}}` + suffix
+	_, firstErr := Decode(strings.NewReader(first))
+	_, secondErr := Decode(strings.NewReader(second))
+	if firstErr == nil || secondErr == nil || firstErr.Error() != secondErr.Error() || !strings.Contains(firstErr.Error(), "missing-a") {
+		t.Fatalf("диагностика зависит от порядка map: %v / %v", firstErr, secondErr)
 	}
 }
 


### PR DESCRIPTION
## Результат

- Добавлен явно версионированный контракт workflow v2: `start`, `after`, `decisions`, `to`/`finish`, `maxVisits` и `onLimit`.
- Сохранена полная совместимость legacy workflow без `version` и с `version: 1`.
- Валидатор проверяет ссылки, достижимость, безопасное завершение, статический after-DAG и обязательные лимиты decision-циклов.
- Старый runtime явно отклоняет v2 до подключения visit-aware исполнения в следующем PR стека.

## Ключевые решения

- Обычный цикл `after` остаётся ошибкой; цикл разрешён только через статический маршрут агентного решения.
- Диагностика решений детерминирована и не зависит от порядка Go map.
- `null`, неизвестные поля, повторные JSON-ключи и смешение v1/v2 отклоняются.

## Проверки

- `go test ./...`
- `go vet ./...`
- `gofmt -d`
- `git diff --check`
- независимое read-only ревью: APPROVE

## Размер и ограничения

Полный diff: 806 изменённых строк. Это больше ориентира 500 строк, но меньше блокирующего предела 1200. PR является первым слоем стека для #50; исполнение v2 намеренно ещё закрыто защитной ошибкой.

Part of #50