### PR TITLE
Добавить планирование агентных ветвлений

### DIFF
--- a/internal/scheduler/agent.go
+++ b/internal/scheduler/agent.go
@@ -1,0 +1,518 @@
+package scheduler
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
+)
+
+// ErrAgentGraphCycle отмечает намеренное ограничение первого visit-aware runtime:
+// схема version=2 уже умеет описывать ограниченные циклы, но до появления учёта
+// maxVisits планировщик не должен запускать из такой схемы ни одного агента.
+// Вызывающий код проверяет ошибку через errors.Is; следующий срез runtime сможет
+// снять ограничение, не меняя остальные ошибки входного контракта.
+var ErrAgentGraphCycle = errors.New("visit-aware планировщик пока не поддерживает циклы")
+
+// AgentTriggerKind описывает сохранённую причину появления посещения. Тип живёт в
+// scheduler, а не в runstore, чтобы чистое ядро не зависело от файлового формата.
+// Persistence-слой переводит свои строковые значения в этот тип на границе.
+type AgentTriggerKind string
+
+const (
+	AgentTriggerStart    AgentTriggerKind = "start"
+	AgentTriggerAfter    AgentTriggerKind = "after"
+	AgentTriggerDecision AgentTriggerKind = "decision"
+)
+
+// AgentTriggerView — минимальная проекция durable trigger, необходимая чистому
+// планировщику. SourceVisitIDs сохраняют исходный порядок: зависимости Step.After
+// для after и единственный visit решения для decision.
+type AgentTriggerView struct {
+	Kind           AgentTriggerKind
+	SourceVisitIDs []string
+	DecisionKey    string
+}
+
+// AgentDecisionView содержит только изменяемую часть durable выбора. Разрешённые
+// To/Finish планировщик всегда берёт из неизменяемого workflow: это не позволяет
+// переданной проекции незаметно подменить пользовательский маршрут.
+type AgentDecisionView struct {
+	Key     string
+	Applied bool
+	Error   string
+}
+
+// AgentVisitView — упорядоченная проекция append-only истории run. Срез должен
+// содержать все visits в durable-порядке: он одновременно задаёт FIFO для after,
+// стабильный приоритет решений и причинную границу natural completion.
+type AgentVisitView struct {
+	VisitID   string
+	StepID    string
+	Iteration int
+	State     State
+	Trigger   AgentTriggerView
+	Decision  *AgentDecisionView
+}
+
+// AgentActivation полностью описывает новое Pending-посещение, кроме его
+// случайного VisitID. Persistence-слой генерирует ID, создаёт файл памяти и одним
+// атомарным commit сохраняет все активации вместе с применёнными решениями.
+type AgentActivation struct {
+	StepID    string
+	Iteration int
+	Trigger   AgentTriggerView
+}
+
+// AgentTerminal — итог всего run. CauseVisitID связывает failed frontier, fatal
+// decision либо explicit finish с конкретным durable visit. Это структурированное
+// доказательство позволяет runstore проверить причину остановки, не разбирая
+// Reason. Пустой CauseVisitID допустим только у естественного успешного исхода,
+// для которого единственного причинного посещения может не существовать.
+type AgentTerminal struct {
+	Outcome      workflow.TerminalOutcome
+	Reason       string
+	CauseVisitID string
+}
+
+// AgentPlan — детерминированный следующий атомарный переход. Decision-активации
+// идут в порядке Visits и route.to, after-активации — в порядке Workflow.Steps.
+// Пустой план без Terminal означает ожидание уже активных/resumable visits.
+type AgentPlan struct {
+	ApplyDecisionVisitIDs []string
+	DecisionActivations   []AgentActivation
+	AfterActivations      []AgentActivation
+	Terminal              *AgentTerminal
+}
+
+// PlanAgentGraph вычисляет следующий переход version=2 без I/O и не изменяет
+// workflow либо visits. Первый срез runtime исполняет только полный DAG: наличие
+// любого цикла, включая decision-route, возвращает ErrAgentGraphCycle до анализа
+// состояний, то есть до возможного запуска Codex.
+//
+// Приоритеты намеренны. Сначала в порядке Visits выбирается terminal decision:
+// missing/poison завершает run ошибкой, finish — указанным исходом. Такой переход
+// не смешивается с новыми visits. Затем независимые route fanout применяются
+// атомарно, после них строятся FIFO after-barriers. Если действий и active visits
+// нет, исход определяет фактический terminal frontier: Failed на его границе даёт
+// failed, иначе граф естественно завершился успешно.
+func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, error) {
+	if err := w.Validate(); err != nil {
+		return AgentPlan{}, fmt.Errorf("visit-aware планировщик: %w", err)
+	}
+	if w.EffectiveVersion() != workflow.VersionAgentGraph {
+		return AgentPlan{}, fmt.Errorf("visit-aware планировщик требует workflow version=2")
+	}
+	if agentGraphHasCycle(w) {
+		return AgentPlan{}, fmt.Errorf("%w: workflow %q", ErrAgentGraphCycle, w.ID)
+	}
+
+	context, err := validateAgentVisitViews(w, visits)
+	if err != nil {
+		return AgentPlan{}, fmt.Errorf("visit-aware планировщик: %w", err)
+	}
+	if terminal, exists := firstDecisionTerminal(context.steps, visits); exists {
+		return terminal, nil
+	}
+
+	plan := AgentPlan{}
+	projectedActive := make(map[string]bool, len(context.active))
+	for stepID := range context.active {
+		projectedActive[stepID] = true
+	}
+
+	// Один decision fanout является неделимой операцией. Если хотя бы одна цель
+	// занята, нельзя применить только свободную часть: повтор после crash иначе не
+	// сможет отличить полный маршрут от частично материализованного.
+	for _, visit := range visits {
+		step := context.steps[visit.StepID]
+		decision := visit.Decision
+		if len(step.Decisions) == 0 || visit.State != Succeeded || decision == nil || decision.Applied || decision.Error != "" {
+			continue
+		}
+		route, exists := step.Decisions[decision.Key]
+		if !exists || route.Finish != nil {
+			// Unknown и finish уже обработаны firstDecisionTerminal. Условие
+			// оставлено защитным, чтобы дальнейшее расширение функции не могло
+			// превратить terminal route в обычную активацию.
+			continue
+		}
+		blocked := false
+		for _, target := range route.To {
+			if projectedActive[target] {
+				blocked = true
+				break
+			}
+		}
+		if blocked {
+			continue
+		}
+		plan.ApplyDecisionVisitIDs = append(plan.ApplyDecisionVisitIDs, visit.VisitID)
+		for _, target := range route.To {
+			plan.DecisionActivations = append(plan.DecisionActivations, AgentActivation{
+				StepID: target, Iteration: visit.Iteration + 1,
+				Trigger: AgentTriggerView{Kind: AgentTriggerDecision, SourceVisitIDs: []string{visit.VisitID}, DecisionKey: decision.Key},
+			})
+			projectedActive[target] = true
+		}
+	}
+
+	// After рассматривается только после direct routes: если оба механизма хотят
+	// один step в одном снимке, явный route получает его первым, а FIFO-источники
+	// after остаются непотреблёнными до следующего вызова.
+	for _, step := range w.Steps {
+		if len(step.After) == 0 || projectedActive[step.ID] {
+			continue
+		}
+		sources, iteration, ready := nextAfterSources(step, context)
+		if !ready {
+			continue
+		}
+		plan.AfterActivations = append(plan.AfterActivations, AgentActivation{
+			StepID: step.ID, Iteration: iteration,
+			Trigger: AgentTriggerView{Kind: AgentTriggerAfter, SourceVisitIDs: sources},
+		})
+		projectedActive[step.ID] = true
+	}
+
+	if len(plan.ApplyDecisionVisitIDs) != 0 || len(plan.DecisionActivations) != 0 || len(plan.AfterActivations) != 0 {
+		return plan, nil
+	}
+	if len(context.active) != 0 {
+		return AgentPlan{}, nil
+	}
+
+	for _, visit := range visits {
+		if visit.State == Failed && !context.advanced[visit.VisitID] {
+			return AgentPlan{Terminal: &AgentTerminal{
+				Outcome:      workflow.OutcomeFailed,
+				Reason:       fmt.Sprintf("terminal-посещение %q шага %q завершилось с ошибкой", visit.VisitID, visit.StepID),
+				CauseVisitID: visit.VisitID,
+			}}, nil
+		}
+	}
+	return AgentPlan{Terminal: &AgentTerminal{
+		Outcome: workflow.OutcomeSucceeded,
+		Reason:  "workflow достиг естественного завершения",
+	}}, nil
+}
+
+// agentPlanningContext — проверенные индексы одного снимка. terminalByStep
+// сохраняет порядок Visits, поэтому поиск следующего after-источника не зависит
+// от map iteration. usedAfter разделён по target/dependency/source: одно событие
+// может честно разбудить несколько разных downstream-кубиков.
+type agentPlanningContext struct {
+	steps          map[string]workflow.Step
+	active         map[string]bool
+	terminalByStep map[string][]AgentVisitView
+	usedAfter      map[agentAfterCause]bool
+	advanced       map[string]bool
+}
+
+type agentAfterCause struct {
+	targetStepID     string
+	dependencyStepID string
+	sourceVisitID    string
+}
+
+type agentDecisionCause struct {
+	targetStepID  string
+	sourceVisitID string
+}
+
+// validateAgentVisitViews защищает чистую публичную границу от неполной или
+// переставленной проекции. Runstore выполняет более подробную проверку metadata,
+// но planner не полагается на невыраженные свойства другого пакета.
+func validateAgentVisitViews(w workflow.Workflow, visits []AgentVisitView) (agentPlanningContext, error) {
+	context := agentPlanningContext{
+		steps: make(map[string]workflow.Step, len(w.Steps)), active: make(map[string]bool),
+		terminalByStep: make(map[string][]AgentVisitView), usedAfter: make(map[agentAfterCause]bool),
+		advanced: make(map[string]bool),
+	}
+	for _, step := range w.Steps {
+		context.steps[step.ID] = step
+	}
+	if len(visits) < len(w.Start) {
+		return agentPlanningContext{}, fmt.Errorf("история не содержит весь начальный префикс workflow.start")
+	}
+
+	seen := make(map[string]AgentVisitView, len(visits))
+	decisionUses := make(map[agentDecisionCause]bool)
+	for index, visit := range visits {
+		step, exists := context.steps[visit.StepID]
+		if !exists || visit.VisitID == "" || visit.Iteration < 1 {
+			return agentPlanningContext{}, fmt.Errorf("visits[%d]: неверный visitId, stepId или iteration", index)
+		}
+		if _, duplicate := seen[visit.VisitID]; duplicate {
+			return agentPlanningContext{}, fmt.Errorf("visits[%d]: повторный visitId %q", index, visit.VisitID)
+		}
+		if !knownAgentState(visit.State) {
+			return agentPlanningContext{}, fmt.Errorf("посещение %q: неизвестное состояние %q", visit.VisitID, visit.State)
+		}
+		if context.active[visit.StepID] {
+			return agentPlanningContext{}, fmt.Errorf("посещение %q появилось до завершения предыдущего visit шага %q", visit.VisitID, visit.StepID)
+		}
+		if !agentVisitTerminal(visit.State) {
+			context.active[visit.StepID] = true
+		}
+		if visit.Decision != nil {
+			if len(step.Decisions) == 0 || visit.Decision.Applied && (visit.State != Succeeded || visit.Decision.Error != "") {
+				return agentPlanningContext{}, fmt.Errorf("посещение %q содержит решение в несовместимом состоянии", visit.VisitID)
+			}
+		}
+
+		if index < len(w.Start) {
+			if visit.StepID != w.Start[index] || visit.Trigger.Kind != AgentTriggerStart || visit.Iteration != 1 {
+				return agentPlanningContext{}, fmt.Errorf("visits[%d] не совпадает с начальным префиксом workflow.start", index)
+			}
+		}
+		switch visit.Trigger.Kind {
+		case AgentTriggerStart:
+			if index >= len(w.Start) || len(visit.Trigger.SourceVisitIDs) != 0 || visit.Trigger.DecisionKey != "" {
+				return agentPlanningContext{}, fmt.Errorf("посещение %q: start допустим только в начальном префиксе", visit.VisitID)
+			}
+		case AgentTriggerAfter:
+			if err := validateAgentAfterTrigger(visit, step, seen, context.terminalByStep, context.usedAfter); err != nil {
+				return agentPlanningContext{}, err
+			}
+		case AgentTriggerDecision:
+			if err := validateAgentDecisionTrigger(visit, seen, decisionUses, context.steps); err != nil {
+				return agentPlanningContext{}, err
+			}
+		default:
+			return agentPlanningContext{}, fmt.Errorf("посещение %q: неизвестный trigger %q", visit.VisitID, visit.Trigger.Kind)
+		}
+		for _, sourceID := range visit.Trigger.SourceVisitIDs {
+			context.advanced[sourceID] = true
+		}
+		seen[visit.VisitID] = visit
+		if agentVisitTerminal(visit.State) {
+			context.terminalByStep[visit.StepID] = append(context.terminalByStep[visit.StepID], visit)
+		}
+	}
+	// Applied является durable-обещанием, что persistence опубликовал весь
+	// переход одним commit. Проверяем обещание после полного прохода: targets
+	// законно расположены позже source visit, поэтому раньше доказать полноту
+	// fanout невозможно. Applied finish в эту функцию попадать не должен вовсе:
+	// он атомарно переводит run в terminal, а planner вычисляет только следующий
+	// переход ещё работающего снимка.
+	for _, visit := range visits {
+		if visit.Decision == nil || !visit.Decision.Applied {
+			continue
+		}
+		route, exists := context.steps[visit.StepID].Decisions[visit.Decision.Key]
+		if !exists {
+			return agentPlanningContext{}, fmt.Errorf("посещение %q: применено неизвестное решение %q", visit.VisitID, visit.Decision.Key)
+		}
+		if route.Finish != nil {
+			return agentPlanningContext{}, fmt.Errorf("посещение %q: применённый finish требует уже terminal run", visit.VisitID)
+		}
+		for _, target := range route.To {
+			if !decisionUses[agentDecisionCause{target, visit.VisitID}] {
+				return agentPlanningContext{}, fmt.Errorf("посещение %q: применённое решение не материализовало target %q", visit.VisitID, target)
+			}
+		}
+	}
+	return context, nil
+}
+
+func validateAgentAfterTrigger(visit AgentVisitView, step workflow.Step, seen map[string]AgentVisitView, terminalByStep map[string][]AgentVisitView, used map[agentAfterCause]bool) error {
+	if len(step.After) == 0 || len(visit.Trigger.SourceVisitIDs) != len(step.After) || visit.Trigger.DecisionKey != "" {
+		return fmt.Errorf("посещение %q: неверная форма after-trigger", visit.VisitID)
+	}
+	maxIteration := 0
+	for index, dependency := range step.After {
+		sourceID := visit.Trigger.SourceVisitIDs[index]
+		source, exists := seen[sourceID]
+		if !exists || source.StepID != dependency || !agentVisitTerminal(source.State) {
+			return fmt.Errorf("посещение %q: неверный after-источник %q", visit.VisitID, sourceID)
+		}
+		expected := ""
+		for _, candidate := range terminalByStep[dependency] {
+			cause := agentAfterCause{step.ID, dependency, candidate.VisitID}
+			if !used[cause] {
+				expected = candidate.VisitID
+				break
+			}
+		}
+		cause := agentAfterCause{step.ID, dependency, sourceID}
+		if sourceID != expected || used[cause] {
+			return fmt.Errorf("посещение %q: after нарушает FIFO зависимости %q", visit.VisitID, dependency)
+		}
+		used[cause] = true
+		maxIteration = max(maxIteration, source.Iteration)
+	}
+	if visit.Iteration != maxIteration {
+		return fmt.Errorf("посещение %q: after должен наследовать максимальную iteration источников", visit.VisitID)
+	}
+	return nil
+}
+
+func validateAgentDecisionTrigger(visit AgentVisitView, seen map[string]AgentVisitView, uses map[agentDecisionCause]bool, steps map[string]workflow.Step) error {
+	if len(visit.Trigger.SourceVisitIDs) != 1 || visit.Trigger.DecisionKey == "" {
+		return fmt.Errorf("посещение %q: неверная форма decision-trigger", visit.VisitID)
+	}
+	source, exists := seen[visit.Trigger.SourceVisitIDs[0]]
+	if !exists || source.State != Succeeded || source.Decision == nil || !source.Decision.Applied || source.Decision.Error != "" || source.Decision.Key != visit.Trigger.DecisionKey {
+		return fmt.Errorf("посещение %q: неверный decision-источник", visit.VisitID)
+	}
+	route, exists := steps[source.StepID].Decisions[source.Decision.Key]
+	if !exists || route.Finish != nil || !slices.Contains(route.To, visit.StepID) {
+		return fmt.Errorf("посещение %q: источник не выбирал этот target", visit.VisitID)
+	}
+	cause := agentDecisionCause{visit.StepID, source.VisitID}
+	if uses[cause] {
+		return fmt.Errorf("посещение %q: decision-target уже материализован", visit.VisitID)
+	}
+	uses[cause] = true
+	if visit.Iteration != source.Iteration+1 {
+		return fmt.Errorf("посещение %q: decision-target должен увеличить iteration", visit.VisitID)
+	}
+	return nil
+}
+
+// firstDecisionTerminal возвращает только terminal-переход. Обычные routes здесь
+// не материализуются: если более поздний visit уже требует немедленного завершения,
+// незаписанные активации более раннего route безопасно отбрасываются.
+func firstDecisionTerminal(steps map[string]workflow.Step, visits []AgentVisitView) (AgentPlan, bool) {
+	for _, visit := range visits {
+		step := steps[visit.StepID]
+		if len(step.Decisions) == 0 {
+			continue
+		}
+		decision := visit.Decision
+		if decision != nil && decision.Error != "" {
+			return fatalDecisionPlan(visit, "durable решение содержит конфликт: "+decision.Error), true
+		}
+		if visit.State != Succeeded {
+			continue
+		}
+		if decision == nil {
+			return fatalDecisionPlan(visit, "успешный turn завершился без choose_decision"), true
+		}
+		if decision.Applied {
+			continue
+		}
+		route, exists := step.Decisions[decision.Key]
+		if !exists {
+			return fatalDecisionPlan(visit, fmt.Sprintf("сохранён неизвестный ключ решения %q", decision.Key)), true
+		}
+		if route.Finish != nil {
+			outcome := *route.Finish
+			return AgentPlan{
+				ApplyDecisionVisitIDs: []string{visit.VisitID},
+				Terminal: &AgentTerminal{
+					Outcome:      outcome,
+					Reason:       fmt.Sprintf("решение %q шага %q выбрало finish %q", decision.Key, visit.StepID, outcome),
+					CauseVisitID: visit.VisitID,
+				},
+			}, true
+		}
+	}
+	return AgentPlan{}, false
+}
+
+func fatalDecisionPlan(visit AgentVisitView, detail string) AgentPlan {
+	return AgentPlan{Terminal: &AgentTerminal{
+		Outcome:      workflow.OutcomeFailed,
+		Reason:       fmt.Sprintf("посещение %q шага решения %q: %s", visit.VisitID, visit.StepID, detail),
+		CauseVisitID: visit.VisitID,
+	}}
+}
+
+// nextAfterSources выбирает по одному самому раннему ещё не потреблённому
+// terminal visit каждой зависимости. Барьер готов только целиком; отсутствие
+// одного источника не расходует уже найденные источники остальных зависимостей.
+func nextAfterSources(step workflow.Step, context agentPlanningContext) ([]string, int, bool) {
+	sources := make([]string, 0, len(step.After))
+	maxIteration := 0
+	for _, dependency := range step.After {
+		found := false
+		for _, candidate := range context.terminalByStep[dependency] {
+			cause := agentAfterCause{step.ID, dependency, candidate.VisitID}
+			if context.usedAfter[cause] {
+				continue
+			}
+			sources = append(sources, candidate.VisitID)
+			maxIteration = max(maxIteration, candidate.Iteration)
+			found = true
+			break
+		}
+		if !found {
+			return nil, 0, false
+		}
+	}
+	return sources, maxIteration, true
+}
+
+func knownAgentState(state State) bool {
+	switch state {
+	case Pending, Starting, Unknown, Running, WaitingForApproval, Failed, Cancelled, Succeeded:
+		return true
+	default:
+		return false
+	}
+}
+
+func agentVisitTerminal(state State) bool {
+	return state == Failed || state == Succeeded
+}
+
+// agentGraphHasCycle проверяет объединение after и всех возможных route.to.
+// Рёбра дедуплицируются, а очередь Кана строится в порядке Steps. Решения map
+// обходятся по отсортированным ключам, поэтому даже внутренний порядок проверки
+// воспроизводим и не зависит от рантайма Go.
+func agentGraphHasCycle(w workflow.Workflow) bool {
+	indices := make(map[string]int, len(w.Steps))
+	for index, step := range w.Steps {
+		indices[step.ID] = index
+	}
+	graph := make([][]int, len(w.Steps))
+	remaining := make([]int, len(w.Steps))
+	seen := make([]map[int]bool, len(w.Steps))
+	addEdge := func(source, target int) {
+		if seen[source] == nil {
+			seen[source] = make(map[int]bool)
+		}
+		if seen[source][target] {
+			return
+		}
+		seen[source][target] = true
+		graph[source] = append(graph[source], target)
+		remaining[target]++
+	}
+	for target, step := range w.Steps {
+		for _, dependency := range step.After {
+			addEdge(indices[dependency], target)
+		}
+	}
+	for source, step := range w.Steps {
+		keys := make([]string, 0, len(step.Decisions))
+		for key := range step.Decisions {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			for _, target := range step.Decisions[key].To {
+				addEdge(source, indices[target])
+			}
+		}
+	}
+	queue := make([]int, 0, len(w.Steps))
+	for node, count := range remaining {
+		if count == 0 {
+			queue = append(queue, node)
+		}
+	}
+	for head := 0; head < len(queue); head++ {
+		for _, target := range graph[queue[head]] {
+			remaining[target]--
+			if remaining[target] == 0 {
+				queue = append(queue, target)
+			}
+		}
+	}
+	return len(queue) != len(w.Steps)
+}

--- a/internal/scheduler/agent_test.go
+++ b/internal/scheduler/agent_test.go
@@ -1,0 +1,390 @@
+package scheduler
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
+)
+
+// TestPlanAgentGraphDecisionFanout проверяет один атомарный transition решения:
+// Applied ставится источнику один раз, а targets сохраняют пользовательский
+// порядок route.to и получают отдельные причинные triggers.
+func TestPlanAgentGraphDecisionFanout(t *testing.T) {
+	w := agentWorkflow([]string{"choice"},
+		agentStep("choice", nil, map[string]workflow.Route{"go": {To: []string{"beta", "alpha"}}}),
+		agentStep("alpha", nil, nil),
+		agentStep("beta", nil, nil),
+	)
+	visits := []AgentVisitView{
+		agentStartVisit("visit-choice", "choice", Succeeded, 1, &AgentDecisionView{Key: "go"}),
+	}
+	got, err := PlanAgentGraph(w, visits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := AgentPlan{
+		ApplyDecisionVisitIDs: []string{"visit-choice"},
+		DecisionActivations: []AgentActivation{
+			{StepID: "beta", Iteration: 2, Trigger: AgentTriggerView{Kind: AgentTriggerDecision, SourceVisitIDs: []string{"visit-choice"}, DecisionKey: "go"}},
+			{StepID: "alpha", Iteration: 2, Trigger: AgentTriggerView{Kind: AgentTriggerDecision, SourceVisitIDs: []string{"visit-choice"}, DecisionKey: "go"}},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fanout потерял атомарность или порядок:\n got: %#v\nwant: %#v", got, want)
+	}
+
+	// После durable application те же targets уже существуют. Повторный вызов
+	// только ждёт их Pending-visits и не материализует маршрут второй раз.
+	visits[0].Decision.Applied = true
+	visits = append(visits,
+		agentDecisionVisit("visit-beta", "beta", Pending, 2, "visit-choice", "go", nil),
+		agentDecisionVisit("visit-alpha", "alpha", Pending, 2, "visit-choice", "go", nil),
+	)
+	got, err = PlanAgentGraph(w, visits)
+	if err != nil || !reflect.DeepEqual(got, AgentPlan{}) {
+		t.Fatalf("applied route запланирован повторно: %#v, %v", got, err)
+	}
+}
+
+// TestPlanAgentGraphRejectsIncompleteAppliedDecision не позволяет повреждённой
+// проекции выдать natural success после частично записанного fanout или уже
+// применённого terminal route. Applied обязан доказываться всей историей visits,
+// а finish должен был атомарно завершить run ещё до следующего вызова planner.
+func TestPlanAgentGraphRejectsIncompleteAppliedDecision(t *testing.T) {
+	w := agentWorkflow([]string{"choice"},
+		agentStep("choice", nil, map[string]workflow.Route{
+			"go":   {To: []string{"alpha", "beta"}},
+			"fail": {Finish: agentOutcome(workflow.OutcomeFailed)},
+		}),
+		agentStep("alpha", nil, nil),
+		agentStep("beta", nil, nil),
+	)
+	tests := []struct {
+		name     string
+		decision AgentDecisionView
+		visits   []AgentVisitView
+		contains string
+	}{
+		{
+			name: "partial fanout", decision: AgentDecisionView{Key: "go", Applied: true},
+			visits: []AgentVisitView{
+				agentDecisionVisit("alpha-1", "alpha", Succeeded, 2, "choice-1", "go", nil),
+			},
+			contains: "beta",
+		},
+		{name: "applied finish", decision: AgentDecisionView{Key: "fail", Applied: true}, contains: "terminal run"},
+		{name: "unknown", decision: AgentDecisionView{Key: "missing", Applied: true}, contains: "неизвестное решение"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			choice := agentStartVisit("choice-1", "choice", Succeeded, 1, &tc.decision)
+			visits := append([]AgentVisitView{choice}, tc.visits...)
+			got, err := PlanAgentGraph(w, visits)
+			if err == nil || !strings.Contains(err.Error(), tc.contains) || !reflect.DeepEqual(got, AgentPlan{}) {
+				t.Fatalf("неполный applied transition принят: %#v, %v", got, err)
+			}
+		})
+	}
+}
+
+// TestPlanAgentGraphDefersWholeFanout не допускает частичное применение route:
+// занятая beta откладывает и её повторное посещение, и свободную alpha. После
+// завершения beta обе цели появляются вместе в исходном порядке.
+func TestPlanAgentGraphDefersWholeFanout(t *testing.T) {
+	w := agentWorkflow([]string{"choice", "beta"},
+		agentStep("choice", nil, map[string]workflow.Route{"go": {To: []string{"beta", "alpha"}}}),
+		agentStep("alpha", nil, nil),
+		agentStep("beta", nil, nil),
+	)
+	visits := []AgentVisitView{
+		agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "go"}),
+		agentStartVisit("beta-1", "beta", Running, 1, nil),
+	}
+	got, err := PlanAgentGraph(w, visits)
+	if err != nil || !reflect.DeepEqual(got, AgentPlan{}) {
+		t.Fatalf("частично занятый fanout не был отложен целиком: %#v, %v", got, err)
+	}
+
+	visits[1].State = Succeeded
+	got, err = PlanAgentGraph(w, visits)
+	if err != nil || !reflect.DeepEqual(got.ApplyDecisionVisitIDs, []string{"choice-1"}) || len(got.DecisionActivations) != 2 ||
+		got.DecisionActivations[0].StepID != "beta" || got.DecisionActivations[1].StepID != "alpha" {
+		t.Fatalf("освободившийся fanout не применён целиком: %#v, %v", got, err)
+	}
+}
+
+// TestPlanAgentGraphFailedAfterRecovery фиксирует различие технического Failed и
+// результата всего workflow: Failed удовлетворяет after, а успешный recovery
+// становится новым frontier и позволяет natural completion завершиться успешно.
+func TestPlanAgentGraphFailedAfterRecovery(t *testing.T) {
+	w := agentWorkflow([]string{"work"},
+		agentStep("work", nil, nil),
+		agentStep("recovery", []string{"work"}, nil),
+	)
+	visits := []AgentVisitView{agentStartVisit("work-1", "work", Failed, 1, nil)}
+	got, err := PlanAgentGraph(w, visits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantActivation := AgentActivation{
+		StepID: "recovery", Iteration: 1,
+		Trigger: AgentTriggerView{Kind: AgentTriggerAfter, SourceVisitIDs: []string{"work-1"}},
+	}
+	if !reflect.DeepEqual(got.AfterActivations, []AgentActivation{wantActivation}) || got.Terminal != nil {
+		t.Fatalf("Failed не разбудил recovery: %#v", got)
+	}
+
+	visits = append(visits, AgentVisitView{
+		VisitID: "recovery-1", StepID: "recovery", Iteration: 1, State: Succeeded,
+		Trigger: wantActivation.Trigger,
+	})
+	got, err = PlanAgentGraph(w, visits)
+	if err != nil || got.Terminal == nil || got.Terminal.Outcome != workflow.OutcomeSucceeded {
+		t.Fatalf("обработанный Failed отравил natural completion: %#v, %v", got, err)
+	}
+}
+
+// TestPlanAgentGraphDecisionFailures проверяет две доказуемые fatal-причины.
+// CauseVisitID не выводится из текста: runstore сможет связать terminal run с
+// конкретным durable фактом даже при незавершённой параллельной ветке.
+func TestPlanAgentGraphDecisionFailures(t *testing.T) {
+	w := agentWorkflow([]string{"choice", "parallel"},
+		agentStep("choice", nil, map[string]workflow.Route{"done": {Finish: agentOutcome(workflow.OutcomeSucceeded)}}),
+		agentStep("parallel", nil, nil),
+	)
+	tests := []struct {
+		name     string
+		state    State
+		decision *AgentDecisionView
+		contains string
+	}{
+		{name: "missing", state: Succeeded, contains: "без choose_decision"},
+		{name: "poisoned running", state: Running, decision: &AgentDecisionView{Key: "done", Error: "два разных вызова"}, contains: "конфликт"},
+		{name: "poisoned cancelled", state: Cancelled, decision: &AgentDecisionView{Key: "done", Error: "два разных вызова"}, contains: "конфликт"},
+		{name: "unknown", state: Succeeded, decision: &AgentDecisionView{Key: "other"}, contains: "неизвестный ключ"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			visits := []AgentVisitView{
+				agentStartVisit("choice-1", "choice", tc.state, 1, tc.decision),
+				agentStartVisit("parallel-1", "parallel", Running, 1, nil),
+			}
+			got, err := PlanAgentGraph(w, visits)
+			if err != nil || got.Terminal == nil || got.Terminal.Outcome != workflow.OutcomeFailed ||
+				got.Terminal.CauseVisitID != "choice-1" || !strings.Contains(got.Terminal.Reason, tc.contains) {
+				t.Fatalf("fatal decision потерял исход или proof: %#v, %v", got, err)
+			}
+			if len(got.ApplyDecisionVisitIDs) != 0 || len(got.DecisionActivations) != 0 || len(got.AfterActivations) != 0 {
+				t.Fatalf("fatal decision смешан с другими действиями: %#v", got)
+			}
+		})
+	}
+}
+
+// TestPlanAgentGraphFinishIsImmediate не позволяет параллельному Running visit
+// задержать явный finish или добавить в тот же атомарный commit обычные routes.
+func TestPlanAgentGraphFinishIsImmediate(t *testing.T) {
+	w := agentWorkflow([]string{"route", "finish", "busy"},
+		agentStep("route", nil, map[string]workflow.Route{"go": {To: []string{"work"}}}),
+		agentStep("finish", nil, map[string]workflow.Route{"stop": {Finish: agentOutcome(workflow.OutcomeFailed)}}),
+		agentStep("busy", nil, nil),
+		agentStep("work", nil, nil),
+	)
+	visits := []AgentVisitView{
+		agentStartVisit("route-1", "route", Succeeded, 1, &AgentDecisionView{Key: "go"}),
+		agentStartVisit("finish-1", "finish", Succeeded, 1, &AgentDecisionView{Key: "stop"}),
+		agentStartVisit("busy-1", "busy", Running, 1, nil),
+	}
+	got, err := PlanAgentGraph(w, visits)
+	if err != nil || got.Terminal == nil || got.Terminal.Outcome != workflow.OutcomeFailed ||
+		got.Terminal.CauseVisitID != "finish-1" || !reflect.DeepEqual(got.ApplyDecisionVisitIDs, []string{"finish-1"}) || len(got.DecisionActivations) != 0 {
+		t.Fatalf("finish не получил немедленный изолированный transition: %#v, %v", got, err)
+	}
+}
+
+// TestPlanAgentGraphDefersSharedTarget показывает no-overlap между двумя готовыми
+// решениями. Первый visit в durable-порядке занимает общий target; второй choice
+// остаётся unapplied целиком и продолжает только после завершения target.
+func TestPlanAgentGraphDefersSharedTarget(t *testing.T) {
+	route := map[string]workflow.Route{"go": {To: []string{"shared"}}}
+	w := agentWorkflow([]string{"first", "second"},
+		agentStep("first", nil, route),
+		agentStep("second", nil, route),
+		agentStep("shared", nil, nil),
+	)
+	visits := []AgentVisitView{
+		agentStartVisit("first-1", "first", Succeeded, 1, &AgentDecisionView{Key: "go"}),
+		agentStartVisit("second-1", "second", Succeeded, 1, &AgentDecisionView{Key: "go"}),
+	}
+	got, err := PlanAgentGraph(w, visits)
+	if err != nil || !reflect.DeepEqual(got.ApplyDecisionVisitIDs, []string{"first-1"}) || len(got.DecisionActivations) != 1 {
+		t.Fatalf("общий target активирован с overlap: %#v, %v", got, err)
+	}
+
+	visits[0].Decision.Applied = true
+	visits = append(visits, agentDecisionVisit("shared-1", "shared", Succeeded, 2, "first-1", "go", nil))
+	got, err = PlanAgentGraph(w, visits)
+	if err != nil || !reflect.DeepEqual(got.ApplyDecisionVisitIDs, []string{"second-1"}) ||
+		len(got.DecisionActivations) != 1 || got.DecisionActivations[0].Trigger.SourceVisitIDs[0] != "second-1" {
+		t.Fatalf("отложенное решение не продолжилось после освобождения target: %#v, %v", got, err)
+	}
+}
+
+// TestPlanAgentGraphFIFOJoin создаёт две полные пары источников. Первый join уже
+// потребил ранние visits, поэтому новый barrier обязан взять вторые источники в
+// порядке Step.After и унаследовать их максимальную iteration.
+func TestPlanAgentGraphFIFOJoin(t *testing.T) {
+	fanout := map[string]workflow.Route{"go": {To: []string{"left", "right"}}}
+	w := agentWorkflow([]string{"wave-one", "wave-two"},
+		agentStep("wave-one", nil, fanout),
+		agentStep("wave-two", nil, fanout),
+		agentStep("left", nil, nil),
+		agentStep("right", nil, nil),
+		agentStep("join", []string{"right", "left"}, nil),
+	)
+	visits := []AgentVisitView{
+		agentStartVisit("wave-1", "wave-one", Succeeded, 1, &AgentDecisionView{Key: "go", Applied: true}),
+		agentStartVisit("wave-2", "wave-two", Succeeded, 1, &AgentDecisionView{Key: "go", Applied: true}),
+		agentDecisionVisit("left-1", "left", Succeeded, 2, "wave-1", "go", nil),
+		agentDecisionVisit("right-1", "right", Succeeded, 2, "wave-1", "go", nil),
+		agentDecisionVisit("left-2", "left", Succeeded, 2, "wave-2", "go", nil),
+		agentDecisionVisit("right-2", "right", Succeeded, 2, "wave-2", "go", nil),
+		{
+			VisitID: "join-1", StepID: "join", Iteration: 2, State: Succeeded,
+			Trigger: AgentTriggerView{Kind: AgentTriggerAfter, SourceVisitIDs: []string{"right-1", "left-1"}},
+		},
+	}
+	got, err := PlanAgentGraph(w, visits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := AgentActivation{
+		StepID: "join", Iteration: 2,
+		Trigger: AgentTriggerView{Kind: AgentTriggerAfter, SourceVisitIDs: []string{"right-2", "left-2"}},
+	}
+	if !reflect.DeepEqual(got.AfterActivations, []AgentActivation{want}) {
+		t.Fatalf("join нарушил FIFO/order/iteration: got %#v, want %#v", got.AfterActivations, want)
+	}
+}
+
+// TestPlanAgentGraphCancelledWaits подтверждает, что Cancelled не является
+// after-источником и не превращает временное отсутствие действий в completion.
+func TestPlanAgentGraphCancelledWaits(t *testing.T) {
+	w := agentWorkflow([]string{"work"},
+		agentStep("work", nil, nil),
+		agentStep("after", []string{"work"}, nil),
+	)
+	got, err := PlanAgentGraph(w, []AgentVisitView{agentStartVisit("work-1", "work", Cancelled, 1, nil)})
+	if err != nil || !reflect.DeepEqual(got, AgentPlan{}) {
+		t.Fatalf("Cancelled ошибочно удовлетворил after или завершил run: %#v, %v", got, err)
+	}
+}
+
+// TestPlanAgentGraphNaturalQuiescence проверяет фактический causal frontier, а не
+// все исторические ошибки. Не выбранная половина статического join не блокирует
+// естественный успех, но необработанный Failed-лист завершает run ошибкой.
+func TestPlanAgentGraphNaturalQuiescence(t *testing.T) {
+	t.Run("stranded join succeeds", func(t *testing.T) {
+		w := agentWorkflow([]string{"choice"},
+			agentStep("choice", nil, map[string]workflow.Route{
+				"left": {To: []string{"left"}}, "right": {To: []string{"right"}},
+			}),
+			agentStep("left", nil, nil),
+			agentStep("right", nil, nil),
+			agentStep("join", []string{"left", "right"}, nil),
+		)
+		visits := []AgentVisitView{
+			agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "left", Applied: true}),
+			agentDecisionVisit("left-1", "left", Succeeded, 2, "choice-1", "left", nil),
+		}
+		got, err := PlanAgentGraph(w, visits)
+		if err != nil || got.Terminal == nil || got.Terminal.Outcome != workflow.OutcomeSucceeded || got.Terminal.CauseVisitID != "" {
+			t.Fatalf("невыбранная ветка заблокировала natural completion: %#v, %v", got, err)
+		}
+	})
+
+	t.Run("failed frontier fails", func(t *testing.T) {
+		w := agentWorkflow([]string{"leaf"}, agentStep("leaf", nil, nil))
+		got, err := PlanAgentGraph(w, []AgentVisitView{agentStartVisit("leaf-1", "leaf", Failed, 1, nil)})
+		if err != nil || got.Terminal == nil || got.Terminal.Outcome != workflow.OutcomeFailed || got.Terminal.CauseVisitID != "leaf-1" {
+			t.Fatalf("Failed frontier не определил natural outcome: %#v, %v", got, err)
+		}
+	})
+}
+
+// TestPlanAgentGraphRejectsCycles проверяет временную production-границу PR3a.
+// Оба workflow валидны по публичному v2-контракту благодаря maxVisits/onLimit,
+// однако pure planner возвращает узнаваемый sentinel до проверки visits.
+func TestPlanAgentGraphRejectsCycles(t *testing.T) {
+	limit := 2
+	onLimit := workflow.OutcomeFailed
+	tests := []struct {
+		name  string
+		start []string
+		steps []workflow.Step
+	}{
+		{
+			name: "self loop", start: []string{"loop"},
+			steps: []workflow.Step{{
+				ID: "loop", Type: "agent", Prompt: "Повтори", After: []string{}, MaxVisits: &limit, OnLimit: &onLimit,
+				Decisions: map[string]workflow.Route{"again": {To: []string{"loop"}}},
+			}},
+		},
+		{
+			name: "two nodes", start: []string{"first"},
+			steps: []workflow.Step{
+				{ID: "first", Type: "agent", Prompt: "Первый", After: []string{}, MaxVisits: &limit, OnLimit: &onLimit,
+					Decisions: map[string]workflow.Route{"next": {To: []string{"second"}}}},
+				{ID: "second", Type: "agent", Prompt: "Второй", After: []string{}, MaxVisits: &limit, OnLimit: &onLimit,
+					Decisions: map[string]workflow.Route{"again": {To: []string{"first"}}}},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			version := workflow.VersionAgentGraph
+			w := workflow.Workflow{Version: &version, ID: "cycle", Start: tc.start, Steps: tc.steps}
+			if err := w.Validate(); err != nil {
+				t.Fatalf("fixture обязан быть допустимым будущим v2-графом: %v", err)
+			}
+			got, err := PlanAgentGraph(w, nil)
+			if !errors.Is(err, ErrAgentGraphCycle) || !reflect.DeepEqual(got, AgentPlan{}) {
+				t.Fatalf("цикл не остановлен sentinel-ошибкой: %#v, %v", got, err)
+			}
+		})
+	}
+}
+
+func agentWorkflow(start []string, steps ...workflow.Step) workflow.Workflow {
+	version := workflow.VersionAgentGraph
+	return workflow.Workflow{Version: &version, ID: "agent-test", Start: start, Steps: steps}
+}
+
+func agentStep(id string, after []string, decisions map[string]workflow.Route) workflow.Step {
+	if after == nil {
+		after = []string{}
+	}
+	return workflow.Step{ID: id, Type: "agent", Prompt: "Выполни " + id, After: after, Decisions: decisions}
+}
+
+func agentStartVisit(visitID, stepID string, state State, iteration int, decision *AgentDecisionView) AgentVisitView {
+	return AgentVisitView{
+		VisitID: visitID, StepID: stepID, Iteration: iteration, State: state,
+		Trigger: AgentTriggerView{Kind: AgentTriggerStart}, Decision: decision,
+	}
+}
+
+func agentDecisionVisit(visitID, stepID string, state State, iteration int, sourceID, key string, decision *AgentDecisionView) AgentVisitView {
+	return AgentVisitView{
+		VisitID: visitID, StepID: stepID, Iteration: iteration, State: state,
+		Trigger:  AgentTriggerView{Kind: AgentTriggerDecision, SourceVisitIDs: []string{sourceID}, DecisionKey: key},
+		Decision: decision,
+	}
+}
+
+func agentOutcome(outcome workflow.TerminalOutcome) *workflow.TerminalOutcome {
+	return &outcome
+}


### PR DESCRIPTION
## Что сделано

- добавлен чистый visit-aware планировщик workflow v2 без файловых и сетевых побочных эффектов;
- реализованы детерминированные decision fan-out, немедленный finish и FIFO-барьеры after для технических Succeeded/Failed;
- Cancelled оставлен возобновляемым и не считается источником after;
- missing, unknown и poisoned решения завершают run диагностируемой ошибкой с CauseVisitID;
- natural outcome вычисляется по причинному frontier, поэтому обработанный recovery технический Failed не отравляет успешный итог;
- применённые переходы проверяются на полный fan-out, а overlap одного step не допускается;
- до отдельного bounded-loop среза любой цикл полного графа безопасно отклоняется ErrAgentGraphCycle до запуска Codex.

## Проверки

- env GOCACHE=/private/tmp/lawa-go-cache go test ./...
- env GOCACHE=/private/tmp/lawa-go-cache go vet ./...
- env GOCACHE=/private/tmp/lawa-go-cache go test -race ./internal/scheduler
- независимое ревью: APPROVE

## Размер

908 добавленных строк. Это выше ориентира 500 строк, но ниже блокирующего лимита 1200; основной объём — самодостаточная валидация causal history и регрессионные тесты.

Зависит от #73. Часть #50.