### PR TITLE
Добавить формат истории запусков v4

### DIFF
--- a/internal/runstore/store.go
+++ b/internal/runstore/store.go
@@ -68,20 +68,23 @@ type Input struct {
 
 // Metadata — версия формата и постоянные связи запуска. ParentRunID появился в
 // v2; пустое значение у прежнего v1 означает корень дерева. ChildRequestID есть
-// только у нативных детей v3 и не содержит исходный callId. State использует
-// внутренний словарь планировщика, а не статусы протокола Codex.
+// у app-server детей v3/v4 и не содержит исходный callId. Steps принадлежат лишь
+// legacy v1-v3, а v4 хранит общий RunState и append-only Visits.
 type Metadata struct {
-	Version           int    `json:"version"`
-	RunID             string `json:"runId"`
-	ParentRunID       string `json:"parentRunId,omitempty"`
-	ChildRequestID    string `json:"childRequestId,omitempty"`
-	CWD               string `json:"cwd"`
-	InitiatorThreadID string `json:"initiatorThreadId,omitempty"` // Только чтение форматов v1/v2.
-	Steps             []Step `json:"steps"`
+	Version           int      `json:"version"`
+	RunID             string   `json:"runId"`
+	ParentRunID       string   `json:"parentRunId,omitempty"`
+	ChildRequestID    string   `json:"childRequestId,omitempty"`
+	CWD               string   `json:"cwd"`
+	InitiatorThreadID string   `json:"initiatorThreadId,omitempty"` // Только чтение форматов v1/v2.
+	Steps             []Step   `json:"steps,omitempty"`
+	RunState          RunState `json:"runState,omitempty"`
+	StopReason        string   `json:"stopReason,omitempty"`
+	Visits            []Visit  `json:"visits,omitempty"`
 }
 
-// Step связывает ID из графа с отдельным файлом памяти, thread и последним turn
-// Codex App Server. Произвольный ID из workflow не используется как имя файла.
+// Step связывает legacy ID из графа с отдельным файлом памяти, thread и последним
+// turn Codex App Server. Произвольный ID workflow не используется как имя файла.
 // Revision сохраняется только для чтения исторического app-native формата v2.
 type Step struct {
 	ID            string          `json:"id"`
@@ -121,12 +124,35 @@ func Create(root string, in Input) (Snapshot, error) {
 	return create(root, in, syncDir)
 }
 
+// CreateAgentGraph создаёт формат v4 только для workflow version=2. Это узкий
+// внутренний API пакета: production-команды продолжают вызывать Create, который
+// намеренно получает отказ legacy-планировщика до появления visit-aware
+// координатора. Разделение не позволяет частично включить новый runtime.
+func CreateAgentGraph(root string, in Input) (Snapshot, error) {
+	return createAgentGraph(root, in, syncDir)
+}
+
 // create принимает синхронизацию каталогов явно, чтобы тесты могли воспроизвести
 // отказ диска без глобальных подмен, влияющих на параллельные вызовы Create.
 func create(root string, in Input, syncDirectory func(string) error) (_ Snapshot, err error) {
+	return createMode(root, in, syncDirectory, false)
+}
+
+// createAgentGraph оставляет Sync инъекцией только для проверок границ записи.
+func createAgentGraph(root string, in Input, syncDirectory func(string) error) (_ Snapshot, err error) {
+	return createMode(root, in, syncDirectory, true)
+}
+
+// createMode сохраняет общий crash-safe протокол обоих форматов. Выбор режима
+// влияет только на представление metadata и набор файлов памяти; legacy Create
+// по-прежнему проходит через scheduler.Evaluate внутри Snapshot.validate.
+func createMode(root string, in Input, syncDirectory func(string) error, agentGraph bool) (_ Snapshot, err error) {
 	w, err := workflow.Decode(bytes.NewReader(in.WorkflowJSON))
 	if err != nil {
 		return Snapshot{}, err
+	}
+	if agentGraph && w.EffectiveVersion() != workflow.VersionAgentGraph {
+		return Snapshot{}, fmt.Errorf("CreateAgentGraph требует workflow version=2")
 	}
 	if !validText(in.Task) || !utf8.ValidString(in.Comment) || !validText(in.CWD) {
 		return Snapshot{}, fmt.Errorf("нужны постановка и cwd; текст должен быть UTF-8")
@@ -157,8 +183,18 @@ func create(root string, in Input, syncDirectory func(string) error) (_ Snapshot
 	}
 	s := Snapshot{Workflow: w, Task: formattedTask(in.Task, in.Comment)}
 	s.Meta = Metadata{Version: 3, RunID: newID(), ParentRunID: in.ParentRunID, ChildRequestID: in.ChildRequestID, CWD: cwd}
-	for _, step := range w.Steps {
-		s.Meta.Steps = append(s.Meta.Steps, Step{ID: step.ID, ThreadID: newID(), State: scheduler.Pending})
+	if agentGraph {
+		s.Meta.Version, s.Meta.RunState = 4, RunRunning
+		for _, stepID := range w.Start {
+			s.Meta.Visits = append(s.Meta.Visits, Visit{
+				VisitID: newID(), StepID: stepID, Visit: 1, Iteration: 1,
+				Trigger: VisitTrigger{Kind: TriggerStart}, State: scheduler.Pending,
+			})
+		}
+	} else {
+		for _, step := range w.Steps {
+			s.Meta.Steps = append(s.Meta.Steps, Step{ID: step.ID, ThreadID: newID(), State: scheduler.Pending})
+		}
 	}
 	if err = s.validate(s.Meta.RunID); err != nil {
 		return Snapshot{}, err
@@ -186,8 +222,8 @@ func create(root string, in Input, syncDirectory func(string) error) (_ Snapshot
 		return Snapshot{}, err
 	}
 	files := map[string][]byte{"workflow.json": in.WorkflowJSON, "task.md": []byte(s.Task), "meta.json.tmp": meta}
-	for _, step := range s.Meta.Steps {
-		files[filepath.Join("memory", step.ThreadID+".md")] = nil
+	for _, memoryID := range s.memoryIDs() {
+		files[filepath.Join("memory", memoryID+".md")] = nil
 	}
 	for name, data := range files {
 		if err = writeNewFile(filepath.Join(dir, name), data); err != nil {
@@ -267,6 +303,9 @@ func FindMatchingChildren(root string, inputs []Input) ([]Snapshot, []bool, erro
 }
 
 func childOccupied(snapshot Snapshot) bool {
+	if snapshot.Meta.Version == 4 {
+		return snapshot.Meta.RunState == RunRunning
+	}
 	for _, step := range snapshot.Meta.Steps {
 		switch step.State {
 		case scheduler.Pending, scheduler.Starting, scheduler.Unknown, scheduler.Running, scheduler.WaitingForApproval:
@@ -331,10 +370,10 @@ func LoadForDashboard(root, runID string) (Snapshot, error) {
 	return loadForDashboard(dir, runID)
 }
 
-// ReadMemory возвращает память только существующего кубика из валидного run.
+// ReadMemory возвращает память только известного legacy threadId или v4 visitId.
 // os.Root удерживает чтение внутри каталога даже при конкурентной подмене пути;
 // проверка обычного файла не позволяет использовать симлинк на чужие данные.
-func ReadMemory(root, runID, threadID string) ([]byte, error) {
+func ReadMemory(root, runID, memoryID string) ([]byte, error) {
 	dir, err := openRun(root, runID)
 	if err != nil {
 		return nil, err
@@ -345,13 +384,13 @@ func ReadMemory(root, runID, threadID string) ([]byte, error) {
 		return nil, err
 	}
 	found := false
-	for _, step := range snapshot.Meta.Steps {
-		found = found || step.ThreadID == threadID
+	for _, knownID := range snapshot.memoryIDs() {
+		found = found || knownID == memoryID
 	}
 	if !found {
-		return nil, fmt.Errorf("неизвестный threadId памяти %q", threadID)
+		return nil, fmt.Errorf("неизвестный идентификатор памяти %q", memoryID)
 	}
-	return readFile(dir, filepath.Join("memory", threadID+".md"))
+	return readFile(dir, filepath.Join("memory", memoryID+".md"))
 }
 
 // ReadStatusImage читает только стабильный PNG статуса. Отдельная функция вместо
@@ -380,6 +419,11 @@ func RemoveUnstarted(root, runID string) error {
 	for _, step := range snapshot.Meta.Steps {
 		if step.State != scheduler.Pending || step.CodexThreadID != "" {
 			return fmt.Errorf("откат run %q запрещён: шаг %q уже передан исполнителю", runID, step.ID)
+		}
+	}
+	for _, visit := range snapshot.Meta.Visits {
+		if visit.State != scheduler.Pending || visit.CodexThreadID != "" || visit.TurnID != "" || visit.Attempt != 0 || visit.Decision != nil {
+			return fmt.Errorf("откат run %q запрещён: посещение %q уже передано исполнителю", runID, visit.VisitID)
 		}
 	}
 	root, err = filepath.Abs(root)
@@ -457,6 +501,9 @@ func loadSnapshot(dir *os.Root, runID string, rejectUnknownMembers bool) (Snapsh
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("meta.json: %w", err)
 	}
+	if err = validateMetadataShape(meta, s.Meta); err != nil {
+		return Snapshot{}, fmt.Errorf("meta.json: %w", err)
+	}
 	data, err := readFile(dir, "workflow.json")
 	if err != nil {
 		return Snapshot{}, err
@@ -472,13 +519,13 @@ func loadSnapshot(dir *os.Root, runID string, rejectUnknownMembers bool) (Snapsh
 	if err = s.validate(runID); err != nil {
 		return Snapshot{}, err
 	}
-	for _, step := range s.Meta.Steps {
-		info, err := dir.Lstat(filepath.Join("memory", step.ThreadID+".md"))
+	for _, memoryID := range s.memoryIDs() {
+		info, err := dir.Lstat(filepath.Join("memory", memoryID+".md"))
 		if err != nil {
 			return Snapshot{}, err
 		}
 		if !info.Mode().IsRegular() {
-			return Snapshot{}, fmt.Errorf("память шага %q должна быть обычным файлом", step.ID)
+			return Snapshot{}, fmt.Errorf("память %q должна быть обычным файлом", memoryID)
 		}
 	}
 	if s.Meta.Version == 2 {
@@ -491,18 +538,43 @@ func loadSnapshot(dir *os.Root, runID string, rejectUnknownMembers bool) (Snapsh
 	return s, nil
 }
 
+// validateMetadataShape различает отсутствующее поле и явный null/zero. Обычная
+// структура Go этого не сохраняет, но смешение Steps и Visits означает попытку
+// прочитать новый runtime по правилам старого и потому должно быть отвергнуто.
+func validateMetadataShape(data []byte, metadata Metadata) error {
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	has := func(name string) bool { _, exists := fields[name]; return exists }
+	if metadata.Version == 4 {
+		if has("steps") || !has("runState") || !has("visits") {
+			return fmt.Errorf("metadata v4 требует runState/visits и запрещает legacy steps")
+		}
+		return nil
+	}
+	if metadata.Version >= 1 && metadata.Version <= 3 && (has("runState") || has("stopReason") || has("visits")) {
+		return fmt.Errorf("legacy metadata не может содержать поля v4")
+	}
+	return nil
+}
+
 // validate отклоняет повреждённую постановку, несовместимую версию, потерянные
 // или дублированные связи и состояния, способные создать повторный чат.
 // Starting без ID оставляем как неопределённый результат создания,
 // а не превращаем в новый Pending.
 func (s Snapshot) validate(runID string) error {
 	m := s.Meta
+	if m.Version == 4 {
+		return s.validateAgentGraph(runID)
+	}
 	oldFormat := m.Version == 1 || m.Version == 2
 	if (m.Version != 1 && m.Version != 2 && m.Version != 3) || m.Version == 1 && m.ParentRunID != "" ||
 		m.RunID != runID || m.ParentRunID == m.RunID || m.ParentRunID != "" && !validID(m.ParentRunID) ||
 		m.ChildRequestID != "" && (m.Version != 3 || m.ParentRunID == "" || !validID(m.ChildRequestID)) ||
 		!filepath.IsAbs(m.CWD) || !validText(m.CWD) || strings.ContainsRune(m.CWD, 0) ||
 		oldFormat && !validText(m.InitiatorThreadID) || m.Version == 3 && m.InitiatorThreadID != "" ||
+		m.RunState != "" || m.StopReason != "" || m.Visits != nil ||
 		len(m.Steps) != len(s.Workflow.Steps) {
 		return fmt.Errorf("повреждены входы, версия или состав meta.json")
 	}
@@ -544,6 +616,19 @@ func (s Snapshot) validate(runID string) error {
 	}
 	_, err := scheduler.Evaluate(s.Workflow, states)
 	return err
+}
+
+// memoryIDs возвращает только проверенные validate непрозрачные имена файлов.
+// В legacy файл принадлежит логическому шагу, а в v4 — отдельному посещению.
+func (s Snapshot) memoryIDs() []string {
+	ids := make([]string, 0, len(s.Meta.Steps)+len(s.Meta.Visits))
+	for _, step := range s.Meta.Steps {
+		ids = append(ids, step.ThreadID)
+	}
+	for _, visit := range s.Meta.Visits {
+		ids = append(ids, visit.VisitID)
+	}
+	return ids
 }
 
 // historicalAppNative ищет только защитные marker-файлы опубликованного v2

--- a/internal/runstore/visits.go
+++ b/internal/runstore/visits.go
@@ -1,0 +1,316 @@
+package runstore
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
+)
+
+// RunState — сохранённый итог всего agent-graph run. Он отделён от состояния
+// отдельного посещения: технический Failed одного агента может быть нормальным
+// входом следующего проверяющего кубика через after.
+type RunState string
+
+const (
+	RunRunning   RunState = "running"
+	RunSucceeded RunState = "succeeded"
+	RunFailed    RunState = "failed"
+)
+
+// TriggerKind объясняет, почему появилось посещение. Источник сохраняется по
+// visitId, а не по stepId: при цикле это единственный однозначный causal link.
+type TriggerKind string
+
+const (
+	TriggerStart    TriggerKind = "start"
+	TriggerAfter    TriggerKind = "after"
+	TriggerDecision TriggerKind = "decision"
+)
+
+// VisitTrigger хранит неизменяемую причину активации. SourceVisitIDs упорядочены:
+// для after они следуют порядку Step.After, для decision допустим один источник.
+type VisitTrigger struct {
+	Kind           TriggerKind `json:"kind"`
+	SourceVisitIDs []string    `json:"sourceVisitIds,omitempty"`
+	DecisionKey    string      `json:"decisionKey,omitempty"`
+}
+
+// DecisionRecord — durable commit одного вызова агента решения. To/Finish и
+// Skipped материализуются из неизменяемого workflow в момент commit, поэтому
+// resume не разбирает финальный текст и не вычисляет маршрут повторно. Applied
+// станет границей ровно-однократного применения в следующем срезе runtime.
+type DecisionRecord struct {
+	Key         string                    `json:"key"`
+	Explanation string                    `json:"explanation,omitempty"`
+	TurnID      string                    `json:"turnId"`
+	CallID      string                    `json:"callId"`
+	To          []string                  `json:"to,omitempty"`
+	Finish      *workflow.TerminalOutcome `json:"finish,omitempty"`
+	Skipped     []string                  `json:"skipped,omitempty"`
+	Applied     bool                      `json:"applied"`
+	Error       string                    `json:"error,omitempty"`
+}
+
+// Visit — одна попытка логического шага в истории графа. Visit возрастает без
+// пропусков отдельно для каждого StepID; VisitID адресует metadata и файл памяти.
+// Attempt возрастает при каждом новом turn того же Codex-чата. Старые посещения
+// никогда не переиспользуются для следующего прохода цикла.
+type Visit struct {
+	VisitID        string          `json:"visitId"`
+	StepID         string          `json:"stepId"`
+	Visit          int             `json:"visit"`
+	Iteration      int             `json:"iteration"`
+	Attempt        int             `json:"attempt"`
+	Trigger        VisitTrigger    `json:"trigger"`
+	State          scheduler.State `json:"state"`
+	CodexThreadID  string          `json:"codexThreadId,omitempty"`
+	TurnID         string          `json:"turnId,omitempty"`
+	TechnicalError string          `json:"technicalError,omitempty"`
+	Decision       *DecisionRecord `json:"decision,omitempty"`
+}
+
+// validateAgentGraph проверяет v4 как самодостаточный append-only журнал. Все
+// ссылки источников обязаны вести назад по Visits: это исключает подмену истории
+// и позволяет следующему координатору безопасно продолжить после сбоя процесса.
+func (s Snapshot) validateAgentGraph(runID string) error {
+	m := s.Meta
+	if m.Version != 4 || !validID(m.RunID) || m.RunID != runID || m.RunID == m.ParentRunID ||
+		m.ParentRunID != "" && !validID(m.ParentRunID) ||
+		m.ChildRequestID != "" && (m.ParentRunID == "" || !validID(m.ChildRequestID)) ||
+		!filepathIsSafeAbsolute(m.CWD) || m.InitiatorThreadID != "" || m.Steps != nil ||
+		s.Workflow.EffectiveVersion() != workflow.VersionAgentGraph || len(m.Visits) < len(s.Workflow.Start) {
+		return fmt.Errorf("повреждены входы, версия или состав meta.json v4")
+	}
+	if !validText(s.Task) {
+		return fmt.Errorf("task.md: постановка должна быть непустым текстом UTF-8")
+	}
+	if err := s.Workflow.Validate(); err != nil {
+		return fmt.Errorf("workflow v4: %w", err)
+	}
+	if m.RunState != RunRunning && m.RunState != RunSucceeded && m.RunState != RunFailed ||
+		m.RunState == RunRunning && m.StopReason != "" || m.RunState != RunRunning && !safeStoredText(m.StopReason, true) {
+		return fmt.Errorf("runState не соответствует безопасной причине остановки")
+	}
+
+	steps := make(map[string]workflow.Step, len(s.Workflow.Steps))
+	for _, step := range s.Workflow.Steps {
+		steps[step.ID] = step
+	}
+	seen, chats := make(map[string]Visit), make(map[string]bool)
+	numbers, active := make(map[string]int), make(map[string]bool)
+	afterUses, decisionUses := make(map[afterCause]bool), make(map[decisionCause]bool)
+	for index, visit := range m.Visits {
+		step, exists := steps[visit.StepID]
+		if !exists || !validID(visit.VisitID) {
+			return fmt.Errorf("посещение %q: неизвестный stepId или неверный visitId", visit.VisitID)
+		}
+		if _, duplicate := seen[visit.VisitID]; duplicate {
+			return fmt.Errorf("посещение %q: повторный visitId", visit.VisitID)
+		}
+		numbers[visit.StepID]++
+		if visit.Visit != numbers[visit.StepID] || visit.Iteration < 1 || visit.Attempt < 0 {
+			return fmt.Errorf("посещение %q: нарушена нумерация visit/iteration/attempt", visit.VisitID)
+		}
+		if err := validateVisitState(visit, chats); err != nil {
+			return fmt.Errorf("посещение %q: %w", visit.VisitID, err)
+		}
+		if active[visit.StepID] {
+			return fmt.Errorf("предыдущее посещение шага %q ещё не завершено", visit.StepID)
+		}
+		if !visitTerminal(visit.State) {
+			active[visit.StepID] = true
+		}
+		if err := validateTrigger(index, visit, step, s.Workflow.Start, m.Visits[:index], seen, afterUses, decisionUses); err != nil {
+			return fmt.Errorf("посещение %q: %w", visit.VisitID, err)
+		}
+		if err := validateDecision(visit, step); err != nil {
+			return fmt.Errorf("посещение %q: %w", visit.VisitID, err)
+		}
+		seen[visit.VisitID] = visit
+	}
+	matchingFinish := false
+	for _, visit := range m.Visits {
+		if visit.Decision == nil || !visit.Decision.Applied {
+			continue
+		}
+		for _, target := range visit.Decision.To {
+			if !decisionUses[decisionCause{target, visit.VisitID}] {
+				return fmt.Errorf("решение посещения %q не материализовало target %q", visit.VisitID, target)
+			}
+		}
+		if visit.Decision.Finish != nil {
+			expected := RunFailed
+			if *visit.Decision.Finish == workflow.OutcomeSucceeded {
+				expected = RunSucceeded
+			}
+			if m.RunState != expected {
+				return fmt.Errorf("finish посещения %q не совпадает с runState", visit.VisitID)
+			}
+			matchingFinish = true
+		}
+	}
+	if m.RunState != RunRunning && len(active) != 0 && !matchingFinish {
+		return fmt.Errorf("терминальный run с незавершёнными visits требует применённый finish")
+	}
+	return nil
+}
+
+// Причины активации сравниваются составными ключами без склейки пользовательских
+// stepId: так любые допустимые символы в ID не создают ложных совпадений.
+type afterCause struct{ targetStepID, dependencyStepID, sourceVisitID string }
+type decisionCause struct{ targetStepID, sourceVisitID string }
+
+// filepathIsSafeAbsolute повторяет общую границу cwd без принятия NUL.
+func filepathIsSafeAbsolute(path string) bool {
+	return filepath.IsAbs(path) && validText(path) && !strings.ContainsRune(path, 0)
+}
+
+// validateVisitState связывает внешний chat/turn с фазой. Thread глобально
+// уникален, а turnId и callId являются непрозрачными ID внутри своего thread.
+func validateVisitState(visit Visit, chats map[string]bool) error {
+	switch visit.State {
+	case scheduler.Pending:
+		if visit.CodexThreadID != "" || visit.TurnID != "" || visit.Attempt != 0 || visit.TechnicalError != "" || visit.Decision != nil {
+			return fmt.Errorf("Pending не может содержать результаты запуска")
+		}
+	case scheduler.Starting:
+		if visit.TurnID != "" || visit.Attempt != 0 || visit.TechnicalError != "" || visit.Decision != nil {
+			return fmt.Errorf("Starting не может содержать turn или результат")
+		}
+	case scheduler.Unknown, scheduler.Running, scheduler.WaitingForApproval, scheduler.Failed, scheduler.Cancelled, scheduler.Succeeded:
+		if !safeStoredText(visit.CodexThreadID, true) {
+			return fmt.Errorf("состояние %q требует безопасный codexThreadId", visit.State)
+		}
+	default:
+		return fmt.Errorf("неизвестное состояние %q", visit.State)
+	}
+	if visit.CodexThreadID != "" {
+		if !safeStoredText(visit.CodexThreadID, true) || chats[visit.CodexThreadID] {
+			return fmt.Errorf("неверный или повторный codexThreadId")
+		}
+		chats[visit.CodexThreadID] = true
+	}
+	if (visit.TurnID == "") != (visit.Attempt == 0) || visit.TurnID != "" && !safeStoredText(visit.TurnID, true) {
+		return fmt.Errorf("attempt и turnId должны появляться вместе")
+	}
+	if (visit.State == scheduler.Running || visit.State == scheduler.WaitingForApproval || visit.State == scheduler.Succeeded) && visit.Attempt == 0 {
+		return fmt.Errorf("состояние %q требует сохранённый turn", visit.State)
+	}
+	if visit.TechnicalError != "" && (visit.State != scheduler.Unknown && visit.State != scheduler.Failed && visit.State != scheduler.Cancelled || !safeStoredText(visit.TechnicalError, false)) {
+		return fmt.Errorf("technicalError недопустима для состояния или небезопасна")
+	}
+	return nil
+}
+
+func validateTrigger(index int, visit Visit, step workflow.Step, start []string, history []Visit, seen map[string]Visit, afterUses map[afterCause]bool, decisionUses map[decisionCause]bool) error {
+	if index < len(start) {
+		if visit.StepID != start[index] || visit.Trigger.Kind != TriggerStart || visit.Visit != 1 || visit.Iteration != 1 {
+			return fmt.Errorf("начальные посещения должны совпадать с порядком workflow.start")
+		}
+	}
+	switch visit.Trigger.Kind {
+	case TriggerStart:
+		if index >= len(start) || len(visit.Trigger.SourceVisitIDs) != 0 || visit.Trigger.DecisionKey != "" {
+			return fmt.Errorf("start допустим только в начальном префиксе без источников")
+		}
+	case TriggerAfter:
+		if len(step.After) == 0 || len(visit.Trigger.SourceVisitIDs) != len(step.After) || visit.Trigger.DecisionKey != "" {
+			return fmt.Errorf("after должен содержать источник для каждого Step.After")
+		}
+		maxIteration := 0
+		for i, sourceID := range visit.Trigger.SourceVisitIDs {
+			source, exists := seen[sourceID]
+			if !exists || !visitTerminal(source.State) || source.StepID != step.After[i] {
+				return fmt.Errorf("after-источник %q не является нужным завершённым посещением", sourceID)
+			}
+			cause := afterCause{visit.StepID, step.After[i], sourceID}
+			expected := ""
+			for _, candidate := range history {
+				candidateCause := afterCause{visit.StepID, step.After[i], candidate.VisitID}
+				if candidate.StepID == step.After[i] && visitTerminal(candidate.State) && !afterUses[candidateCause] {
+					expected = candidate.VisitID
+					break
+				}
+			}
+			if sourceID != expected || afterUses[cause] {
+				return fmt.Errorf("after должен потреблять самый ранний неиспользованный источник")
+			}
+			afterUses[cause] = true
+			maxIteration = max(maxIteration, source.Iteration)
+		}
+		if visit.Iteration != maxIteration {
+			return fmt.Errorf("after должен наследовать максимальную iteration источников")
+		}
+	case TriggerDecision:
+		if len(visit.Trigger.SourceVisitIDs) != 1 || visit.Trigger.DecisionKey == "" {
+			return fmt.Errorf("decision требует один источник и ключ")
+		}
+		source, exists := seen[visit.Trigger.SourceVisitIDs[0]]
+		if !exists || source.State != scheduler.Succeeded || source.Decision == nil || !source.Decision.Applied ||
+			source.Decision.Key != visit.Trigger.DecisionKey || !slices.Contains(source.Decision.To, visit.StepID) {
+			return fmt.Errorf("decision-источник не применял этот маршрут к шагу")
+		}
+		cause := decisionCause{visit.StepID, source.VisitID}
+		if decisionUses[cause] {
+			return fmt.Errorf("decision-источник уже материализовал этот target")
+		}
+		decisionUses[cause] = true
+		if visit.Iteration != source.Iteration+1 {
+			return fmt.Errorf("decision-target должен увеличить iteration источника")
+		}
+	default:
+		return fmt.Errorf("неизвестный trigger %q", visit.Trigger.Kind)
+	}
+	return nil
+}
+
+func validateDecision(visit Visit, step workflow.Step) error {
+	if visit.Decision == nil {
+		// Succeeded описывает только фактический terminal turn Codex. Отсутствие
+		// обязательного выбора является бизнес-ошибкой всего workflow, которую
+		// visit-aware планировщик сохраняет отдельно в RunState/StopReason.
+		return nil
+	}
+	d := visit.Decision
+	route, exists := step.Decisions[d.Key]
+	if !exists || visit.Attempt == 0 || !safeStoredText(d.TurnID, true) || !safeStoredText(d.CallID, true) || !safeStoredText(d.Explanation, false) ||
+		!slices.Equal(d.To, route.To) || !sameOutcome(d.Finish, route.Finish) {
+		return fmt.Errorf("решение не совпадает с разрешённым маршрутом workflow")
+	}
+	keys := make([]string, 0, len(step.Decisions)-1)
+	for key := range step.Decisions {
+		if key != d.Key {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	if !slices.Equal(d.Skipped, keys) || d.Applied && visit.State != scheduler.Succeeded ||
+		d.Error != "" && (!safeStoredText(d.Error, false) || d.Applied) {
+		return fmt.Errorf("решение содержит неверные skipped/error")
+	}
+	return nil
+}
+
+func visitTerminal(state scheduler.State) bool {
+	return state == scheduler.Failed || state == scheduler.Succeeded
+}
+
+func sameOutcome(left, right *workflow.TerminalOutcome) bool {
+	return left == nil && right == nil || left != nil && right != nil && *left == *right
+}
+
+// safeStoredText не даёт непроверенной диагностике сохранить управляющие
+// символы для будущего terminal/dashboard. Ограничение защищает и размер meta.
+func safeStoredText(value string, required bool) bool {
+	if !utf8.ValidString(value) || len(value) > 4096 || strings.IndexFunc(value, unicode.IsControl) >= 0 {
+		return false
+	}
+	return !required || strings.TrimSpace(value) != ""
+}

--- a/internal/runstore/visits_test.go
+++ b/internal/runstore/visits_test.go
@@ -1,0 +1,343 @@
+//go:build darwin || linux
+
+package runstore
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
+)
+
+// agentGraphInput содержит два стартовых посещения, три варианта решения и
+// обычное after-ребро. Этого достаточно для проверки материалации маршрута,
+// причин активации и независимости параллельных visits без запуска coordinator.
+func agentGraphInput(t *testing.T) Input {
+	t.Helper()
+	return Input{
+		WorkflowJSON: []byte(`{
+  "version": 2,
+  "id": "agent-graph",
+  "start": ["choice", "audit"],
+  "steps": [
+    {"id":"choice","type":"agent","prompt":"Выбери маршрут","after":[],"decisions":{
+      "go":{"to":["work"]},"done":{"finish":"succeeded"},"fail":{"finish":"failed"}}},
+    {"id":"audit","type":"agent","prompt":"Проверь вход","after":[],"decisions":{"done":{"finish":"succeeded"}}},
+    {"id":"work","type":"agent","prompt":"Выполни работу","after":[]},
+    {"id":"check","type":"agent","prompt":"Проверь результат","after":["work"]}
+  ]
+}`),
+		Task: "Выполнить agent graph", Comment: "Тест", CWD: t.TempDir(),
+	}
+}
+
+func testAgentGraphRun(t *testing.T) (string, Snapshot, *LockedRun) {
+	t.Helper()
+	root := t.TempDir()
+	snapshot, err := CreateAgentGraph(root, agentGraphInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, snapshot.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := run.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	return root, snapshot, run
+}
+
+// TestCreateAgentGraph проверяет границу безопасного включения: публичный Create
+// всё ещё отказывает через legacy scheduler, а специальный API создаёт только
+// start-visits v4 и отдельную память по непрозрачному visitId.
+func TestCreateAgentGraph(t *testing.T) {
+	root, input := filepath.Join(t.TempDir(), "runs"), agentGraphInput(t)
+	if got, err := Create(root, input); err == nil || !strings.Contains(err.Error(), "runtime workflow version=2") || !reflect.DeepEqual(got, Snapshot{}) {
+		t.Fatalf("публичный Create включил v2 runtime: %+v, %v", got, err)
+	}
+	if _, err := os.Stat(root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("отказ Create оставил файлы: %v", err)
+	}
+	snapshot, err := CreateAgentGraph(root, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Meta.Version != 4 || snapshot.Meta.RunState != RunRunning || snapshot.Meta.Steps != nil || len(snapshot.Meta.Visits) != 2 {
+		t.Fatalf("неверная основа v4: %+v", snapshot.Meta)
+	}
+	if !childOccupied(snapshot) {
+		t.Fatal("running v4 child ошибочно считается завершённым")
+	}
+	finished := snapshot
+	finished.Meta.RunState = RunSucceeded
+	if childOccupied(finished) {
+		t.Fatal("terminal v4 child ошибочно считается занятым")
+	}
+	for index, visit := range snapshot.Meta.Visits {
+		if visit.StepID != snapshot.Workflow.Start[index] || visit.Visit != 1 || visit.Iteration != 1 ||
+			visit.Attempt != 0 || visit.State != scheduler.Pending || visit.Trigger.Kind != TriggerStart || !validID(visit.VisitID) {
+			t.Fatalf("неверное начальное посещение: %+v", visit)
+		}
+		memory := filepath.Join(root, snapshot.Meta.RunID, "memory", visit.VisitID+".md")
+		if data, err := os.ReadFile(memory); err != nil || len(data) != 0 {
+			t.Fatalf("не создана память visit: %q, %v", data, err)
+		}
+		mustWrite(t, memory, []byte("память посещения"))
+		if data, err := ReadMemory(root, snapshot.Meta.RunID, visit.VisitID); err != nil || string(data) != "память посещения" {
+			t.Fatalf("ReadMemory не использует visitId: %q, %v", data, err)
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(root, snapshot.Meta.RunID, "meta.json"))
+	if err != nil || bytes.Contains(data, []byte(`"steps"`)) || !bytes.Contains(data, []byte(`"visits"`)) {
+		t.Fatalf("v4 смешан с legacy metadata: %s, %v", data, err)
+	}
+	if loaded, err := Load(root, snapshot.Meta.RunID); err != nil || !reflect.DeepEqual(loaded, snapshot) {
+		t.Fatalf("v4 не читается: %+v, %v", loaded, err)
+	}
+	withUnknown := bytes.Replace(data, []byte(`"runState":"running"`), []byte(`"runState":"running","future":true`), 1)
+	mustWrite(t, filepath.Join(root, snapshot.Meta.RunID, "meta.json"), withUnknown)
+	if _, err := Load(root, snapshot.Meta.RunID); err == nil {
+		t.Fatal("строгий Load принял неизвестное поле v4")
+	}
+	withLegacyNull := bytes.Replace(data, []byte(`"runState"`), []byte(`"steps":null,"runState"`), 1)
+	mustWrite(t, filepath.Join(root, snapshot.Meta.RunID, "meta.json"), withLegacyNull)
+	if _, err := Load(root, snapshot.Meta.RunID); err == nil {
+		t.Fatal("v4 принял даже null legacy-поле steps")
+	}
+	mustWrite(t, filepath.Join(root, snapshot.Meta.RunID, "meta.json"), data)
+	legacy := testInput(t)
+	if got, err := CreateAgentGraph(root, legacy); err == nil || !reflect.DeepEqual(got, Snapshot{}) {
+		t.Fatalf("CreateAgentGraph принял legacy workflow: %+v, %v", got, err)
+	}
+	if err := RemoveUnstarted(root, snapshot.Meta.RunID); err != nil {
+		t.Fatalf("не начатый v4 run не удалён: %v", err)
+	}
+	if _, err := Load(root, snapshot.Meta.RunID); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("удалённый v4 run остался доступен: %v", err)
+	}
+}
+
+// TestLegacyMetadataRejectsV4Fields не позволяет старому runtime молча
+// проигнорировать часть нового журнала при ручной подмене version/meta.
+func TestLegacyMetadataRejectsV4Fields(t *testing.T) {
+	root := t.TempDir()
+	snapshot, err := Create(root, testInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, mutate := range map[string]func(*Metadata){
+		"runState":   func(meta *Metadata) { meta.RunState = RunRunning },
+		"stopReason": func(meta *Metadata) { meta.StopReason = "неожиданное поле" },
+		"visits": func(meta *Metadata) {
+			meta.Visits = []Visit{{VisitID: newID(), StepID: "чужой"}}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			meta := snapshot.Meta
+			mutate(&meta)
+			data, marshalErr := json.Marshal(meta)
+			if marshalErr != nil {
+				t.Fatal(marshalErr)
+			}
+			mustWrite(t, filepath.Join(root, snapshot.Meta.RunID, "meta.json"), data)
+			if _, loadErr := Load(root, snapshot.Meta.RunID); loadErr == nil {
+				t.Fatalf("legacy metadata приняла поле v4 %s", name)
+			}
+		})
+	}
+	original, err := json.Marshal(snapshot.Meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withNull := bytes.Replace(original, []byte(`"version":3`), []byte(`"version":3,"visits":null`), 1)
+	mustWrite(t, filepath.Join(root, snapshot.Meta.RunID, "meta.json"), withNull)
+	if _, err := Load(root, snapshot.Meta.RunID); err == nil {
+		t.Fatal("legacy metadata приняла visits:null")
+	}
+}
+
+// TestAgentGraphMetadataValidation строит допустимую историю с decision и after,
+// затем независимо повреждает важные инварианты append-only журнала.
+func TestAgentGraphMetadataValidation(t *testing.T) {
+	_, initial, _ := testAgentGraphRun(t)
+	snapshot := initial
+	choice := &snapshot.Meta.Visits[0]
+	choice.State, choice.CodexThreadID, choice.TurnID, choice.Attempt = scheduler.Succeeded, "chat-choice", "turn-choice", 1
+	choice.Decision = &DecisionRecord{Key: "go", TurnID: "turn-choice", CallID: "call-1", To: []string{"work"}, Skipped: []string{"done", "fail"}, Applied: true}
+	workID := newID()
+	snapshot.Meta.Visits = append(snapshot.Meta.Visits, Visit{
+		VisitID: workID, StepID: "work", Visit: 1, Iteration: 2,
+		Trigger: VisitTrigger{Kind: TriggerDecision, SourceVisitIDs: []string{choice.VisitID}, DecisionKey: "go"},
+		State:   scheduler.Succeeded, CodexThreadID: "chat-work", TurnID: "turn-work", Attempt: 1,
+	}, Visit{
+		VisitID: newID(), StepID: "check", Visit: 1, Iteration: 2,
+		Trigger: VisitTrigger{Kind: TriggerAfter, SourceVisitIDs: []string{workID}}, State: scheduler.Pending,
+	})
+	if err := snapshot.validate(snapshot.Meta.RunID); err != nil {
+		t.Fatalf("допустимая история не прошла проверку: %v", err)
+	}
+	// Failed является технически завершённым входом after, в отличие от
+	// Cancelled: прерванный чат ещё можно продолжить новым turn.
+	failedSource := cloneSnapshotMetadata(t, snapshot)
+	failedSource.Meta.Visits[2].State = scheduler.Failed
+	failedSource.Meta.Visits[2].TechnicalError = "проверка упала"
+	if err := failedSource.validate(failedSource.Meta.RunID); err != nil {
+		t.Fatalf("after не принял технический Failed: %v", err)
+	}
+	// App Server адресует turn/call внутри thread; одинаковые opaque ID в двух
+	// разных чатах не являются конфликтом глобального журнала.
+	scopedIDs := cloneSnapshotMetadata(t, snapshot)
+	scopedIDs.Workflow.Steps = slices.Clone(scopedIDs.Workflow.Steps)
+	scopedIDs.Meta.Visits[2].TurnID = "turn-choice"
+	outcome := workflow.OutcomeSucceeded
+	scopedIDs.Workflow.Steps[2].Decisions = map[string]workflow.Route{"done": {Finish: &outcome}}
+	scopedIDs.Meta.Visits[2].Decision = &DecisionRecord{Key: "done", TurnID: "turn-choice", CallID: "call-1", Finish: &outcome}
+	if err := scopedIDs.validate(scopedIDs.Meta.RunID); err != nil {
+		t.Fatalf("локальные turn/call ID ошибочно потребовали глобальной уникальности: %v", err)
+	}
+	// Явный finish завершает весь run немедленно и остаётся главным источником
+	// истины, даже если параллельное посещение ещё Pending, Running или уже
+	// Cancelled. Fixture сохраняет настоящий applied finish, а не подменяет им
+	// решение `go`, которое обязано материализовать target.
+	finishSnapshot := func(key string, state RunState, reason string) Snapshot {
+		result := cloneSnapshotMetadata(t, initial)
+		choice := &result.Meta.Visits[0]
+		choice.State, choice.CodexThreadID, choice.TurnID, choice.Attempt = scheduler.Succeeded, "chat-finish", "turn-finish", 1
+		route := result.Workflow.Steps[0].Decisions[key]
+		finish := *route.Finish
+		choice.Decision = &DecisionRecord{Key: key, TurnID: "turn-finish", CallID: "call-finish", Finish: &finish, Skipped: []string{"done", "fail", "go"}, Applied: true}
+		choice.Decision.Skipped = slices.DeleteFunc(choice.Decision.Skipped, func(candidate string) bool { return candidate == key })
+		result.Meta.RunState, result.Meta.StopReason = state, reason
+		return result
+	}
+	terminalWithPending := finishSnapshot("done", RunSucceeded, "агент выбрал успешное завершение")
+	if err := terminalWithPending.validate(terminalWithPending.Meta.RunID); err != nil {
+		t.Fatalf("terminal run не принял оставшиеся Pending visits: %v", err)
+	}
+	terminalWithRunning := cloneSnapshotMetadata(t, terminalWithPending)
+	terminalWithRunning.Meta.Visits[1].State = scheduler.Running
+	terminalWithRunning.Meta.Visits[1].CodexThreadID = "chat-audit"
+	terminalWithRunning.Meta.Visits[1].TurnID = "turn-audit"
+	terminalWithRunning.Meta.Visits[1].Attempt = 1
+	if err := terminalWithRunning.validate(terminalWithRunning.Meta.RunID); err != nil {
+		t.Fatalf("terminal run не принял оставшееся Running-посещение: %v", err)
+	}
+	terminalWithCancelled := finishSnapshot("fail", RunFailed, "агент выбрал неуспешное завершение")
+	terminalWithCancelled.Meta.Visits[1].State = scheduler.Cancelled
+	terminalWithCancelled.Meta.Visits[1].CodexThreadID = "chat-audit"
+	if err := terminalWithCancelled.validate(terminalWithCancelled.Meta.RunID); err != nil {
+		t.Fatalf("terminal run не принял оставшееся Cancelled-посещение: %v", err)
+	}
+	clone := func() Snapshot {
+		return cloneSnapshotMetadata(t, snapshot)
+	}
+	for name, mutate := range map[string]func(*Snapshot){
+		"legacy steps":       func(s *Snapshot) { s.Meta.Steps = []Step{{ID: "choice"}} },
+		"duplicate visit id": func(s *Snapshot) { s.Meta.Visits[2].VisitID = s.Meta.Visits[0].VisitID },
+		"visit gap":          func(s *Snapshot) { s.Meta.Visits[2].Visit = 2 },
+		"unknown source":     func(s *Snapshot) { s.Meta.Visits[2].Trigger.SourceVisitIDs[0] = newID() },
+		"wrong after order":  func(s *Snapshot) { s.Meta.Visits[3].Trigger.SourceVisitIDs[0] = s.Meta.Visits[0].VisitID },
+		"decision iteration": func(s *Snapshot) { s.Meta.Visits[2].Iteration = 1 },
+		"after iteration":    func(s *Snapshot) { s.Meta.Visits[3].Iteration = 3 },
+		"duplicate chat":     func(s *Snapshot) { s.Meta.Visits[2].CodexThreadID = "chat-choice" },
+		"unsafe diagnostic": func(s *Snapshot) {
+			s.Meta.Visits[2].State, s.Meta.Visits[2].TechnicalError = scheduler.Failed, "ошибка\x1b[31m"
+		},
+		"changed route": func(s *Snapshot) { s.Meta.Visits[0].Decision.To = []string{"audit"} },
+		"unmaterialized route": func(s *Snapshot) {
+			s.Meta.Visits = s.Meta.Visits[:2]
+		},
+		"failed decision source": func(s *Snapshot) {
+			s.Meta.Visits[0].State = scheduler.Failed
+		},
+		"cancelled decision source": func(s *Snapshot) {
+			s.Meta.Visits[0].State = scheduler.Cancelled
+		},
+		"cancelled after source": func(s *Snapshot) {
+			s.Meta.Visits[2].State = scheduler.Cancelled
+		},
+		"active duplicate": func(s *Snapshot) {
+			s.Meta.Visits = append(s.Meta.Visits, Visit{VisitID: newID(), StepID: "audit", Visit: 2, Iteration: 3, State: scheduler.Pending, Trigger: VisitTrigger{Kind: TriggerAfter}})
+		},
+		"reused decision cause": func(s *Snapshot) {
+			s.Meta.Visits = append(s.Meta.Visits, Visit{VisitID: newID(), StepID: "work", Visit: 2, Iteration: 2, State: scheduler.Pending,
+				Trigger: VisitTrigger{Kind: TriggerDecision, SourceVisitIDs: []string{s.Meta.Visits[0].VisitID}, DecisionKey: "go"}})
+		},
+		"reused after cause": func(s *Snapshot) {
+			s.Meta.Visits[3].State, s.Meta.Visits[3].CodexThreadID = scheduler.Succeeded, "chat-check"
+			s.Meta.Visits[3].TurnID, s.Meta.Visits[3].Attempt = "turn-check", 1
+			s.Meta.Visits = append(s.Meta.Visits, Visit{VisitID: newID(), StepID: "check", Visit: 2, Iteration: 2, State: scheduler.Pending,
+				Trigger: VisitTrigger{Kind: TriggerAfter, SourceVisitIDs: []string{s.Meta.Visits[2].VisitID}}})
+		},
+		"failed without reason": func(s *Snapshot) {
+			s.Meta.RunState = RunFailed
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			damaged := clone()
+			mutate(&damaged)
+			if err := damaged.validate(damaged.Meta.RunID); err == nil {
+				t.Fatal("повреждённая v4 metadata принята")
+			}
+		})
+	}
+	finishMismatch := cloneSnapshotMetadata(t, terminalWithPending)
+	finishMismatch.Meta.RunState, finishMismatch.Meta.StopReason = RunFailed, "подменённый итог"
+	if err := finishMismatch.validate(finishMismatch.Meta.RunID); err == nil {
+		t.Fatalf("applied finish не связан с итоговым runState: %+v", finishMismatch.Meta.Visits[0].Decision)
+	}
+	overlap := cloneSnapshotMetadata(t, snapshot)
+	overlap.Meta.Visits = append(overlap.Meta.Visits, Visit{VisitID: newID(), StepID: "audit", Visit: 2, Iteration: 2,
+		State: scheduler.Succeeded, CodexThreadID: "chat-audit-2", TurnID: "turn-audit-2", Attempt: 1})
+	if err := overlap.validate(overlap.Meta.RunID); err == nil || !strings.Contains(err.Error(), "предыдущее посещение") {
+		t.Fatalf("terminal visit обошёл незавершённое предыдущее посещение: %v", err)
+	}
+}
+
+// TestAfterTriggerFIFO не позволяет переставить причинность уже завершённых
+// посещений: каждый after-barrier обязан потреблять их в durable-порядке Visits.
+func TestAfterTriggerFIFO(t *testing.T) {
+	first := Visit{VisitID: newID(), StepID: "work", State: scheduler.Succeeded, Iteration: 1}
+	second := Visit{VisitID: newID(), StepID: "work", State: scheduler.Succeeded, Iteration: 2}
+	history := []Visit{first, second}
+	seen := map[string]Visit{first.VisitID: first, second.VisitID: second}
+	uses := map[afterCause]bool{}
+	trigger := func(source Visit) error {
+		return validateTrigger(2, Visit{StepID: "check", Iteration: source.Iteration,
+			Trigger: VisitTrigger{Kind: TriggerAfter, SourceVisitIDs: []string{source.VisitID}}},
+			workflow.Step{ID: "check", After: []string{"work"}}, nil, history, seen, uses, map[decisionCause]bool{})
+	}
+	if err := trigger(second); err == nil {
+		t.Fatal("after принял более поздний источник раньше первого")
+	}
+	if err := trigger(first); err != nil {
+		t.Fatalf("after отклонил самый ранний источник: %v", err)
+	}
+	if err := trigger(second); err != nil {
+		t.Fatalf("after не перешёл к следующему источнику: %v", err)
+	}
+}
+
+func cloneSnapshotMetadata(t *testing.T, snapshot Snapshot) Snapshot {
+	t.Helper()
+	data, err := json.Marshal(snapshot.Meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := Snapshot{Workflow: snapshot.Workflow, Task: snapshot.Task, HistoricalAppNative: snapshot.HistoricalAppNative}
+	if err := json.Unmarshal(data, &result.Meta, json.RejectUnknownMembers(true)); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}


### PR DESCRIPTION
## Что сделано

- добавлен versioned формат metadata v4 с отдельными visits, run outcome и причиной остановки;
- начальные visits создаются только для workflow version 2 через изолированный CreateAgentGraph, а production runtime пока остаётся закрыт;
- зафиксированы durable triggers, decision records и исходный turn решения;
- строгая валидация гарантирует FIFO для after, полную материализацию applied routes, отсутствие перекрывающихся visits и корректный global finish;
- legacy metadata v1-v3, память и child lookup сохраняют совместимость.

## Размер

Полный diff: **792 изменённые строки** (768 добавлений, 24 удаления). Это выше ориентира 500 строк, но ниже блокирующего предела 1200; слой оставлен цельным, потому что модель metadata и её валидатор образуют один совместимый контракт.

## Проверки

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/runstore`
- отдельная сборка/тест runstore без следующего stacked слоя мутаций
- `gofmt -d`
- `git diff --check`
- два независимых read-only ревью: APPROVE

Зависит от #71. Следующий PR добавит атомарные операции над visits и decisions.

Part of #50