### PR TITLE
Добавить применение агентных переходов

### DIFF
--- a/internal/runstore/advance.go
+++ b/internal/runstore/advance.go
@@ -1,0 +1,234 @@
+//go:build darwin || linux
+
+package runstore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
+)
+
+// AgentAdvance — результат одной атомарной материализации pure-плана. Snapshot
+// уже содержит новые visits и Applied-флаги; CreatedVisits связывает ordered
+// activations планировщика с созданными visitId для следующего шага coordinator.
+// Changed=false означает, что durable snapshot уже полностью применён.
+type AgentAdvance struct {
+	Snapshot      Snapshot
+	Plan          scheduler.AgentPlan
+	CreatedVisits []Visit
+	Changed       bool
+}
+
+// AdvanceAgentGraph применяет только локальные причинные переходы v4. Под общей
+// блокировкой run функция перечитывает durable snapshot, получает чистый план,
+// проверяет будущую metadata, сохраняет пустую память каждого нового visit и
+// лишь затем одним Rename публикует Applied+Visits либо terminal outcome.
+//
+// Порядок файлов намеренный: авария до meta оставляет недостижимую orphan memory,
+// которую Load игнорирует; обратный порядок мог бы опубликовать visit без памяти.
+// После неоднозначного результата записи meta владелец poisoned и обязан закрыться.
+func (r *LockedRun) AdvanceAgentGraph() (AgentAdvance, error) {
+	return r.advanceAgentGraph((*os.File).Sync)
+}
+
+// advanceAgentGraph принимает Sync-hook только для проверки crash boundaries.
+func (r *LockedRun) advanceAgentGraph(syncFile func(*os.File) error) (AgentAdvance, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.check(); err != nil {
+		return AgentAdvance{}, err
+	}
+	snapshot, err := load(r.dir, r.runID)
+	if err != nil {
+		return AgentAdvance{}, err
+	}
+	if snapshot.Meta.Version != 4 {
+		return AgentAdvance{}, fmt.Errorf("AdvanceAgentGraph требует meta.json v4")
+	}
+	if snapshot.Meta.RunState != RunRunning {
+		return AgentAdvance{}, fmt.Errorf("завершённый agent-graph run нельзя продвигать")
+	}
+	plan, err := scheduler.PlanAgentGraph(snapshot.Workflow, agentVisitViews(snapshot.Meta.Visits))
+	if err != nil {
+		return AgentAdvance{}, err
+	}
+	if plan.Terminal != nil && (len(plan.DecisionActivations) != 0 || len(plan.AfterActivations) != 0) {
+		return AgentAdvance{}, fmt.Errorf("планировщик смешал terminal outcome и новые activations")
+	}
+	changed := len(plan.ApplyDecisionVisitIDs) != 0 || len(plan.DecisionActivations) != 0 || len(plan.AfterActivations) != 0 || plan.Terminal != nil
+	if !changed {
+		return AgentAdvance{Snapshot: snapshot, Plan: plan}, nil
+	}
+
+	if err = applyAgentDecisionFlags(&snapshot, plan.ApplyDecisionVisitIDs); err != nil {
+		return AgentAdvance{}, err
+	}
+	created := materializeAgentVisits(snapshot.Meta.Visits, plan.DecisionActivations, plan.AfterActivations)
+	snapshot.Meta.Visits = append(snapshot.Meta.Visits, created...)
+	if plan.Terminal != nil {
+		switch plan.Terminal.Outcome {
+		case workflow.OutcomeSucceeded:
+			snapshot.Meta.RunState = RunSucceeded
+		case workflow.OutcomeFailed:
+			snapshot.Meta.RunState = RunFailed
+		default:
+			return AgentAdvance{}, fmt.Errorf("планировщик вернул неизвестный terminal outcome %q", plan.Terminal.Outcome)
+		}
+		snapshot.Meta.StopReason = compactAgentStopReason(plan.Terminal.Reason)
+		snapshot.Meta.StopVisitID = plan.Terminal.CauseVisitID
+		// Защитный fallback сохраняет проверяемую причину даже при регрессии
+		// planner: штатный explicit finish уже возвращает свой CauseVisitID.
+		if snapshot.Meta.StopVisitID == "" && len(plan.ApplyDecisionVisitIDs) == 1 {
+			snapshot.Meta.StopVisitID = plan.ApplyDecisionVisitIDs[0]
+		}
+	}
+	// Валидация до создания файлов отлавливает ошибку planner/bridge без orphan.
+	// Повторяем её и внутри будущих Load, поэтому сохранённый снимок не опирается
+	// на доверие к одной версии чистого планировщика.
+	if err = snapshot.validate(r.runID); err != nil {
+		return AgentAdvance{}, fmt.Errorf("применить agent-graph plan: %w", err)
+	}
+	if err = createAgentVisitMemories(r.dir, created, syncFile); err != nil {
+		return AgentAdvance{}, fmt.Errorf("создать память новых посещений: %w", err)
+	}
+	if err = saveMetadata(r.dir, snapshot.Meta, syncFile); err != nil {
+		return AgentAdvance{}, r.recordVisitSaveFailure(err)
+	}
+	return AgentAdvance{Snapshot: snapshot, Plan: plan, CreatedVisits: slices.Clone(created), Changed: true}, nil
+}
+
+// compactAgentStopReason превращает диагностический текст pure planner в
+// безопасное поле metadata. Пользовательские step ID и decision key могут быть
+// длинными и содержать экранированные JSON control-символы; такой корректный
+// workflow всё равно обязан завершиться, а не навсегда остаться Running из-за
+// локального ограничения хранения. Управляющие руны записываются видимым кодом,
+// затем строка обрезается по UTF-8-границе вместе с маркером сокращения.
+func compactAgentStopReason(value string) string {
+	var escaped strings.Builder
+	escaped.Grow(min(len(value), maxStoredTextBytes))
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			fmt.Fprintf(&escaped, `\u%04X`, character)
+			continue
+		}
+		escaped.WriteRune(character)
+	}
+	reason := strings.TrimSpace(escaped.String())
+	if reason == "" {
+		reason = "workflow завершён без указанной причины"
+	}
+	if len(reason) <= maxStoredTextBytes {
+		return reason
+	}
+	const suffix = "…"
+	limit := maxStoredTextBytes - len(suffix)
+	for limit > 0 && !utf8.RuneStart(reason[limit]) {
+		limit--
+	}
+	return reason[:limit] + suffix
+}
+
+// applyAgentDecisionFlags меняет только перечисленные planner решения. Повторный
+// ID и уже Applied означают внутреннюю ошибку плана: обычный crash-retry сначала
+// перечитывает metadata и pure planner возвращает zero plan.
+func applyAgentDecisionFlags(snapshot *Snapshot, visitIDs []string) error {
+	indices := visitIndices(snapshot.Meta.Visits)
+	seen := make(map[string]bool, len(visitIDs))
+	for _, visitID := range visitIDs {
+		index, exists := indices[visitID]
+		if !exists || seen[visitID] {
+			return fmt.Errorf("планировщик указал неизвестное или повторное решение visit %q", visitID)
+		}
+		seen[visitID] = true
+		visit := &snapshot.Meta.Visits[index]
+		if visit.State != scheduler.Succeeded || visit.Decision == nil || visit.Decision.Applied || visit.Decision.Error != "" {
+			return fmt.Errorf("решение посещения %q нельзя применить", visitID)
+		}
+		visit.Decision.Applied = true
+	}
+	return nil
+}
+
+// materializeAgentVisits сохраняет порядок planner: сначала выбранные decision
+// targets в порядке Visits/route.to, затем after-barriers в порядке Steps. Номер
+// Visit считается по уже durable истории и возрастает отдельно для StepID.
+func materializeAgentVisits(history []Visit, decision, after []scheduler.AgentActivation) []Visit {
+	numbers := make(map[string]int)
+	for _, visit := range history {
+		numbers[visit.StepID] = visit.Visit
+	}
+	activations := make([]scheduler.AgentActivation, 0, len(decision)+len(after))
+	activations = append(activations, decision...)
+	activations = append(activations, after...)
+	created := make([]Visit, 0, len(activations))
+	for _, activation := range activations {
+		numbers[activation.StepID]++
+		created = append(created, Visit{
+			VisitID: newID(), StepID: activation.StepID, Visit: numbers[activation.StepID],
+			Iteration: activation.Iteration, State: scheduler.Pending,
+			Trigger: VisitTrigger{
+				Kind: TriggerKind(activation.Trigger.Kind), SourceVisitIDs: slices.Clone(activation.Trigger.SourceVisitIDs),
+				DecisionKey: activation.Trigger.DecisionKey,
+			},
+		})
+	}
+	return created
+}
+
+// agentVisitViews копирует только семантику, которой владеет scheduler. Внешние
+// thread/turn, память и диагностика остаются деталями persistence/coordinator.
+func agentVisitViews(visits []Visit) []scheduler.AgentVisitView {
+	views := make([]scheduler.AgentVisitView, 0, len(visits))
+	for _, visit := range visits {
+		view := scheduler.AgentVisitView{
+			VisitID: visit.VisitID, StepID: visit.StepID, Iteration: visit.Iteration, State: visit.State,
+			Trigger: scheduler.AgentTriggerView{
+				Kind: scheduler.AgentTriggerKind(visit.Trigger.Kind), SourceVisitIDs: slices.Clone(visit.Trigger.SourceVisitIDs),
+				DecisionKey: visit.Trigger.DecisionKey,
+			},
+		}
+		if visit.Decision != nil {
+			view.Decision = &scheduler.AgentDecisionView{Key: visit.Decision.Key, Applied: visit.Decision.Applied, Error: visit.Decision.Error}
+		}
+		views = append(views, view)
+	}
+	return views
+}
+
+// createAgentVisitMemories синхронизирует каждый inode и затем имя в memory/.
+// При любой ошибке metadata не публикуется, а уже созданные файлы намеренно не
+// удаляются: их имена случайны, старый snapshot на них не ссылается, а удаление
+// после неясного Sync создало бы ещё одну недоказуемую границу durability.
+func createAgentVisitMemories(dir *os.Root, visits []Visit, syncFile func(*os.File) error) error {
+	if len(visits) == 0 {
+		return nil
+	}
+	for _, visit := range visits {
+		name := filepath.Join("memory", visit.VisitID+".md")
+		file, err := dir.OpenFile(name, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err != nil {
+			return err
+		}
+		if err = syncFile(file); err == nil {
+			err = file.Close()
+		} else {
+			err = errors.Join(err, file.Close())
+		}
+		if err != nil {
+			return err
+		}
+	}
+	memory, err := dir.Open("memory")
+	if err != nil {
+		return err
+	}
+	return errors.Join(syncFile(memory), memory.Close())
+}

--- a/internal/runstore/advance_test.go
+++ b/internal/runstore/advance_test.go
@@ -1,0 +1,353 @@
+//go:build darwin || linux
+
+package runstore
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+)
+
+// advanceInput даёт fanout из одного решения и общий after-barrier. Второй
+// стартовый visit нужен для проверки, что независимая активная работа не мешает
+// применить route или немедленный explicit finish.
+func advanceInput(t *testing.T) Input {
+	t.Helper()
+	return Input{WorkflowJSON: []byte(`{
+  "version":2,
+  "id":"advance",
+  "start":["decision","parallel"],
+  "steps":[
+    {"id":"decision","type":"agent","prompt":"Выбери","after":[],"decisions":{
+      "branch":{"to":["left","right"]},"done":{"finish":"succeeded"},"fail":{"finish":"failed"}}},
+    {"id":"parallel","type":"agent","prompt":"Параллельно","after":[]},
+    {"id":"left","type":"agent","prompt":"Левая ветка","after":[]},
+    {"id":"right","type":"agent","prompt":"Правая ветка","after":[]},
+    {"id":"join","type":"agent","prompt":"Объединить","after":["left","right"]}
+  ]
+}`), Task: "Продвинуть граф", Comment: "Тест persistence bridge", CWD: t.TempDir()}
+}
+
+func testAdvanceRun(t *testing.T) (string, Snapshot, *LockedRun) {
+	t.Helper()
+	root := t.TempDir()
+	snapshot, err := CreateAgentGraph(root, advanceInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, snapshot.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := run.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	return root, snapshot, run
+}
+
+func finishDecisionVisit(t *testing.T, run *LockedRun, visitID, key string) {
+	t.Helper()
+	if err := run.ReserveVisits([]string{visitID}); err == nil {
+		err = run.UpdateVisit(visitID, scheduler.Unknown, "chat-decision", "")
+		if err == nil {
+			err = run.SetVisitTurn(visitID, "turn-decision")
+		}
+		if err == nil {
+			_, err = run.CommitDecision(visitID, "chat-decision", "turn-decision", key, "выбран маршрут", "call-decision")
+		}
+		if err == nil {
+			err = run.UpdateVisit(visitID, scheduler.Succeeded, "chat-decision", "")
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal(err)
+	}
+}
+
+// TestAdvanceAgentGraphRouteAndAfter проверяет два последовательных durable
+// перехода: decision fanout и after после технического Failed одной из веток.
+// Повтор каждого Advance не создаёт новый visit или файл памяти.
+func TestAdvanceAgentGraphRouteAndAfter(t *testing.T) {
+	root, initial, run := testAdvanceRun(t)
+	decisionID := initial.Meta.Visits[0].VisitID
+	finishDecisionVisit(t, run, decisionID, "branch")
+
+	advanced, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !advanced.Changed || len(advanced.Plan.ApplyDecisionVisitIDs) != 1 || len(advanced.CreatedVisits) != 2 {
+		t.Fatalf("fanout применён не полностью: %+v", advanced)
+	}
+	for index, stepID := range []string{"left", "right"} {
+		visit := advanced.CreatedVisits[index]
+		if visit.StepID != stepID || visit.Visit != 1 || visit.Iteration != 2 || visit.State != scheduler.Pending ||
+			visit.Trigger.Kind != TriggerDecision || !reflect.DeepEqual(visit.Trigger.SourceVisitIDs, []string{decisionID}) || visit.Trigger.DecisionKey != "branch" {
+			t.Fatalf("неверное decision-посещение: %+v", visit)
+		}
+		if info, err := os.Stat(filepath.Join(root, initial.Meta.RunID, "memory", visit.VisitID+".md")); err != nil || !info.Mode().IsRegular() {
+			t.Fatalf("нет памяти нового visit: %v, %v", info, err)
+		}
+	}
+	if !advanced.Snapshot.Meta.Visits[0].Decision.Applied {
+		t.Fatal("decision и targets не опубликованы одним commit")
+	}
+	beforeRetry := advanced.Snapshot.Meta
+	retry, err := run.AdvanceAgentGraph()
+	if err != nil || retry.Changed || !reflect.DeepEqual(retry.Snapshot.Meta, beforeRetry) {
+		t.Fatalf("повтор fanout создал дубликаты: %+v, %v", retry, err)
+	}
+
+	left, right := advanced.CreatedVisits[0], advanced.CreatedVisits[1]
+	if err := run.ReserveVisits([]string{left.VisitID, right.VisitID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(left.VisitID, scheduler.Unknown, "chat-left", ""); err == nil {
+		err = run.UpdateVisit(left.VisitID, scheduler.Failed, "chat-left", "тест упал")
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(right.VisitID, scheduler.Unknown, "chat-right", ""); err == nil {
+		err = run.SetVisitTurn(right.VisitID, "turn-right")
+		if err == nil {
+			err = run.UpdateVisit(right.VisitID, scheduler.Succeeded, "chat-right", "")
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal(err)
+	}
+
+	joined, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !joined.Changed || len(joined.Plan.AfterActivations) != 1 || len(joined.CreatedVisits) != 1 {
+		t.Fatalf("after-barrier не материализован: %+v", joined)
+	}
+	join := joined.CreatedVisits[0]
+	if join.StepID != "join" || join.Iteration != 2 || join.Trigger.Kind != TriggerAfter ||
+		!reflect.DeepEqual(join.Trigger.SourceVisitIDs, []string{left.VisitID, right.VisitID}) {
+		t.Fatalf("after не сохранил ordered Failed/Succeeded sources: %+v", join)
+	}
+	if retry, err = run.AdvanceAgentGraph(); err != nil || retry.Changed || len(retry.Snapshot.Meta.Visits) != len(joined.Snapshot.Meta.Visits) {
+		t.Fatalf("повтор after создал дубликат: %+v, %v", retry, err)
+	}
+}
+
+// TestAdvanceAgentGraphFinishWithActiveVisit фиксирует приоритет explicit finish:
+// он атомарно связывается с Applied decision и останавливает планирование, не
+// переписывая состояние уже работающего параллельного visit.
+func TestAdvanceAgentGraphFinishWithActiveVisit(t *testing.T) {
+	_, initial, run := testAdvanceRun(t)
+	decisionID, parallelID := initial.Meta.Visits[0].VisitID, initial.Meta.Visits[1].VisitID
+	finishDecisionVisit(t, run, decisionID, "done")
+	if err := run.ReserveVisits([]string{parallelID}); err == nil {
+		err = run.UpdateVisit(parallelID, scheduler.Unknown, "chat-parallel", "")
+		if err == nil {
+			err = run.SetVisitTurn(parallelID, "turn-parallel")
+		}
+		if err == nil {
+			err = run.UpdateVisit(parallelID, scheduler.Running, "chat-parallel", "")
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal(err)
+	}
+
+	result, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Changed || result.Plan.Terminal == nil || result.Snapshot.Meta.RunState != RunSucceeded ||
+		result.Snapshot.Meta.StopReason == "" || result.Snapshot.Meta.StopVisitID != decisionID ||
+		!result.Snapshot.Meta.Visits[0].Decision.Applied || result.Snapshot.Meta.Visits[1].State != scheduler.Running || len(result.CreatedVisits) != 0 {
+		t.Fatalf("finish опубликован неатомарно: %+v", result)
+	}
+	if _, err := run.AdvanceAgentGraph(); err == nil {
+		t.Fatal("terminal run принят для повторного планирования")
+	}
+}
+
+// TestAdvanceAgentGraphFatalDecision сохраняет проверяемый CauseVisitID, когда
+// успешный decision-turn завершился без обязательного choose_decision.
+func TestAdvanceAgentGraphFatalDecision(t *testing.T) {
+	_, initial, run := testAdvanceRun(t)
+	visitID := initial.Meta.Visits[0].VisitID
+	if err := run.ReserveVisits([]string{visitID}); err == nil {
+		err = run.UpdateVisit(visitID, scheduler.Unknown, "chat-decision", "")
+		if err == nil {
+			err = run.SetVisitTurn(visitID, "turn-decision")
+		}
+		if err == nil {
+			err = run.UpdateVisit(visitID, scheduler.Succeeded, "chat-decision", "")
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal(err)
+	}
+	result, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Snapshot.Meta.RunState != RunFailed || result.Snapshot.Meta.StopVisitID != visitID || result.Snapshot.Meta.StopReason == "" || len(result.CreatedVisits) != 0 {
+		t.Fatalf("fatal decision не сохранил доказанную причину: %+v", result)
+	}
+}
+
+// TestAdvanceAgentGraphCompactsStopReason воспроизводит корректный workflow с
+// очень длинным decision key и управляющим символом. Choice остаётся точным в
+// durable DecisionRecord, но производная операторская причина обязана пройти
+// ограничения metadata и не блокировать применение terminal route.
+func TestAdvanceAgentGraphCompactsStopReason(t *testing.T) {
+	input := advanceInput(t)
+	key := strings.Repeat("решение🙂", 600) + "\x1b"
+	encodedKey, err := json.Marshal(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input.WorkflowJSON = bytes.Replace(input.WorkflowJSON, []byte(`"fail"`), encodedKey, 1)
+	root := t.TempDir()
+	initial, err := CreateAgentGraph(root, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+	finishDecisionVisit(t, run, initial.Meta.Visits[0].VisitID, key)
+
+	result, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Snapshot.Meta.RunState != RunFailed || !result.Snapshot.Meta.Visits[0].Decision.Applied ||
+		!safeStoredText(result.Snapshot.Meta.StopReason, true) || !strings.HasSuffix(result.Snapshot.Meta.StopReason, "…") ||
+		strings.ContainsRune(result.Snapshot.Meta.StopReason, '\x1b') {
+		t.Fatalf("terminal reason не нормализована безопасно: state=%q reason=%q", result.Snapshot.Meta.RunState, result.Snapshot.Meta.StopReason)
+	}
+}
+
+// TestAdvanceAgentGraphMemoryBeforeMetadata воспроизводит отказ Sync meta до
+// Rename. Новая память уже durable, но остаётся orphan; старая metadata цела,
+// владелец poisoned, а reopen строит новые IDs и применяет маршрут ровно один раз.
+func TestAdvanceAgentGraphMemoryBeforeMetadata(t *testing.T) {
+	root, initial, run := testAdvanceRun(t)
+	finishDecisionVisit(t, run, initial.Meta.Visits[0].VisitID, "branch")
+	memoryDir := filepath.Join(root, initial.Meta.RunID, "memory")
+	memoriesReady := false
+	result, err := run.advanceAgentGraph(func(file *os.File) error {
+		info, statErr := file.Stat()
+		if statErr != nil {
+			return statErr
+		}
+		if !info.IsDir() && info.Size() > 0 {
+			entries, readErr := os.ReadDir(memoryDir)
+			memoriesReady = readErr == nil && len(entries) == 4
+			return syscall.EIO
+		}
+		return file.Sync()
+	})
+	if !errors.Is(err, syscall.EIO) || !memoriesReady || !reflect.DeepEqual(result, AgentAdvance{}) {
+		t.Fatalf("не воспроизведена граница memory-before-meta: %+v, %v", result, err)
+	}
+	if _, err := run.Load(); !errors.Is(err, syscall.EIO) {
+		t.Fatalf("владелец продолжил после неоднозначной записи meta: %v", err)
+	}
+	onDisk, err := Load(root, initial.Meta.RunID)
+	if err != nil || len(onDisk.Meta.Visits) != 2 || onDisk.Meta.Visits[0].Decision.Applied {
+		t.Fatalf("отказ до Rename частично опубликовал plan: %+v, %v", onDisk.Meta, err)
+	}
+	if err := run.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	if result, err = reopened.AdvanceAgentGraph(); err != nil || !result.Changed || len(result.CreatedVisits) != 2 {
+		t.Fatalf("reopen не применил сохранённое решение: %+v, %v", result, err)
+	}
+	entries, err := os.ReadDir(memoryDir)
+	if err != nil || len(entries) != 6 {
+		t.Fatalf("orphan memory потеряна или стала достижимой: %v, %v", entries, err)
+	}
+}
+
+// TestAdvanceAgentGraphGuards отклоняет legacy, циклическую и повреждённую
+// историю до любой новой памяти или metadata.
+func TestAdvanceAgentGraphGuards(t *testing.T) {
+	t.Run("legacy", func(t *testing.T) {
+		root := t.TempDir()
+		snapshot, err := Create(root, testInput(t))
+		if err != nil {
+			t.Fatal(err)
+		}
+		run, err := OpenLocked(root, snapshot.Meta.RunID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer run.Close()
+		if _, err := run.AdvanceAgentGraph(); err == nil {
+			t.Fatal("legacy run принят visit-aware bridge")
+		}
+	})
+	t.Run("cycle", func(t *testing.T) {
+		input := advanceInput(t)
+		input.WorkflowJSON = []byte(`{"version":2,"id":"cycle","start":["loop"],"steps":[
+          {"id":"loop","type":"agent","prompt":"Повтори","after":[],"maxVisits":2,
+           "decisions":{"repeat":{"to":["loop"]},"done":{"finish":"succeeded"}}}]}`)
+		root := t.TempDir()
+		snapshot, err := CreateAgentGraph(root, input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		run, err := OpenLocked(root, snapshot.Meta.RunID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer run.Close()
+		if _, err := run.AdvanceAgentGraph(); !errors.Is(err, scheduler.ErrAgentGraphCycle) {
+			t.Fatalf("циклический workflow прошёл первый runtime: %v", err)
+		}
+	})
+	t.Run("tampered", func(t *testing.T) {
+		root, snapshot, run := testAdvanceRun(t)
+		metaPath := filepath.Join(root, snapshot.Meta.RunID, "meta.json")
+		data, err := os.ReadFile(metaPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		damaged := bytes.Replace(data, []byte(`"state":"pending"`), []byte(`"state":"broken"`), 1)
+		if bytes.Equal(data, damaged) {
+			t.Fatal("fixture не повредила metadata")
+		}
+		mustWrite(t, metaPath, damaged)
+		if _, err := run.AdvanceAgentGraph(); err == nil || !strings.Contains(err.Error(), "неизвестное состояние") {
+			t.Fatalf("повреждённая metadata принята: %v", err)
+		}
+	})
+}

--- a/internal/runstore/store.go
+++ b/internal/runstore/store.go
@@ -80,6 +80,7 @@ type Metadata struct {
 	Steps             []Step   `json:"steps,omitempty"`
 	RunState          RunState `json:"runState,omitempty"`
 	StopReason        string   `json:"stopReason,omitempty"`
+	StopVisitID       string   `json:"stopVisitId,omitempty"`
 	Visits            []Visit  `json:"visits,omitempty"`
 }
 
@@ -553,7 +554,7 @@ func validateMetadataShape(data []byte, metadata Metadata) error {
 		}
 		return nil
 	}
-	if metadata.Version >= 1 && metadata.Version <= 3 && (has("runState") || has("stopReason") || has("visits")) {
+	if metadata.Version >= 1 && metadata.Version <= 3 && (has("runState") || has("stopReason") || has("stopVisitId") || has("visits")) {
 		return fmt.Errorf("legacy metadata не может содержать поля v4")
 	}
 	return nil
@@ -574,7 +575,7 @@ func (s Snapshot) validate(runID string) error {
 		m.ChildRequestID != "" && (m.Version != 3 || m.ParentRunID == "" || !validID(m.ChildRequestID)) ||
 		!filepath.IsAbs(m.CWD) || !validText(m.CWD) || strings.ContainsRune(m.CWD, 0) ||
 		oldFormat && !validText(m.InitiatorThreadID) || m.Version == 3 && m.InitiatorThreadID != "" ||
-		m.RunState != "" || m.StopReason != "" || m.Visits != nil ||
+		m.RunState != "" || m.StopReason != "" || m.StopVisitID != "" || m.Visits != nil ||
 		len(m.Steps) != len(s.Workflow.Steps) {
 		return fmt.Errorf("повреждены входы, версия или состав meta.json")
 	}

--- a/internal/runstore/visits.go
+++ b/internal/runstore/visits.go
@@ -95,7 +95,8 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 		return fmt.Errorf("workflow v4: %w", err)
 	}
 	if m.RunState != RunRunning && m.RunState != RunSucceeded && m.RunState != RunFailed ||
-		m.RunState == RunRunning && m.StopReason != "" || m.RunState != RunRunning && !safeStoredText(m.StopReason, true) {
+		m.RunState == RunRunning && (m.StopReason != "" || m.StopVisitID != "") ||
+		m.RunState != RunRunning && !safeStoredText(m.StopReason, true) {
 		return fmt.Errorf("runState не соответствует безопасной причине остановки")
 	}
 
@@ -106,6 +107,7 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 	seen, chats := make(map[string]Visit), make(map[string]bool)
 	numbers, active := make(map[string]int), make(map[string]bool)
 	afterUses, decisionUses := make(map[afterCause]bool), make(map[decisionCause]bool)
+	advanced := make(map[string]bool)
 	for index, visit := range m.Visits {
 		step, exists := steps[visit.StepID]
 		if !exists || !validID(visit.VisitID) {
@@ -133,9 +135,12 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 		if err := validateDecision(visit, step); err != nil {
 			return fmt.Errorf("посещение %q: %w", visit.VisitID, err)
 		}
+		for _, sourceID := range visit.Trigger.SourceVisitIDs {
+			advanced[sourceID] = true
+		}
 		seen[visit.VisitID] = visit
 	}
-	matchingFinish := false
+	matchingFinishID := ""
 	for _, visit := range m.Visits {
 		if visit.Decision == nil || !visit.Decision.Applied {
 			continue
@@ -153,11 +158,48 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 			if m.RunState != expected {
 				return fmt.Errorf("finish посещения %q не совпадает с runState", visit.VisitID)
 			}
-			matchingFinish = true
+			if matchingFinishID != "" {
+				return fmt.Errorf("run содержит больше одного применённого finish")
+			}
+			matchingFinishID = visit.VisitID
 		}
 	}
-	if m.RunState != RunRunning && len(active) != 0 && !matchingFinish {
-		return fmt.Errorf("терминальный run с незавершёнными visits требует применённый finish")
+	stopVisit, hasStopVisit := seen[m.StopVisitID]
+	if m.StopVisitID != "" && !hasStopVisit {
+		return fmt.Errorf("stopVisitId не ссылается на сохранённое посещение")
+	}
+	if matchingFinishID != "" && m.StopVisitID != matchingFinishID {
+		return fmt.Errorf("terminal finish требует свой visitId как причину остановки")
+	}
+	fatalDecision := false
+	if hasStopVisit {
+		step := steps[stopVisit.StepID]
+		fatalDecision = len(step.Decisions) != 0 && (stopVisit.Decision != nil && stopVisit.Decision.Error != "" ||
+			stopVisit.Decision == nil && stopVisit.State == scheduler.Succeeded)
+	}
+	if m.RunState != RunRunning && matchingFinishID == "" {
+		switch {
+		case fatalDecision:
+			if m.RunState != RunFailed {
+				return fmt.Errorf("ошибка решения может завершить run только как failed")
+			}
+		case m.RunState == RunFailed:
+			if !hasStopVisit || stopVisit.State != scheduler.Failed || advanced[stopVisit.VisitID] {
+				return fmt.Errorf("natural failed требует stopVisitId необработанного Failed-посещения")
+			}
+		case m.RunState == RunSucceeded:
+			if m.StopVisitID != "" {
+				return fmt.Errorf("natural succeeded не должен содержать stopVisitId")
+			}
+			for _, visit := range m.Visits {
+				if visit.State == scheduler.Failed && !advanced[visit.VisitID] {
+					return fmt.Errorf("natural succeeded содержит необработанное Failed-посещение %q", visit.VisitID)
+				}
+			}
+		}
+	}
+	if m.RunState != RunRunning && len(active) != 0 && matchingFinishID == "" && !fatalDecision {
+		return fmt.Errorf("терминальный run с незавершёнными visits требует применённый finish или ошибку решения")
 	}
 	return nil
 }
@@ -306,10 +348,12 @@ func sameOutcome(left, right *workflow.TerminalOutcome) bool {
 	return left == nil && right == nil || left != nil && right != nil && *left == *right
 }
 
+const maxStoredTextBytes = 4096
+
 // safeStoredText не даёт непроверенной диагностике сохранить управляющие
 // символы для будущего terminal/dashboard. Ограничение защищает и размер meta.
 func safeStoredText(value string, required bool) bool {
-	if !utf8.ValidString(value) || len(value) > 4096 || strings.IndexFunc(value, unicode.IsControl) >= 0 {
+	if !utf8.ValidString(value) || len(value) > maxStoredTextBytes || strings.IndexFunc(value, unicode.IsControl) >= 0 {
 		return false
 	}
 	return !required || strings.TrimSpace(value) != ""

--- a/internal/runstore/visits_locked_test.go
+++ b/internal/runstore/visits_locked_test.go
@@ -166,7 +166,7 @@ func TestTerminalRunDoesNotReserve(t *testing.T) {
 		choice := &snapshot.Meta.Visits[0]
 		choice.State, choice.CodexThreadID, choice.TurnID, choice.Attempt = scheduler.Succeeded, "chat", "turn", 1
 		choice.Decision = &DecisionRecord{Key: "done", TurnID: "turn", CallID: "call", Finish: cloneOutcome(snapshot.Workflow.Steps[0].Decisions["done"].Finish), Skipped: []string{"fail", "go"}, Applied: true}
-		snapshot.Meta.RunState, snapshot.Meta.StopReason = RunSucceeded, "агент выбрал успешное завершение"
+		snapshot.Meta.RunState, snapshot.Meta.StopReason, snapshot.Meta.StopVisitID = RunSucceeded, "агент выбрал успешное завершение", choice.VisitID
 		return true, nil
 	})
 	if err != nil {

--- a/internal/runstore/visits_test.go
+++ b/internal/runstore/visits_test.go
@@ -137,8 +137,9 @@ func TestLegacyMetadataRejectsV4Fields(t *testing.T) {
 		t.Fatal(err)
 	}
 	for name, mutate := range map[string]func(*Metadata){
-		"runState":   func(meta *Metadata) { meta.RunState = RunRunning },
-		"stopReason": func(meta *Metadata) { meta.StopReason = "неожиданное поле" },
+		"runState":    func(meta *Metadata) { meta.RunState = RunRunning },
+		"stopReason":  func(meta *Metadata) { meta.StopReason = "неожиданное поле" },
+		"stopVisitId": func(meta *Metadata) { meta.StopVisitID = newID() },
 		"visits": func(meta *Metadata) {
 			meta.Visits = []Visit{{VisitID: newID(), StepID: "чужой"}}
 		},
@@ -218,7 +219,7 @@ func TestAgentGraphMetadataValidation(t *testing.T) {
 		finish := *route.Finish
 		choice.Decision = &DecisionRecord{Key: key, TurnID: "turn-finish", CallID: "call-finish", Finish: &finish, Skipped: []string{"done", "fail", "go"}, Applied: true}
 		choice.Decision.Skipped = slices.DeleteFunc(choice.Decision.Skipped, func(candidate string) bool { return candidate == key })
-		result.Meta.RunState, result.Meta.StopReason = state, reason
+		result.Meta.RunState, result.Meta.StopReason, result.Meta.StopVisitID = state, reason, choice.VisitID
 		return result
 	}
 	terminalWithPending := finishSnapshot("done", RunSucceeded, "агент выбрал успешное завершение")
@@ -239,6 +240,45 @@ func TestAgentGraphMetadataValidation(t *testing.T) {
 	if err := terminalWithCancelled.validate(terminalWithCancelled.Meta.RunID); err != nil {
 		t.Fatalf("terminal run не принял оставшееся Cancelled-посещение: %v", err)
 	}
+	// Без explicit finish итог обязан быть доказан causal frontier: техническая
+	// ошибка, уже потреблённая after, не мешает успеху, а необработанный Failed
+	// является единственно допустимой причиной natural failed.
+	natural := cloneSnapshotMetadata(t, snapshot)
+	natural.Meta.Visits[1].State, natural.Meta.Visits[1].CodexThreadID = scheduler.Succeeded, "chat-audit"
+	natural.Meta.Visits[1].TurnID, natural.Meta.Visits[1].Attempt = "turn-audit", 1
+	natural.Meta.Visits[3].State, natural.Meta.Visits[3].CodexThreadID = scheduler.Succeeded, "chat-check"
+	natural.Meta.Visits[3].TurnID, natural.Meta.Visits[3].Attempt = "turn-check", 1
+	natural.Meta.RunState, natural.Meta.StopReason = RunSucceeded, "workflow достиг естественного завершения"
+	if err := natural.validate(natural.Meta.RunID); err != nil {
+		t.Fatalf("доказанный natural success отклонён: %v", err)
+	}
+	handledFailure := cloneSnapshotMetadata(t, natural)
+	handledFailure.Meta.Visits[2].State, handledFailure.Meta.Visits[2].TechnicalError = scheduler.Failed, "тест упал"
+	if err := handledFailure.validate(handledFailure.Meta.RunID); err != nil {
+		t.Fatalf("обработанный Failed ошибочно отравил natural success: %v", err)
+	}
+	naturalFailure := cloneSnapshotMetadata(t, natural)
+	naturalFailure.Meta.Visits[1].State, naturalFailure.Meta.Visits[1].TechnicalError = scheduler.Failed, "аудит упал"
+	naturalFailure.Meta.RunState, naturalFailure.Meta.StopReason = RunFailed, "необработанное terminal-посещение завершилось с ошибкой"
+	naturalFailure.Meta.StopVisitID = naturalFailure.Meta.Visits[1].VisitID
+	if err := naturalFailure.validate(naturalFailure.Meta.RunID); err != nil {
+		t.Fatalf("доказанный natural failed отклонён: %v", err)
+	}
+	wrongNaturalCause := cloneSnapshotMetadata(t, naturalFailure)
+	wrongNaturalCause.Meta.StopVisitID = wrongNaturalCause.Meta.Visits[0].VisitID
+	if err := wrongNaturalCause.validate(wrongNaturalCause.Meta.RunID); err == nil {
+		t.Fatal("natural failed принял не-Failed причину")
+	}
+	falseSuccess := cloneSnapshotMetadata(t, naturalFailure)
+	falseSuccess.Meta.RunState, falseSuccess.Meta.StopReason, falseSuccess.Meta.StopVisitID = RunSucceeded, "ложный успех", ""
+	if err := falseSuccess.validate(falseSuccess.Meta.RunID); err == nil {
+		t.Fatal("natural succeeded принял необработанный Failed frontier")
+	}
+	falseSuccessCause := cloneSnapshotMetadata(t, natural)
+	falseSuccessCause.Meta.StopVisitID = falseSuccessCause.Meta.Visits[0].VisitID
+	if err := falseSuccessCause.validate(falseSuccessCause.Meta.RunID); err == nil {
+		t.Fatal("natural succeeded принял произвольный stopVisitId")
+	}
 	clone := func() Snapshot {
 		return cloneSnapshotMetadata(t, snapshot)
 	}
@@ -258,6 +298,7 @@ func TestAgentGraphMetadataValidation(t *testing.T) {
 		"unmaterialized route": func(s *Snapshot) {
 			s.Meta.Visits = s.Meta.Visits[:2]
 		},
+		"unknown stop visit": func(s *Snapshot) { s.Meta.StopVisitID = newID() },
 		"failed decision source": func(s *Snapshot) {
 			s.Meta.Visits[0].State = scheduler.Failed
 		},


### PR DESCRIPTION
## Что сделано

- добавлен AdvanceAgentGraph, который под блокировкой перечитывает v4 snapshot и применяет pure planner plan;
- Applied-флаги решения, ordered fan-out/after visits и terminal outcome публикуются одним атомарным обновлением metadata;
- память каждого нового visit создаётся и fsync-ится до публикации ссылки из meta.json;
- повтор после crash/reopen не создаёт дубликаты; неоднозначная ошибка записи metadata отравляет текущего владельца run;
- terminal reason связывается с проверяемым StopVisitID, а natural outcome проверяется по causal frontier;
- длинные и управляющие фрагменты terminal reason безопасно экранируются и UTF-8-корректно ограничиваются;
- legacy v1-v3, циклы до bounded-loop среза и повреждённая история отклоняются без изменений.

## Проверки

- env GOCACHE=/private/tmp/lawa-go-cache go test -count=1 ./...
- env GOCACHE=/private/tmp/lawa-go-cache go test -count=1 -race ./internal/runstore
- env GOCACHE=/private/tmp/lawa-go-cache go vet ./...
- независимое ревью: APPROVE

## Размер

685 добавлений и 12 удалений, всего 697 изменённых строк. Это выше ориентира 500 строк, но ниже блокирующего лимита 1200; основной объём — crash-boundary и causal-integrity тесты.

Зависит от #74. Часть #50.