### PR TITLE
Подготовить выполнение посещений agent-графа

### DIFF
--- a/internal/coordinator/agent_prepare.go
+++ b/internal/coordinator/agent_prepare.go
@@ -1,0 +1,453 @@
+package coordinator
+
+import (
+	"context"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/stray-live-pixel/Lawa/internal/capacity"
+	"github.com/stray-live-pixel/Lawa/internal/codex"
+	"github.com/stray-live-pixel/Lawa/internal/runstore"
+	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
+)
+
+const chooseDecisionToolName = "choose_decision"
+
+// agentWorkKind отделяет создание нового Codex-чата от нового turn уже
+// сохранённого чата. Оба вида работы занимают одинаковый slot параллельности и
+// адресуются visitId; stepId после появления циклов перестаёт быть уникальным.
+type agentWorkKind uint8
+
+const (
+	agentWorkLaunch agentWorkKind = iota + 1
+	agentWorkContinuation
+)
+
+// agentWork — полностью подготовленный сетевой запрос одного посещения. Lease
+// передаётся будущему execution-циклу и должен удерживаться до terminal result.
+// Для continuation ThreadID содержит уже сохранённый Codex thread; новый launch
+// получает его только через OnThread и поэтому возвращается с пустым ThreadID.
+type agentWork struct {
+	VisitID, StepID, ThreadID string
+	Command                   codex.Command
+	kind                      agentWorkKind
+	lease                     *capacity.Lease
+}
+
+// agentPreparation сохраняет единый FIFO и для новых, и для продолженных visits.
+// WaitingForCapacity содержит visitId, а не stepId: один и тот же логический
+// кубик может иметь несколько независимых посещений в durable-истории.
+type agentPreparation struct {
+	Work               []agentWork
+	WaitingForCapacity []string
+}
+
+// prepareAgentVisits строит команды всех доступных Pending/Cancelled visits,
+// получает для начала FIFO доступные root-wide slots и только после этого одним
+// durable commit переводит выбранные Pending в Starting. До успешного ReserveVisits
+// вызывающий код не имеет права передавать новый launch клиенту Codex.
+//
+// Вызывающий код обязан непосредственно перед подготовкой выполнить
+// AdvanceAgentGraph и остановиться на его terminal результате. Prepare намеренно
+// не дублирует planner: иначе unapplied finish мог бы соревноваться с запуском
+// уже существующего Pending visit, а две реализации переходов начали бы расходиться.
+//
+// Cancelled выбирается лишь для явного resume и не меняется на диске заранее:
+// связь с прежним чатом уже сохранена. Карта continued ограничивает один continue
+// на visit за один execution-процесс; функция её не меняет, потому что владение
+// начинается только когда вызывающий код зарегистрировал activeExecution.
+func prepareAgentVisits(
+	run *runstore.LockedRun,
+	root string,
+	pool *capacity.Pool,
+	continueCancelled bool,
+	continued map[string]bool,
+	configure func(runstore.Snapshot, *codex.Command),
+) (agentPreparation, error) {
+	if run == nil {
+		return agentPreparation{}, errors.New("координатор agent-graph: нужен открытый запуск")
+	}
+	snapshot, err := run.Load()
+	if err != nil {
+		return agentPreparation{}, fmt.Errorf("координатор agent-graph: прочитать запуск: %w", err)
+	}
+	if snapshot.Meta.Version != 4 || snapshot.Workflow.EffectiveVersion() != workflow.VersionAgentGraph {
+		return agentPreparation{}, errors.New("координатор agent-graph: подготовка требует meta.json v4 и workflow version=2")
+	}
+	if snapshot.Meta.RunState != runstore.RunRunning {
+		return agentPreparation{}, errors.New("координатор agent-graph: завершённый run не принимает новые turn")
+	}
+	runDir, err := validateAgentRoot(run, snapshot, root)
+	if err != nil {
+		return agentPreparation{}, err
+	}
+	if pool == nil {
+		pool = capacity.Unlimited()
+	}
+
+	steps := make(map[string]workflow.Step, len(snapshot.Workflow.Steps))
+	for _, step := range snapshot.Workflow.Steps {
+		steps[step.ID] = step
+	}
+	// Команды строятся до получения slots и durable reserve. Поэтому конфликт
+	// встроенного имени инструмента либо повреждённая причинная ссылка не оставит
+	// Starting, хотя ни один сетевой запрос ещё даже не мог начаться.
+	candidates := make([]agentWork, 0)
+	for _, visit := range snapshot.Meta.Visits {
+		kind := agentWorkKind(0)
+		switch {
+		case visit.State == scheduler.Pending:
+			kind = agentWorkLaunch
+		case visit.State == scheduler.Cancelled && continueCancelled && !continued[visit.VisitID]:
+			kind = agentWorkContinuation
+		default:
+			continue
+		}
+		step, exists := steps[visit.StepID]
+		if !exists {
+			return agentPreparation{}, fmt.Errorf("координатор agent-graph: посещение %q ссылается на неизвестный шаг %q", visit.VisitID, visit.StepID)
+		}
+		prompt, promptErr := buildAgentPrompt(snapshot, step, visit, runDir)
+		if promptErr != nil {
+			return agentPreparation{}, promptErr
+		}
+		ownMemory := filepath.Join(runDir, "memory", visit.VisitID+".md")
+		command := codex.Command{
+			CWD:         snapshot.Meta.CWD,
+			Title:       fmt.Sprintf("Lawa: %s / %s #%d, итерация %d [%s]", snapshot.Workflow.ID, visit.StepID, visit.Visit, visit.Iteration, snapshot.Meta.RunID),
+			Text:        prompt,
+			Permissions: stepPermissions(runDir, ownMemory, visit.VisitID),
+		}
+		applyRuntimeSettings(&command, snapshot.Workflow.Model, step)
+		if configure != nil {
+			// Конфигуратор CLI первым добавляет run_child/run_children. Только после
+			// него coordinator может завернуть handler, не потеряв дочерние tools.
+			configure(snapshot, &command)
+		}
+		if err = addChooseDecision(run, step, visit, &command); err != nil {
+			return agentPreparation{}, fmt.Errorf("координатор agent-graph: посещение %q: %w", visit.VisitID, err)
+		}
+		candidates = append(candidates, agentWork{
+			VisitID: visit.VisitID, StepID: visit.StepID, ThreadID: visit.CodexThreadID,
+			Command: command, kind: kind,
+		})
+	}
+
+	prepared := agentPreparation{}
+	for index := range candidates {
+		lease, available, acquireErr := pool.TryAcquire()
+		if acquireErr != nil {
+			return agentPreparation{}, errors.Join(
+				fmt.Errorf("координатор agent-graph: получить слот параллельности: %w", acquireErr),
+				releaseAgentWork(prepared.Work),
+			)
+		}
+		if !available {
+			for _, waiting := range candidates[index:] {
+				prepared.WaitingForCapacity = append(prepared.WaitingForCapacity, waiting.VisitID)
+			}
+			break
+		}
+		candidate := candidates[index]
+		candidate.lease = lease
+		prepared.Work = append(prepared.Work, candidate)
+	}
+
+	reserved := make([]string, 0, len(prepared.Work))
+	for _, work := range prepared.Work {
+		if work.kind == agentWorkLaunch {
+			reserved = append(reserved, work.VisitID)
+		}
+	}
+	if err = run.ReserveVisits(reserved); err != nil {
+		return agentPreparation{}, errors.Join(
+			fmt.Errorf("координатор agent-graph: зарезервировать посещения: %w", err),
+			releaseAgentWork(prepared.Work),
+		)
+	}
+	return prepared, nil
+}
+
+// releaseAgentWork возвращает все уже полученные slots при ошибке подготовки.
+// Повторный Release безопасен, но нормальный execution вызывает его лишь после
+// получения результата соответствующего turn.
+func releaseAgentWork(work []agentWork) error {
+	var err error
+	for _, item := range work {
+		err = errors.Join(err, item.lease.Release())
+	}
+	return err
+}
+
+// validateAgentRoot проверяет именно root, переданный execution-циклом. LockedRun
+// читает файлы через собственный os.Root, но prompt и permission profile строятся
+// из отдельной Options.Root; без этой сверки опечатка дала бы агенту чужие пути.
+func validateAgentRoot(run *runstore.LockedRun, snapshot runstore.Snapshot, root string) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		return "", errors.New("координатор agent-graph: нужна папка хранения root")
+	}
+	runDir, err := run.ResolveDirectory(root)
+	if err != nil {
+		return "", fmt.Errorf("координатор agent-graph: проверить root: %w", err)
+	}
+	// Проверка каждого leaf не замечает симлинк в memory: Lstat вернул бы уже
+	// целевой обычный файл. Поэтому сначала отдельно фиксируем настоящий каталог,
+	// а затем проверяем каждую разрешённую агенту память.
+	memoryDir := filepath.Join(runDir, "memory")
+	memoryInfo, err := os.Lstat(memoryDir)
+	if err != nil || !memoryInfo.IsDir() {
+		if err == nil {
+			err = errors.New("не является настоящим каталогом без симлинка")
+		}
+		return "", fmt.Errorf("координатор agent-graph: проверить каталог памяти: %w", err)
+	}
+	for _, visit := range snapshot.Meta.Visits {
+		memory := filepath.Join(runDir, "memory", visit.VisitID+".md")
+		info, statErr := os.Lstat(memory)
+		if statErr != nil || !info.Mode().IsRegular() {
+			if statErr == nil {
+				statErr = errors.New("не является обычным файлом")
+			}
+			return "", fmt.Errorf("координатор agent-graph: проверить память посещения %q: %w", visit.VisitID, statErr)
+		}
+	}
+	return runDir, nil
+}
+
+// buildAgentPrompt передаёт агенту только durable-факты одного согласованного
+// snapshot. Содержимое memory не копируется в prompt: абсолютные пути позволяют
+// агенту прочитать нужные результаты без раздувания каждого следующего turn.
+// Причинные источники перечислены отдельно и в сохранённом порядке; остальные
+// terminal visits дают доступ к истории параллельных веток и будущих итераций.
+func buildAgentPrompt(snapshot runstore.Snapshot, step workflow.Step, visit runstore.Visit, runDir string) (string, error) {
+	visits := make(map[string]runstore.Visit, len(snapshot.Meta.Visits))
+	for _, saved := range snapshot.Meta.Visits {
+		visits[saved.VisitID] = saved
+	}
+	causal := make(map[string]bool, len(visit.Trigger.SourceVisitIDs))
+	var sources strings.Builder
+	if len(visit.Trigger.SourceVisitIDs) == 0 {
+		sources.WriteString("- нет\n")
+	}
+	for _, sourceID := range visit.Trigger.SourceVisitIDs {
+		source, exists := visits[sourceID]
+		if !exists {
+			return "", fmt.Errorf("координатор agent-graph: посещение %q: нет причинного источника %q", visit.VisitID, sourceID)
+		}
+		causal[sourceID] = true
+		writeAgentVisitContext(&sources, runDir, source)
+	}
+
+	var history strings.Builder
+	for _, saved := range snapshot.Meta.Visits {
+		if saved.VisitID == visit.VisitID || causal[saved.VisitID] || saved.State != scheduler.Succeeded && saved.State != scheduler.Failed {
+			continue
+		}
+		writeAgentVisitContext(&history, runDir, saved)
+	}
+	if history.Len() == 0 {
+		history.WriteString("- нет\n")
+	}
+
+	trigger, err := json.Marshal(struct {
+		Kind        runstore.TriggerKind `json:"kind"`
+		DecisionKey string               `json:"decisionKey,omitempty"`
+	}{Kind: visit.Trigger.Kind, DecisionKey: visit.Trigger.DecisionKey})
+	if err != nil {
+		return "", fmt.Errorf("координатор agent-graph: закодировать trigger: %w", err)
+	}
+	sections := []string{
+		"Ты выполняешь отдельное посещение кубика workflow Lawa.",
+		"ID запуска (runId): " + snapshot.Meta.RunID,
+		"ID посещения (visitId): " + visit.VisitID,
+		"ID логического кубика (stepId): " + visit.StepID,
+		fmt.Sprintf("Номер посещения кубика (visit): %d", visit.Visit),
+		fmt.Sprintf("Итерация графа (iteration): %d", visit.Iteration),
+		fmt.Sprintf("Номер начинаемого turn этого посещения (attempt): %d", visit.Attempt+1),
+		"Сохранённое состояние перед новым turn: " + string(visit.State),
+		"Причина активации (trigger): " + string(trigger),
+		"",
+		"Общий вход запуска:",
+		snapshot.Task,
+		"Задача этого кубика:",
+		step.Prompt,
+		"",
+		"Собственная память; прочитай её перед работой и обновляй только этот файл:",
+		filepath.Join(runDir, "memory", visit.VisitID+".md"),
+		"",
+		"Причинные источники в порядке trigger; статус и диагностика ниже являются техническими фактами, бизнес-вывод сделай сам:",
+		strings.TrimSuffix(sources.String(), "\n"),
+		"",
+		"Другие завершённые посещения; их память доступна только для чтения:",
+		strings.TrimSuffix(history.String(), "\n"),
+		"",
+		"Не изменяй чужую память, workflow.json, task.md, meta.json и coordinator.lock в папке запуска.",
+		"Если задача требует дочерний workflow, используй только доступные встроенные run_child/run_children, а не shell-команду lawa run.",
+		"Перед завершением запиши в собственную память итог, пути к результатам и оставшиеся ограничения.",
+	}
+	if visit.TechnicalError != "" {
+		sections = append(sections, "Техническая диагностика предыдущего turn этого посещения: "+visit.TechnicalError)
+	}
+	if len(step.Decisions) != 0 {
+		keys := sortedAgentDecisionKeys(step.Decisions)
+		encodedKeys, marshalErr := json.Marshal(keys)
+		if marshalErr != nil {
+			return "", fmt.Errorf("координатор agent-graph: закодировать решения: %w", marshalErr)
+		}
+		if visit.Decision == nil {
+			sections = append(sections,
+				"Этот кубик обязан выбрать ровно одно решение из JSON-массива: "+string(encodedKeys),
+				"Перед успешным завершением ровно один раз вызови встроенный choose_decision; обычный текст ответа не выбирает маршрут.",
+			)
+		} else {
+			encodedDecision, marshalErr := json.Marshal(visit.Decision.Key)
+			if marshalErr != nil {
+				return "", fmt.Errorf("координатор agent-graph: закодировать сохранённое решение: %w", marshalErr)
+			}
+			sections = append(sections,
+				"Решение уже устойчиво сохранено предыдущим turn: "+string(encodedDecision)+".",
+				"Не вызывай choose_decision повторно; закончи оставшуюся работу и сохрани память.",
+			)
+			if visit.Decision.Explanation != "" {
+				sections = append(sections, "Сохранённое объяснение решения: "+visit.Decision.Explanation)
+			}
+		}
+	}
+	return strings.Join(sections, "\n"), nil
+}
+
+// writeAgentVisitContext добавляет одну безопасную строку истории. TechnicalError
+// уже ограничена и очищена валидатором meta v4; решение кодируется как JSON,
+// чтобы допустимые пробелы в key не меняли структуру служебного текста.
+func writeAgentVisitContext(target *strings.Builder, runDir string, visit runstore.Visit) {
+	decision := ""
+	if visit.Decision != nil {
+		encoded, _ := json.Marshal(visit.Decision.Key)
+		decision = ", решение=" + string(encoded)
+		if visit.Decision.Explanation != "" {
+			decision += ", объяснение=" + visit.Decision.Explanation
+		}
+	}
+	diagnostic := ""
+	if visit.TechnicalError != "" {
+		diagnostic = ", техническая диагностика=" + visit.TechnicalError
+	}
+	fmt.Fprintf(target, "- step=%s, visit=%d, iteration=%d, visitId=%s, state=%s%s%s, memory=%s\n",
+		visit.StepID, visit.Visit, visit.Iteration, visit.VisitID, visit.State, diagnostic, decision,
+		filepath.Join(runDir, "memory", visit.VisitID+".md"))
+}
+
+// addChooseDecision резервирует имя graph-control tool после внешнего
+// ConfigureCommand. Для обычного кубика и для уже сохранённого выбора команда
+// остаётся без этого инструмента. Captured handler вызывается для любого другого
+// имени ровно один раз, поэтому run_child/run_children не дублируются.
+func addChooseDecision(run *runstore.LockedRun, step workflow.Step, visit runstore.Visit, command *codex.Command) error {
+	for _, tool := range command.DynamicTools {
+		if tool.Name == chooseDecisionToolName {
+			return fmt.Errorf("ConfigureCommand занял служебное имя %q", chooseDecisionToolName)
+		}
+	}
+	if len(command.DynamicTools) != 0 && command.CallDynamicTool == nil {
+		return errors.New("ConfigureCommand добавил dynamic tools без обработчика")
+	}
+	if len(step.Decisions) == 0 || visit.Decision != nil {
+		return nil
+	}
+	keys := sortedAgentDecisionKeys(step.Decisions)
+	schema, err := json.Marshal(struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Decision struct {
+				Type string   `json:"type"`
+				Enum []string `json:"enum"`
+			} `json:"decision"`
+			Explanation struct {
+				Type      string `json:"type"`
+				MaxLength int    `json:"maxLength"`
+			} `json:"explanation"`
+		} `json:"properties"`
+		Required []string `json:"required"`
+	}{
+		Type: "object", AdditionalProperties: false, Required: []string{"decision"},
+		Properties: struct {
+			Decision struct {
+				Type string   `json:"type"`
+				Enum []string `json:"enum"`
+			} `json:"decision"`
+			Explanation struct {
+				Type      string `json:"type"`
+				MaxLength int    `json:"maxLength"`
+			} `json:"explanation"`
+		}{
+			Decision: struct {
+				Type string   `json:"type"`
+				Enum []string `json:"enum"`
+			}{Type: "string", Enum: keys},
+			Explanation: struct {
+				Type      string `json:"type"`
+				MaxLength int    `json:"maxLength"`
+			}{Type: "string", MaxLength: 4096},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("построить схему choose_decision: %w", err)
+	}
+	command.DynamicTools = append(command.DynamicTools, codex.DynamicTool{
+		Name:        chooseDecisionToolName,
+		Description: "Устойчиво сохранить ровно одно разрешённое решение текущего посещения; маршрут будет применён координатором после успешного завершения turn.",
+		InputSchema: schema,
+	})
+	previous := command.CallDynamicTool
+	command.CallDynamicTool = func(ctx context.Context, call codex.DynamicToolCall) (string, error) {
+		if call.Tool != chooseDecisionToolName {
+			if previous == nil {
+				return "", fmt.Errorf("неподдерживаемый dynamic tool %q", call.Tool)
+			}
+			return previous(ctx, call)
+		}
+		var input struct {
+			Decision    string `json:"decision"`
+			Explanation string `json:"explanation,omitempty"`
+		}
+		if err := json.Unmarshal(call.Arguments, &input, json.RejectUnknownMembers(true)); err != nil {
+			return "", fmt.Errorf("прочитать choose_decision: %w", err)
+		}
+		record, err := run.CommitDecision(
+			visit.VisitID, call.ThreadID, call.TurnID,
+			input.Decision, input.Explanation, call.CallID,
+		)
+		if err != nil {
+			return "", err
+		}
+		response, err := json.Marshal(struct {
+			Committed bool                      `json:"committed"`
+			Decision  string                    `json:"decision"`
+			To        []string                  `json:"to,omitempty"`
+			Finish    *workflow.TerminalOutcome `json:"finish,omitempty"`
+		}{Committed: true, Decision: record.Key, To: slices.Clone(record.To), Finish: record.Finish})
+		if err != nil {
+			return "", fmt.Errorf("подтвердить choose_decision: %w", err)
+		}
+		return string(response), nil
+	}
+	return nil
+}
+
+// sortedAgentDecisionKeys исключает зависимость schema и prompt от порядка map.
+// Сравнение ключей остаётся точным: пробелы не обрезаются и регистр не меняется.
+func sortedAgentDecisionKeys(decisions map[string]workflow.Route) []string {
+	keys := make([]string, 0, len(decisions))
+	for key := range decisions {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/coordinator/agent_prepare_test.go
+++ b/internal/coordinator/agent_prepare_test.go
@@ -1,0 +1,424 @@
+package coordinator
+
+import (
+	"context"
+	"encoding/json/v2"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stray-live-pixel/Lawa/internal/capacity"
+	"github.com/stray-live-pixel/Lawa/internal/codex"
+	"github.com/stray-live-pixel/Lawa/internal/runstore"
+	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+)
+
+// createAgentPreparationRun создаёт настоящий v4 run: тесты подготовки должны
+// проходить через тот же строгий Load и те же memory-файлы, что production resume.
+func createAgentPreparationRun(t *testing.T, definition string) (string, runstore.Snapshot, *runstore.LockedRun) {
+	t.Helper()
+	root := t.TempDir()
+	snapshot, err := runstore.CreateAgentGraph(root, runstore.Input{
+		WorkflowJSON: []byte(definition), Task: "Сделать MVP\n\nКомментарий: проверить границы", CWD: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runstore.OpenLocked(root, snapshot.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = run.Close() })
+	return root, snapshot, run
+}
+
+// completeAgentVisit переводит visit через обязательные durable границы. Нельзя
+// записать Running/Succeeded сразу: v4 требует сначала сохранить chat и turn.
+func completeAgentVisit(t *testing.T, run *runstore.LockedRun, visitID, chat string, state scheduler.State, diagnostic string) {
+	t.Helper()
+	if err := run.UpdateVisit(visitID, scheduler.Unknown, chat, ""); err == nil {
+		err = run.SetVisitTurn(visitID, "turn-"+visitID)
+		if err == nil {
+			err = run.UpdateVisit(visitID, state, chat, diagnostic)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal(err)
+	}
+}
+
+// TestPrepareAgentVisitsFIFOAndCapacity проверяет общий порядок двух видов
+// работы. Старый Cancelled visit получает единственный slot раньше нового
+// Pending, а Pending не становится Starting, пока slot действительно недоступен.
+func TestPrepareAgentVisitsFIFOAndCapacity(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"fifo","start":["first","second"],"steps":[
+    {"id":"first","type":"agent","prompt":"Первый","after":[]},
+    {"id":"second","type":"agent","prompt":"Второй","after":[]}
+  ]}`)
+	firstID, secondID := initial.Meta.Visits[0].VisitID, initial.Meta.Visits[1].VisitID
+	if err := run.ReserveVisits([]string{firstID}); err != nil {
+		t.Fatal(err)
+	}
+	completeAgentVisit(t, run, firstID, "chat-first", scheduler.Cancelled, "остановлено оператором")
+	pool, err := capacity.Configure(root, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := prepareAgentVisits(run, root, pool, true, map[string]bool{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prepared.Work) != 1 || prepared.Work[0].VisitID != firstID || prepared.Work[0].kind != agentWorkContinuation || prepared.Work[0].ThreadID != "chat-first" ||
+		!reflect.DeepEqual(prepared.WaitingForCapacity, []string{secondID}) {
+		t.Fatalf("FIFO либо вид работы потерян: %+v", prepared)
+	}
+	saved, err := run.Load()
+	if err != nil || saved.Meta.Visits[1].State != scheduler.Pending {
+		t.Fatalf("ожидающий slot visit был зарезервирован: %+v, %v", saved.Meta.Visits, err)
+	}
+	if err := releaseAgentWork(prepared.Work); err != nil {
+		t.Fatal(err)
+	}
+
+	// Execution помечает continuation перед запуском. После освобождения slot
+	// следующий FIFO-кандидат резервируется ровно один раз по visitId.
+	prepared, err = prepareAgentVisits(run, root, pool, true, map[string]bool{firstID: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = releaseAgentWork(prepared.Work) })
+	if len(prepared.Work) != 1 || prepared.Work[0].VisitID != secondID || prepared.Work[0].kind != agentWorkLaunch || len(prepared.WaitingForCapacity) != 0 {
+		t.Fatalf("Pending visit не получил освобождённый slot: %+v", prepared)
+	}
+	saved, err = run.Load()
+	if err != nil || saved.Meta.Visits[1].State != scheduler.Starting || saved.Meta.Visits[1].CodexThreadID != "" {
+		t.Fatalf("launch не зарезервирован до сети: %+v, %v", saved.Meta.Visits, err)
+	}
+}
+
+// TestAgentPromptContainsDurableVisitContext фиксирует полезный агенту контекст:
+// failed является нормальным after-источником, его техническая диагностика не
+// подменяется бизнес-выводом, а несвязанная завершённая ветка остаётся доступна.
+func TestAgentPromptContainsDurableVisitContext(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"context","start":["history","source"],"steps":[
+    {"id":"history","type":"agent","prompt":"Собери фон","after":[]},
+    {"id":"source","type":"agent","prompt":"Запусти тест","after":[]},
+    {"id":"checker","type":"agent","prompt":"Разбери результат","after":["source"],"decisions":{
+      "stop":{"finish":"failed"},"continue":{"to":["target"]}}},
+    {"id":"target","type":"agent","prompt":"Продолжи","after":[]}
+  ]}`)
+	historyID, sourceID := initial.Meta.Visits[0].VisitID, initial.Meta.Visits[1].VisitID
+	if err := run.ReserveVisits([]string{historyID, sourceID}); err != nil {
+		t.Fatal(err)
+	}
+	completeAgentVisit(t, run, historyID, "chat-history", scheduler.Succeeded, "")
+	completeAgentVisit(t, run, sourceID, "chat-source", scheduler.Failed, "сеть недоступна")
+	advanced, err := run.AdvanceAgentGraph()
+	if err != nil || len(advanced.CreatedVisits) != 1 || advanced.CreatedVisits[0].StepID != "checker" {
+		t.Fatalf("after не создал checker: %+v, %v", advanced, err)
+	}
+	checker := advanced.CreatedVisits[0]
+	prepared, err := prepareAgentVisits(run, root, capacity.Unlimited(), false, nil, nil)
+	if err != nil || len(prepared.Work) != 1 || prepared.Work[0].VisitID != checker.VisitID {
+		t.Fatalf("checker не подготовлен: %+v, %v", prepared, err)
+	}
+	t.Cleanup(func() { _ = releaseAgentWork(prepared.Work) })
+	command := prepared.Work[0].Command
+	runDir, err := filepath.EvalSymlinks(filepath.Join(root, initial.Meta.RunID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fragment := range []string{
+		initial.Meta.RunID, checker.VisitID, "Сделать MVP", "проверить границы", "Разбери результат",
+		"Номер посещения кубика (visit): 1", "Итерация графа (iteration): 1", "(attempt): 1",
+		"step=source", "state=failed", "техническая диагностика=сеть недоступна",
+		filepath.Join(runDir, "memory", sourceID+".md"), "step=history", "state=succeeded",
+		filepath.Join(runDir, "memory", historyID+".md"), filepath.Join(runDir, "memory", checker.VisitID+".md"),
+		`["continue","stop"]`, "ровно один раз вызови встроенный choose_decision",
+	} {
+		if !strings.Contains(command.Text, fragment) {
+			t.Errorf("visit-aware prompt не содержит %q\n%s", fragment, command.Text)
+		}
+	}
+	profile := command.Permissions
+	if profile == nil || profile.Name != "lawa-"+checker.VisitID || !reflect.DeepEqual(profile.ReadPaths, []string{runDir}) ||
+		!reflect.DeepEqual(profile.WritePaths, []string{filepath.Join(runDir, "memory", checker.VisitID+".md")}) {
+		t.Fatalf("visit получил неверные права памяти: %+v", profile)
+	}
+}
+
+// TestChooseDecisionComposesWithConfiguredTools проверяет машинную границу
+// решения целиком: child handler сохраняется, enum детерминирован, неверные JSON
+// не меняют meta, а повторная доставка одного callId возвращает тот же commit.
+func TestChooseDecisionComposesWithConfiguredTools(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"tools","start":["choice"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
+      "stop":{"finish":"succeeded"},"go":{"to":["target"]},"abort":{"finish":"failed"}}},
+    {"id":"target","type":"agent","prompt":"Работай","after":[]}
+  ]}`)
+	delegated := 0
+	configure := func(_ runstore.Snapshot, command *codex.Command) {
+		command.DynamicTools = []codex.DynamicTool{{
+			Name: "run_child", Description: "Запустить ребёнка.", InputSchema: []byte(`{"type":"object"}`),
+		}}
+		command.CallDynamicTool = func(_ context.Context, call codex.DynamicToolCall) (string, error) {
+			delegated++
+			return "child:" + call.Tool, nil
+		}
+	}
+	prepared, err := prepareAgentVisits(run, root, capacity.Unlimited(), false, nil, configure)
+	if err != nil || len(prepared.Work) != 1 {
+		t.Fatalf("decision visit не подготовлен: %+v, %v", prepared, err)
+	}
+	t.Cleanup(func() { _ = releaseAgentWork(prepared.Work) })
+	command := prepared.Work[0].Command
+	if len(command.DynamicTools) != 2 || command.DynamicTools[0].Name != "run_child" || command.DynamicTools[1].Name != chooseDecisionToolName {
+		t.Fatalf("configure tools потеряны или продублированы: %+v", command.DynamicTools)
+	}
+	var schema struct {
+		AdditionalProperties bool `json:"additionalProperties"`
+		Properties           struct {
+			Decision struct {
+				Enum []string `json:"enum"`
+			} `json:"decision"`
+		} `json:"properties"`
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(command.DynamicTools[1].InputSchema, &schema); err != nil || schema.AdditionalProperties ||
+		!reflect.DeepEqual(schema.Required, []string{"decision"}) || !reflect.DeepEqual(schema.Properties.Decision.Enum, []string{"abort", "go", "stop"}) {
+		t.Fatalf("неверная strict schema: %+v, %v", schema, err)
+	}
+	childResult, err := command.CallDynamicTool(t.Context(), codex.DynamicToolCall{Tool: "run_child"})
+	if err != nil || childResult != "child:run_child" || delegated != 1 {
+		t.Fatalf("исходный handler вызван неверно: %q, calls=%d, %v", childResult, delegated, err)
+	}
+
+	visitID := initial.Meta.Visits[0].VisitID
+	if err := run.UpdateVisit(visitID, scheduler.Unknown, "chat-choice", ""); err == nil {
+		err = run.SetVisitTurn(visitID, "turn-choice")
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal(err)
+	}
+	invalid := []codex.DynamicToolCall{
+		{ThreadID: "chat-choice", TurnID: "turn-choice", CallID: "bad-missing", Tool: chooseDecisionToolName, Arguments: []byte(`{}`)},
+		{ThreadID: "chat-choice", TurnID: "turn-choice", CallID: "bad-extra", Tool: chooseDecisionToolName, Arguments: []byte(`{"decision":"go","extra":true}`)},
+		{ThreadID: "chat-choice", TurnID: "turn-choice", CallID: "bad-duplicate", Tool: chooseDecisionToolName, Arguments: []byte(`{"decision":"go","decision":"stop"}`)},
+		{ThreadID: "chat-choice", TurnID: "turn-choice", CallID: "bad-trailing", Tool: chooseDecisionToolName, Arguments: []byte(`{"decision":"go"}{}`)},
+		{ThreadID: "chat-choice", TurnID: "turn-choice", CallID: "bad-key", Tool: chooseDecisionToolName, Arguments: []byte(`{"decision":"unknown"}`)},
+		{ThreadID: "other-chat", TurnID: "turn-choice", CallID: "bad-thread", Tool: chooseDecisionToolName, Arguments: []byte(`{"decision":"go"}`)},
+	}
+	for _, call := range invalid {
+		if _, callErr := command.CallDynamicTool(t.Context(), call); callErr == nil {
+			t.Fatalf("принят неверный choose_decision: %+v", call)
+		}
+	}
+	if saved, loadErr := run.Load(); loadErr != nil || saved.Meta.Visits[0].Decision != nil {
+		t.Fatalf("отказ tool изменил meta: %+v, %v", saved.Meta.Visits[0].Decision, loadErr)
+	}
+	call := codex.DynamicToolCall{
+		ThreadID: "chat-choice", TurnID: "turn-choice", CallID: "call-choice", Tool: chooseDecisionToolName,
+		Arguments: []byte(`{"decision":"go","explanation":"нужна следующая работа"}`),
+	}
+	first, err := command.CallDynamicTool(t.Context(), call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := command.CallDynamicTool(t.Context(), call)
+	if err != nil || first != second || !strings.Contains(first, `"committed":true`) || !strings.Contains(first, `"to":["target"]`) {
+		t.Fatalf("durable replay не подтверждён: %q / %q, %v", first, second, err)
+	}
+	saved, err := run.Load()
+	record := saved.Meta.Visits[0].Decision
+	if err != nil || record == nil || record.Key != "go" || record.CallID != "call-choice" || record.Applied || record.Error != "" ||
+		!reflect.DeepEqual(record.To, []string{"target"}) || !reflect.DeepEqual(record.Skipped, []string{"abort", "stop"}) {
+		t.Fatalf("решение не сохранено ровно один раз: %+v, %v", record, err)
+	}
+}
+
+// TestCancelledDecisionKeepsCommittedChoice не даёт resume попросить модель
+// выбрать маршрут заново. Новый turn получает прежний чат, следующий attempt и
+// только внешние tools; после Succeeded планировщик применит старый durable key.
+func TestCancelledDecisionKeepsCommittedChoice(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"resume-choice","start":["choice"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
+      "go":{"to":["target"]},"stop":{"finish":"failed"}}},
+    {"id":"target","type":"agent","prompt":"Работай","after":[]}
+  ]}`)
+	visitID := initial.Meta.Visits[0].VisitID
+	if err := run.ReserveVisits([]string{visitID}); err != nil {
+		t.Fatal(err)
+	}
+	completeAgentVisit(t, run, visitID, "chat-choice", scheduler.Running, "")
+	if _, err := run.CommitDecision(visitID, "chat-choice", "turn-"+visitID, "go", "продолжить", "call-choice"); err == nil {
+		err = run.UpdateVisit(visitID, scheduler.Cancelled, "chat-choice", "остановлено")
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal(err)
+	}
+	configure := func(_ runstore.Snapshot, command *codex.Command) {
+		command.DynamicTools = []codex.DynamicTool{{Name: "run_child", Description: "Запустить ребёнка.", InputSchema: []byte(`{"type":"object"}`)}}
+		command.CallDynamicTool = func(context.Context, codex.DynamicToolCall) (string, error) { return "child", nil }
+	}
+	prepared, err := prepareAgentVisits(run, root, capacity.Unlimited(), true, map[string]bool{}, configure)
+	if err != nil || len(prepared.Work) != 1 {
+		t.Fatalf("Cancelled choice не продолжен: %+v, %v", prepared, err)
+	}
+	t.Cleanup(func() { _ = releaseAgentWork(prepared.Work) })
+	work := prepared.Work[0]
+	if work.kind != agentWorkContinuation || work.ThreadID != "chat-choice" || len(work.Command.DynamicTools) != 1 || work.Command.DynamicTools[0].Name != "run_child" ||
+		!strings.Contains(work.Command.Text, "(attempt): 2") || !strings.Contains(work.Command.Text, `Решение уже устойчиво сохранено предыдущим turn: "go"`) ||
+		!strings.Contains(work.Command.Text, "Сохранённое состояние перед новым turn: cancelled") ||
+		!strings.Contains(work.Command.Text, "Техническая диагностика предыдущего turn этого посещения: остановлено") ||
+		!strings.Contains(work.Command.Text, "Сохранённое объяснение решения: продолжить") || !strings.Contains(work.Command.Text, "Не вызывай choose_decision повторно") {
+		t.Fatalf("resume потерял durable choice или добавил новый tool: %+v\n%s", work, work.Command.Text)
+	}
+}
+
+// TestPrepareAgentVisitsRejectsWrongRootLegacyAndToolCollision закрепляет
+// production gate и локальные ошибки до Reserve. Ни чужой root, ни v1 snapshot,
+// ни занятое служебное имя не должны оставить Pending visit в Starting.
+func TestPrepareAgentVisitsRejectsWrongRootLegacyAndToolCollision(t *testing.T) {
+	definition := `{
+  "version":2,"id":"guard","start":["choice"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{"done":{"finish":"succeeded"}}}
+  ]}`
+	root, initial, run := createAgentPreparationRun(t, definition)
+	if _, err := prepareAgentVisits(run, t.TempDir(), capacity.Unlimited(), false, nil, nil); err == nil {
+		t.Fatal("чужой root принят")
+	}
+	// Пустого чужого root недостаточно для регрессии split-brain: прежняя
+	// реализация и так падала на отсутствующем memory-файле. Строим правдоподобный
+	// двойник с тем же runId и всеми visitId — identity каталога всё равно должна
+	// не совпасть, а полученный capacity slot обязан остаться свободным.
+	lookalikeRoot := t.TempDir()
+	lookalikeMemory := filepath.Join(lookalikeRoot, initial.Meta.RunID, "memory")
+	if err := os.MkdirAll(lookalikeMemory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, visit := range initial.Meta.Visits {
+		if err := os.WriteFile(filepath.Join(lookalikeMemory, visit.VisitID+".md"), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pool, err := capacity.Configure(root, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareAgentVisits(run, lookalikeRoot, pool, false, nil, nil); err == nil || !strings.Contains(err.Error(), "не на открытый каталог") {
+		t.Fatalf("правдоподобный чужой root принят: %v", err)
+	}
+	lease, available, err := pool.TryAcquire()
+	if err != nil || !available {
+		t.Fatalf("отказ чужому root утёк capacity slot: available=%v, %v", available, err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	collision := func(_ runstore.Snapshot, command *codex.Command) {
+		command.DynamicTools = []codex.DynamicTool{{Name: chooseDecisionToolName, Description: "Подмена.", InputSchema: []byte(`{"type":"object"}`)}}
+		command.CallDynamicTool = func(context.Context, codex.DynamicToolCall) (string, error) { return "bad", nil }
+	}
+	if _, err := prepareAgentVisits(run, root, capacity.Unlimited(), false, nil, collision); err == nil || !strings.Contains(err.Error(), "служебное имя") {
+		t.Fatalf("коллизия choose_decision не отклонена: %v", err)
+	}
+	withoutHandler := func(_ runstore.Snapshot, command *codex.Command) {
+		command.DynamicTools = []codex.DynamicTool{{Name: "run_child", Description: "Без обработчика.", InputSchema: []byte(`{"type":"object"}`)}}
+	}
+	if _, err := prepareAgentVisits(run, root, capacity.Unlimited(), false, nil, withoutHandler); err == nil || !strings.Contains(err.Error(), "без обработчика") {
+		t.Fatalf("dynamic tool без исходного handler не отклонён: %v", err)
+	}
+	saved, err := run.Load()
+	if err != nil || saved.Meta.Visits[0].State != scheduler.Pending || saved.Meta.Visits[0].VisitID != initial.Meta.Visits[0].VisitID {
+		t.Fatalf("локальная ошибка зарезервировала visit: %+v, %v", saved.Meta.Visits, err)
+	}
+
+	legacyRoot := t.TempDir()
+	legacy, err := runstore.Create(legacyRoot, runstore.Input{
+		WorkflowJSON: []byte(`{"id":"legacy","steps":[{"id":"one","type":"agent","prompt":"Один","dependsOn":[]}]}`),
+		Task:         "Задача", CWD: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyRun, err := runstore.OpenLocked(legacyRoot, legacy.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer legacyRun.Close()
+	if _, err := prepareAgentVisits(legacyRun, legacyRoot, capacity.Unlimited(), false, nil, nil); err == nil {
+		t.Fatal("visit-aware prepare принял legacy run")
+	}
+	if _, err := prepareAgentVisits(nil, root, capacity.Unlimited(), false, nil, nil); err == nil {
+		t.Fatal("nil LockedRun принят")
+	}
+
+	// Отдельно проверяем файл памяти: symlink не становится доверенным даже если
+	// указывает на обычный файл. Load/prepare обязаны остановиться до reserve.
+	memory := filepath.Join(root, initial.Meta.RunID, "memory", initial.Meta.Visits[0].VisitID+".md")
+	if err := os.Remove(memory); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(root, initial.Meta.RunID, "task.md"), memory); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareAgentVisits(run, root, capacity.Unlimited(), false, nil, nil); err == nil {
+		t.Fatal("symlink вместо памяти принят")
+	}
+}
+
+// TestPrepareAgentVisitsRejectsSymlinkedMemoryDirectory проверяет предка всех
+// write-путей. Даже если каждый файл в целевом каталоге обычный, симлинк memory
+// не должен позволять вывести память агента из закреплённого дерева запуска.
+func TestPrepareAgentVisitsRejectsSymlinkedMemoryDirectory(t *testing.T) {
+	definition := `{
+  "version":2,"id":"memory-parent","start":["one"],"steps":[
+    {"id":"one","type":"agent","prompt":"Один","after":[]}
+  ]}`
+	root, initial, run := createAgentPreparationRun(t, definition)
+	runMemory := filepath.Join(root, initial.Meta.RunID, "memory")
+	// Цель находится внутри run, поэтому os.Root.Load способен пройти по ссылке.
+	// Это гарантирует, что отказ принадлежит именно проверке permission path, а
+	// не более ранней защите os.Root от выхода за границу запуска.
+	externalMemory := filepath.Join(root, initial.Meta.RunID, "memory-target")
+	if err := os.Mkdir(externalMemory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, visit := range initial.Meta.Visits {
+		source := filepath.Join(runMemory, visit.VisitID+".md")
+		target := filepath.Join(externalMemory, visit.VisitID+".md")
+		data, err := os.ReadFile(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = os.WriteFile(target, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.RemoveAll(runMemory); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Base(externalMemory), runMemory); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareAgentVisits(run, root, capacity.Unlimited(), false, nil, nil); err == nil || !strings.Contains(err.Error(), "каталог памяти") {
+		t.Fatalf("symlink-каталог memory принят: %v", err)
+	}
+	saved, err := run.Load()
+	if err != nil || saved.Meta.Visits[0].State != scheduler.Pending {
+		t.Fatalf("отказ symlink-каталогу зарезервировал visit: %+v, %v", saved.Meta.Visits, err)
+	}
+}

--- a/internal/runstore/locked.go
+++ b/internal/runstore/locked.go
@@ -116,6 +116,50 @@ func (r *LockedRun) Load() (Snapshot, error) {
 	return load(r.dir, r.runID)
 }
 
+// ResolveDirectory подтверждает, что root/runId обозначает тот же каталог,
+// который уже открыт и удерживается этим LockedRun, и возвращает его абсолютный
+// путь без симлинков в root. Одного совпадения runId и содержимого meta.json
+// недостаточно: в другом root может существовать похожий запуск, тогда
+// координатор записывал бы состояние через r.dir, а prompt и права агента
+// указывали бы в чужое дерево.
+//
+// Сам каталог runId обязан быть настоящим каталогом, а не симлинком. Симлинки в
+// пути до root допустимы и разворачиваются до выдачи пути наружу: это сохраняет
+// обычные пользовательские алиасы, но не оставляет в permission profile
+// неоднозначный путь. Проверка identity выполняется под mutex вместе с check,
+// чтобы закрытый или сломанный владелец не мог подтвердить новое обращение.
+func (r *LockedRun) ResolveDirectory(root string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.check(); err != nil {
+		return "", err
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("определить абсолютный root запуска: %w", err)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("разрешить root запуска: %w", err)
+	}
+	candidate := filepath.Join(resolvedRoot, r.runID)
+	candidateInfo, err := os.Lstat(candidate)
+	if err != nil {
+		return "", fmt.Errorf("проверить каталог запуска %q: %w", r.runID, err)
+	}
+	if !candidateInfo.IsDir() {
+		return "", fmt.Errorf("каталог запуска %q должен быть настоящим каталогом без симлинка", r.runID)
+	}
+	lockedInfo, err := r.dir.Stat(".")
+	if err != nil {
+		return "", fmt.Errorf("проверить открытый каталог запуска %q: %w", r.runID, err)
+	}
+	if !os.SameFile(candidateInfo, lockedInfo) {
+		return "", fmt.Errorf("root указывает не на открытый каталог запуска %q", r.runID)
+	}
+	return candidate, nil
+}
+
 // Update меняет только состояние и связь одного шага. Pending может перейти
 // только в Starting без ID: успешная запись этого намерения предшествует запросу
 // создания чата. Из Starting можно привязать подтверждённый/восстановленный ID;


### PR DESCRIPTION
## Что сделано

- Pending и возобновляемые Cancelled visits готовятся в едином FIFO по `visitId`;
- root-wide capacity захватывается до атомарного `ReserveVisits`, а все ошибочные пути освобождают leases;
- команда получает visit-aware prompt с iteration, attempt, причинными источниками, техническими статусами и отдельной памятью;
- права ограничивают запись собственной памятью visit и чтение деревом конкретного run;
- `LockedRun` связывает переданный root с inode реально открытого каталога; похожие чужие runs и symlink-подмены отклоняются;
- поверх уже настроенных `run_child`/`run_children` добавлен строгий `choose_decision` с детерминированным enum;
- выбор устойчиво коммитится по visit/thread/turn/call и точно воспроизводится при повторной доставке;
- Cancelled visit с сохранённым выбором продолжается без повторного выбора маршрута.

## Проверки

- `go test -count=1 ./...`
- `go test -count=1 -race ./internal/runstore ./internal/coordinator`
- `go vet ./...`
- `gofmt -d`
- `git diff --check`
- независимое ревью: исходный P1 split-brain root исправлен, повторный verdict `APPROVE`

## Размер

921 добавленная строка в трёх файлах. PR выше ориентира 500 строк, но ниже блокирующего предела 1200. Целостный результат связывает подготовку команды, права, capacity, durable reserve и decision tool; механическое разделение оставило бы незавершённую границу выполнения.

Production gate пока намеренно закрыт до подключения execution/reconcile-цикла.

Зависит от #76. Часть #50.