### PR TITLE
Добавить атомарные операции посещений

### DIFF
--- a/internal/runstore/visits_locked.go
+++ b/internal/runstore/visits_locked.go
@@ -1,0 +1,304 @@
+//go:build darwin || linux
+
+package runstore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+
+	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
+)
+
+// ReserveVisits атомарно фиксирует намерение запустить всю волну Pending-visits.
+// Метод принимает только visitId: stepId неоднозначен после первого прохода
+// цикла. До успешной публикации metadata сетевые запросы делать нельзя.
+func (r *LockedRun) ReserveVisits(visitIDs []string) error {
+	return r.mutateVisits((*os.File).Sync, func(s *Snapshot) (bool, error) {
+		if len(visitIDs) == 0 {
+			return false, nil
+		}
+		if s.Meta.RunState != RunRunning {
+			return false, fmt.Errorf("завершённый run не принимает новые посещения")
+		}
+		indices := visitIndices(s.Meta.Visits)
+		seen := make(map[string]bool, len(visitIDs))
+		for _, visitID := range visitIDs {
+			index, exists := indices[visitID]
+			if !exists {
+				return false, fmt.Errorf("нет посещения %q", visitID)
+			}
+			if seen[visitID] {
+				return false, fmt.Errorf("посещение %q повторено в резервировании", visitID)
+			}
+			seen[visitID] = true
+			visit := s.Meta.Visits[index]
+			if visit.State != scheduler.Pending || visit.CodexThreadID != "" || visit.Attempt != 0 {
+				return false, fmt.Errorf("посещение %q уже запускалось", visitID)
+			}
+		}
+		for visitID := range seen {
+			index := indices[visitID]
+			s.Meta.Visits[index].State = scheduler.Starting
+		}
+		return true, nil
+	})
+}
+
+// ReleaseUnattemptedVisit снимает только подтверждённое локальным клиентом
+// резервирование, для которого thread/start не отправлялся. После перезапуска
+// одного Starting недостаточно: потерянный ответ мог скрывать созданный чат.
+func (r *LockedRun) ReleaseUnattemptedVisit(visitID string) error {
+	return r.mutateVisits((*os.File).Sync, func(s *Snapshot) (bool, error) {
+		index, err := findVisit(s.Meta.Visits, visitID)
+		if err != nil {
+			return false, err
+		}
+		visit := s.Meta.Visits[index]
+		if visit.State != scheduler.Starting || visit.CodexThreadID != "" || visit.TurnID != "" || visit.Attempt != 0 || visit.Decision != nil {
+			return false, fmt.Errorf("посещение %q: снять можно только неподтверждённое Starting", visitID)
+		}
+		s.Meta.Visits[index].State = scheduler.Pending
+		return true, nil
+	})
+}
+
+// UpdateVisit сохраняет фазу, неизменяемую связь с Codex-чатом и безопасную
+// техническую диагностику. Завершённое посещение неизменяемо; повтор ровно того
+// же значения остаётся идемпотентным и не переписывает диск.
+func (r *LockedRun) UpdateVisit(visitID string, state scheduler.State, codexThreadID, technicalError string) error {
+	return r.updateVisit(visitID, state, codexThreadID, technicalError, (*os.File).Sync)
+}
+
+// updateVisit принимает Sync для регрессионных тестов атомарной публикации.
+func (r *LockedRun) updateVisit(visitID string, state scheduler.State, chat, diagnostic string, syncFile func(*os.File) error) error {
+	return r.mutateVisits(syncFile, func(s *Snapshot) (bool, error) {
+		index, err := findVisit(s.Meta.Visits, visitID)
+		if err != nil {
+			return false, err
+		}
+		old := s.Meta.Visits[index]
+		if old.State == state && old.CodexThreadID == chat && old.TechnicalError == diagnostic {
+			return false, nil
+		}
+		if old.State == scheduler.Pending && state == scheduler.Starting && s.Meta.RunState != RunRunning {
+			return false, fmt.Errorf("завершённый run не принимает новые посещения")
+		}
+		if visitTerminal(old.State) {
+			return false, fmt.Errorf("посещение %q уже завершено и неизменяемо", visitID)
+		}
+		if old.State == scheduler.Pending && (state != scheduler.Pending && state != scheduler.Starting || chat != "") {
+			return false, fmt.Errorf("посещение %q: сначала сохраните Starting без ID чата", visitID)
+		}
+		if old.State != scheduler.Pending && state == scheduler.Pending ||
+			old.State != scheduler.Pending && old.State != scheduler.Starting && state == scheduler.Starting ||
+			old.CodexThreadID != "" && old.CodexThreadID != chat {
+			return false, fmt.Errorf("посещение %q: нельзя сбросить запуск или изменить известный ID чата", visitID)
+		}
+		s.Meta.Visits[index].State = state
+		s.Meta.Visits[index].CodexThreadID = chat
+		s.Meta.Visits[index].TechnicalError = diagnostic
+		return true, nil
+	})
+}
+
+// SetVisitTurn сохраняет очередной distinct turn и увеличивает Attempt. Повтор
+// того же turnId — идемпотентный replay; новый ID после terminal запрещён.
+func (r *LockedRun) SetVisitTurn(visitID, turnID string) error {
+	if !safeStoredText(turnID, true) {
+		return errors.New("нужен безопасный непустой turn-id")
+	}
+	return r.mutateVisits((*os.File).Sync, func(s *Snapshot) (bool, error) {
+		index, err := findVisit(s.Meta.Visits, visitID)
+		if err != nil {
+			return false, err
+		}
+		visit := s.Meta.Visits[index]
+		if visit.TurnID == turnID {
+			return false, nil
+		}
+		if s.Meta.RunState != RunRunning {
+			return false, fmt.Errorf("завершённый run не принимает новый turn")
+		}
+		if visit.Decision != nil && (visit.State != scheduler.Cancelled || visit.Decision.Applied || visit.Decision.Error != "") {
+			return false, fmt.Errorf("посещение %q уже сохранило решение и не принимает новый turn", visitID)
+		}
+		if visitTerminal(visit.State) {
+			return false, fmt.Errorf("посещение %q уже завершено и не принимает новый turn", visitID)
+		}
+		if visit.CodexThreadID == "" || visit.State == scheduler.Pending || visit.State == scheduler.Starting {
+			return false, fmt.Errorf("посещение %q ещё не связано с чатом Codex", visitID)
+		}
+		s.Meta.Visits[index].TurnID = turnID
+		s.Meta.Visits[index].Attempt++
+		return true, nil
+	})
+}
+
+// CommitDecision атомарно сохраняет ровно один разрешённый выбор конкретного
+// visit/thread/turn. Возвращаем материализованную копию маршрута для ответа tool,
+// но единственным источником истины остаётся meta.json. Точный replay безопасен.
+func (r *LockedRun) CommitDecision(visitID, codexThreadID, turnID, key, explanation, callID string) (DecisionRecord, error) {
+	return r.commitDecision(visitID, codexThreadID, turnID, key, explanation, callID, (*os.File).Sync)
+}
+
+func (r *LockedRun) commitDecision(visitID, chat, turnID, key, explanation, callID string, syncFile func(*os.File) error) (DecisionRecord, error) {
+	if !safeStoredText(callID, true) || !validText(key) || !safeStoredText(explanation, false) {
+		return DecisionRecord{}, fmt.Errorf("решение содержит небезопасный key, explanation или callId")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.check(); err != nil {
+		return DecisionRecord{}, err
+	}
+	s, err := load(r.dir, r.runID)
+	if err != nil {
+		return DecisionRecord{}, err
+	}
+	if s.Meta.Version != 4 {
+		return DecisionRecord{}, fmt.Errorf("операция посещений требует meta.json v4")
+	}
+	index, err := findVisit(s.Meta.Visits, visitID)
+	if err != nil {
+		return DecisionRecord{}, err
+	}
+	visit := s.Meta.Visits[index]
+	if visit.CodexThreadID != chat || visit.TurnID != turnID || chat == "" || turnID == "" {
+		return DecisionRecord{}, fmt.Errorf("посещение %q не принадлежит указанным thread/turn", visitID)
+	}
+	step, exists := workflowStep(s, visit.StepID)
+	if !exists {
+		return DecisionRecord{}, fmt.Errorf("нет шага %q", visit.StepID)
+	}
+	route, routeExists := step.Decisions[key]
+	var desired DecisionRecord
+	if routeExists {
+		desired = DecisionRecord{Key: key, Explanation: explanation, TurnID: turnID, CallID: callID, To: slices.Clone(route.To), Finish: cloneOutcome(route.Finish)}
+		for skipped := range step.Decisions {
+			if skipped != key {
+				desired.Skipped = append(desired.Skipped, skipped)
+			}
+		}
+		sort.Strings(desired.Skipped)
+	}
+	if visit.Decision != nil {
+		existing := cloneDecision(*visit.Decision)
+		if routeExists && existing.Error == "" && sameDecisionPayload(existing, desired) {
+			return existing, nil
+		}
+		conflict := fmt.Errorf("посещение %q уже сохранило другое решение", visitID)
+		// После применения или terminal нельзя менять даже диагностику. До этой
+		// границы сохраняем безопасный poison marker, чтобы resume не применил
+		// первый маршрут после обнаруженного второго противоречивого tool call.
+		if visitTerminal(visit.State) || existing.Applied || existing.Error != "" {
+			return existing, conflict
+		}
+		existing.Error = "агент повторно вызвал решение с другим callId или payload"
+		s.Meta.Visits[index].Decision = &existing
+		if err = s.validate(r.runID); err != nil {
+			return DecisionRecord{}, err
+		}
+		if err = saveMetadata(r.dir, s.Meta, syncFile); err != nil {
+			return existing, errors.Join(conflict, r.recordVisitSaveFailure(err))
+		}
+		return existing, conflict
+	}
+	if s.Meta.RunState != RunRunning {
+		return DecisionRecord{}, fmt.Errorf("завершённый run не принимает новое решение")
+	}
+	if !routeExists {
+		return DecisionRecord{}, fmt.Errorf("шаг %q не разрешает решение %q", visit.StepID, key)
+	}
+	if visitTerminal(visit.State) {
+		return DecisionRecord{}, fmt.Errorf("посещение %q уже завершено без решения", visitID)
+	}
+	s.Meta.Visits[index].Decision = &desired
+	if err = s.validate(r.runID); err != nil {
+		return DecisionRecord{}, err
+	}
+	if err = saveMetadata(r.dir, s.Meta, syncFile); err != nil {
+		return DecisionRecord{}, r.recordVisitSaveFailure(err)
+	}
+	return cloneDecision(desired), nil
+}
+
+// mutateVisits сериализует read-modify-validate-publish. Ошибка до save не
+// отравляет владельца; ошибка save оставляет неизвестной сторону Rename и потому
+// запрещает все следующие операции до Close и повторной сверки с диском/Codex.
+func (r *LockedRun) mutateVisits(syncFile func(*os.File) error, mutate func(*Snapshot) (bool, error)) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.check(); err != nil {
+		return err
+	}
+	s, err := load(r.dir, r.runID)
+	if err != nil {
+		return err
+	}
+	if s.Meta.Version != 4 {
+		return fmt.Errorf("операция посещений требует meta.json v4")
+	}
+	changed, err := mutate(&s)
+	if err != nil || !changed {
+		return err
+	}
+	if err = s.validate(r.runID); err != nil {
+		return err
+	}
+	if err = saveMetadata(r.dir, s.Meta, syncFile); err != nil {
+		return r.recordVisitSaveFailure(err)
+	}
+	return nil
+}
+
+func (r *LockedRun) recordVisitSaveFailure(err error) error {
+	r.failed = fmt.Errorf("сохранение посещений запуска %q: %w; остановите новые запросы и восстановите состояние после повторного открытия", r.runID, err)
+	return r.failed
+}
+
+func visitIndices(visits []Visit) map[string]int {
+	result := make(map[string]int, len(visits))
+	for index, visit := range visits {
+		result[visit.VisitID] = index
+	}
+	return result
+}
+
+func findVisit(visits []Visit, visitID string) (int, error) {
+	for index, visit := range visits {
+		if visit.VisitID == visitID {
+			return index, nil
+		}
+	}
+	return -1, fmt.Errorf("нет посещения %q", visitID)
+}
+
+func workflowStep(s Snapshot, stepID string) (workflow.Step, bool) {
+	for _, step := range s.Workflow.Steps {
+		if step.ID == stepID {
+			return step, true
+		}
+	}
+	return workflow.Step{}, false
+}
+
+func cloneOutcome(value *workflow.TerminalOutcome) *workflow.TerminalOutcome {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func cloneDecision(value DecisionRecord) DecisionRecord {
+	value.To, value.Skipped, value.Finish = slices.Clone(value.To), slices.Clone(value.Skipped), cloneOutcome(value.Finish)
+	return value
+}
+
+func sameDecisionPayload(left, right DecisionRecord) bool {
+	return left.Key == right.Key && left.Explanation == right.Explanation && left.TurnID == right.TurnID && left.CallID == right.CallID &&
+		slices.Equal(left.To, right.To) && sameOutcome(left.Finish, right.Finish) && slices.Equal(left.Skipped, right.Skipped)
+}

--- a/internal/runstore/visits_locked_test.go
+++ b/internal/runstore/visits_locked_test.go
@@ -1,0 +1,238 @@
+//go:build darwin || linux
+
+package runstore
+
+import (
+	"errors"
+	"os"
+	"reflect"
+	"syscall"
+	"testing"
+
+	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+)
+
+// TestVisitLifecycle проверяет адресацию только по visitId, пакетный reserve,
+// счётчик distinct turns, безопасную terminal-диагностику и неизменяемость финала.
+func TestVisitLifecycle(t *testing.T) {
+	root, initial, run := testAgentGraphRun(t)
+	first, second := initial.Meta.Visits[0].VisitID, initial.Meta.Visits[1].VisitID
+	if err := run.Reserve([]string{"choice"}); err == nil {
+		t.Fatal("legacy Reserve неожиданно управляет v4")
+	}
+	for _, invalid := range [][]string{{first, "missing"}, {first, first}} {
+		if err := run.ReserveVisits(invalid); err == nil {
+			t.Fatalf("принята неверная волна %v", invalid)
+		}
+	}
+	if err := run.ReserveVisits([]string{first}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.ReleaseUnattemptedVisit(first); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.ReserveVisits([]string{first, second}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(first, scheduler.Unknown, "chat-choice", ""); err != nil {
+		t.Fatal(err)
+	}
+	for _, turn := range []string{"turn-1", "turn-1", "turn-2"} {
+		if err := run.SetVisitTurn(first, turn); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := run.UpdateVisit(first, scheduler.Running, "chat-choice", ""); err != nil {
+		t.Fatal(err)
+	}
+	decision, err := run.CommitDecision(first, "chat-choice", "turn-2", "go", "нужна работа", "call-1")
+	if err != nil || !reflect.DeepEqual(decision.To, []string{"work"}) || !reflect.DeepEqual(decision.Skipped, []string{"done", "fail"}) {
+		t.Fatalf("маршрут не материализован: %+v, %v", decision, err)
+	}
+	if err := run.SetVisitTurn(first, "turn-3"); err == nil {
+		t.Fatal("посещение с durable decision приняло новый turn")
+	}
+	if err := run.UpdateVisit(first, scheduler.Cancelled, "chat-choice", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.SetVisitTurn(first, "turn-3"); err != nil {
+		t.Fatalf("Cancelled с неприменённым решением не продолжился: %v", err)
+	}
+	if err := run.UpdateVisit(first, scheduler.Running, "chat-choice", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(first, scheduler.Succeeded, "chat-choice", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(first, scheduler.Running, "chat-choice", ""); err == nil || run.SetVisitTurn(first, "turn-4") == nil {
+		t.Fatal("terminal visit изменён")
+	}
+	if err := run.UpdateVisit(second, scheduler.Unknown, "chat-audit", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(second, scheduler.Cancelled, "chat-audit", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.SetVisitTurn(second, "turn-audit"); err != nil {
+		t.Fatalf("Cancelled должен продолжаться новым turn: %v", err)
+	}
+	if err := run.UpdateVisit(second, scheduler.Running, "chat-audit", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(second, scheduler.Failed, "chat-audit", "сеть недоступна"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := run.Load()
+	if err != nil || got.Meta.Visits[0].Attempt != 3 || got.Meta.Visits[0].TurnID != "turn-3" || got.Meta.Visits[0].Decision.TurnID != "turn-2" || got.Meta.Visits[1].TechnicalError != "сеть недоступна" {
+		t.Fatalf("жизненный цикл потерян: %+v, %v", got.Meta.Visits, err)
+	}
+	if err := RemoveUnstarted(root, initial.Meta.RunID); err == nil {
+		t.Fatal("начатый v4 run удалён")
+	}
+}
+
+// TestCommitDecisionIdempotency проверяет точный replay и poison marker второго
+// противоречивого вызова. Возвращённая копия не даёт вызывающему изменить диск.
+func TestCommitDecisionIdempotency(t *testing.T) {
+	_, initial, run := testAgentGraphRun(t)
+	visitID := initial.Meta.Visits[0].VisitID
+	err := run.ReserveVisits([]string{visitID})
+	if err == nil {
+		err = run.UpdateVisit(visitID, scheduler.Unknown, "chat", "")
+	}
+	if err == nil {
+		err = run.SetVisitTurn(visitID, "turn")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, _ := run.Load()
+	for _, invalid := range [][3]string{{"other", "turn", "go"}, {"chat", "other", "go"}, {"chat", "turn", "missing"}} {
+		if _, err := run.CommitDecision(visitID, invalid[0], invalid[1], invalid[2], "", "call"); err == nil {
+			t.Fatalf("принята неверная связь решения: %v", invalid)
+		}
+	}
+	if got, _ := run.Load(); !reflect.DeepEqual(got, before) {
+		t.Fatal("отказ решения изменил snapshot")
+	}
+	record, err := run.CommitDecision(visitID, "chat", "turn", "go", "пояснение", "call-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	record.To[0] = "подмена"
+	if _, err := run.CommitDecision(visitID, "chat", "turn", "go", "пояснение", "call-1"); err != nil {
+		t.Fatalf("точный replay не идемпотентен: %v", err)
+	}
+	if _, err := run.CommitDecision(visitID, "chat", "turn", "missing", "другое", "call-2"); err == nil {
+		t.Fatal("второе противоречивое решение принято")
+	}
+	stored, err := run.Load()
+	if err != nil || stored.Meta.Visits[0].Decision.Key != "go" || stored.Meta.Visits[0].Decision.To[0] != "work" || stored.Meta.Visits[0].Decision.Error == "" {
+		t.Fatalf("первый маршрут или poison marker потерян: %+v, %v", stored.Meta.Visits[0].Decision, err)
+	}
+	if err := run.UpdateVisit(visitID, scheduler.Succeeded, "chat", ""); err != nil {
+		t.Fatalf("технический результат poisoned turn не сохранён: %v", err)
+	}
+	stored, err = run.Load()
+	if err != nil || stored.Meta.Visits[0].State != scheduler.Succeeded || stored.Meta.Visits[0].Decision.Error == "" || stored.Meta.Visits[0].Decision.Applied {
+		t.Fatalf("poisoned решение ошибочно применено или потеряно: %+v, %v", stored.Meta.Visits[0], err)
+	}
+
+	// Успешный terminal turn без единого вызова choose_decision также остаётся
+	// фактом истории. Следующий планировщик превратит его в failed всего run и
+	// не будет притворяться, что транспортный turn завершился ошибкой.
+	_, missingInitial, missingRun := testAgentGraphRun(t)
+	missingID := missingInitial.Meta.Visits[0].VisitID
+	if err := missingRun.ReserveVisits([]string{missingID}); err == nil {
+		err = missingRun.UpdateVisit(missingID, scheduler.Unknown, "chat-missing", "")
+	}
+	if err == nil {
+		err = missingRun.SetVisitTurn(missingID, "turn-missing")
+	}
+	if err == nil {
+		err = missingRun.UpdateVisit(missingID, scheduler.Succeeded, "chat-missing", "")
+	}
+	if err != nil {
+		t.Fatalf("completed turn без решения не сохранён: %v", err)
+	}
+}
+
+// TestTerminalRunDoesNotReserve не позволяет гонке с параллельной веткой
+// запустить новый thread после durable commit глобального finish.
+func TestTerminalRunDoesNotReserve(t *testing.T) {
+	_, initial, run := testAgentGraphRun(t)
+	choiceID, pendingID := initial.Meta.Visits[0].VisitID, initial.Meta.Visits[1].VisitID
+	err := run.mutateVisits((*os.File).Sync, func(snapshot *Snapshot) (bool, error) {
+		choice := &snapshot.Meta.Visits[0]
+		choice.State, choice.CodexThreadID, choice.TurnID, choice.Attempt = scheduler.Succeeded, "chat", "turn", 1
+		choice.Decision = &DecisionRecord{Key: "done", TurnID: "turn", CallID: "call", Finish: cloneOutcome(snapshot.Workflow.Steps[0].Decisions["done"].Finish), Skipped: []string{"fail", "go"}, Applied: true}
+		snapshot.Meta.RunState, snapshot.Meta.StopReason = RunSucceeded, "агент выбрал успешное завершение"
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := run.ReserveVisits([]string{pendingID}); err == nil {
+		t.Fatalf("terminal run зарезервировал посещение после finish %s", choiceID)
+	}
+	if err := run.UpdateVisit(pendingID, scheduler.Starting, "", ""); err == nil {
+		t.Fatal("terminal run перевёл Pending в Starting через UpdateVisit")
+	}
+	if err := run.mutateVisits((*os.File).Sync, func(snapshot *Snapshot) (bool, error) {
+		visit := &snapshot.Meta.Visits[1]
+		visit.State, visit.CodexThreadID, visit.TurnID, visit.Attempt = scheduler.Running, "chat-pending", "turn-pending", 1
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run.CommitDecision(pendingID, "chat-pending", "turn-pending", "done", "поздний выбор", "call-pending"); err == nil {
+		t.Fatal("terminal run принял первое решение параллельного агента")
+	}
+	if err := run.mutateVisits((*os.File).Sync, func(snapshot *Snapshot) (bool, error) {
+		snapshot.Meta.Visits[1].State = scheduler.Cancelled
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.SetVisitTurn(pendingID, "turn-after-finish"); err == nil {
+		t.Fatal("terminal run продолжил Cancelled новым turn")
+	}
+}
+
+// TestVisitUpdateSyncFailure воспроизводит отказ до Rename. Владелец после него
+// останавливается, а повторное открытие видит целую прежнюю metadata и продолжает.
+func TestVisitUpdateSyncFailure(t *testing.T) {
+	root, initial, run := testAgentGraphRun(t)
+	visitID := initial.Meta.Visits[0].VisitID
+	if err := run.ReserveVisits([]string{visitID}); err != nil {
+		t.Fatal(err)
+	}
+	err := run.updateVisit(visitID, scheduler.Unknown, "chat", "", func(file *os.File) error {
+		info, statErr := file.Stat()
+		if statErr != nil {
+			return statErr
+		}
+		if !info.IsDir() {
+			return syscall.EIO
+		}
+		return file.Sync()
+	})
+	if !errors.Is(err, syscall.EIO) || !errors.Is(run.ReserveVisits(nil), syscall.EIO) {
+		t.Fatalf("ошибка записи не остановила владельца: %v", err)
+	}
+	external, err := Load(root, initial.Meta.RunID)
+	if err != nil || external.Meta.Visits[0].State != scheduler.Starting || external.Meta.Visits[0].CodexThreadID != "" {
+		t.Fatalf("отказ до Rename повредил metadata: %+v, %v", external.Meta.Visits, err)
+	}
+	if err := run.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	if err := reopened.UpdateVisit(visitID, scheduler.Unknown, "chat", ""); err != nil {
+		t.Fatalf("повторное открытие не восстановило запись: %v", err)
+	}
+}


### PR DESCRIPTION
## Что сделано

- добавлены visitId-only reserve, release, state update и сохранение distinct turns;
- durable choose_decision связывается с точными visit/thread/turn и материализует только разрешённый маршрут;
- exact replay идемпотентен, противоречивый второй вызов сохраняет poison marker;
- Cancelled остаётся resumable, при этом исходный turn уже принятого решения не теряется;
- global finish запрещает новые visits, turns и поздние первые решения;
- неопределённая ошибка записи останавливает владельца до повторного открытия run.

## Размер

Полный diff: **542 изменённые строки** (542 добавления). Это выше ориентира 500 строк, но ниже блокирующего предела 1200; production-код и регрессионные тесты оставлены одним законченным crash-safe слоем.

## Проверки

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/runstore`
- `gofmt -d`
- `git diff --check`
- два независимых read-only ревью: APPROVE

Зависит от #72. Production runtime version 2 остаётся закрыт до следующего coordinator PR.

Part of #50