### PR TITLE
Защитить запуск от конфликтующего решения агента

### DIFF
--- a/internal/coordinator/agent_prepare.go
+++ b/internal/coordinator/agent_prepare.go
@@ -20,6 +20,16 @@ import (
 
 const chooseDecisionToolName = "choose_decision"
 
+var errAgentRunBecameTerminal = errors.New("agent-graph завершился во время подготовки")
+
+// agentTerminalPreparationError отделяет управляющий terminal-сигнал от ошибки
+// освобождения capacity. Execution обязан завершить и прервать active turn, а
+// затем присоединить Cleanup к итоговой диагностике, не маскируя её sentinel.
+type agentTerminalPreparationError struct{ Cleanup error }
+
+func (e *agentTerminalPreparationError) Error() string { return errAgentRunBecameTerminal.Error() }
+func (e *agentTerminalPreparationError) Unwrap() error { return errAgentRunBecameTerminal }
+
 // agentWorkKind отделяет создание нового Codex-чата от нового turn уже
 // сохранённого чата. Оба вида работы занимают одинаковый slot параллельности и
 // адресуются visitId; stepId после появления циклов перестаёт быть уникальным.
@@ -167,9 +177,28 @@ func prepareAgentVisits(
 		}
 	}
 	if err = run.ReserveVisits(reserved); err != nil {
+		releaseErr := releaseAgentWork(prepared.Work)
+		if errors.Is(err, runstore.ErrAgentDecisionPoisoned) {
+			advanced, advanceErr := run.AdvanceAgentGraph()
+			if advanceErr != nil {
+				return agentPreparation{}, errors.Join(
+					fmt.Errorf("координатор agent-graph: завершить конфликтующее решение: %w", advanceErr), releaseErr,
+				)
+			}
+			if advanced.Snapshot.Meta.RunState == runstore.RunRunning {
+				return agentPreparation{}, errors.Join(
+					errors.New("координатор agent-graph: planner не завершил конфликтующее решение"), releaseErr,
+				)
+			}
+			return agentPreparation{}, &agentTerminalPreparationError{Cleanup: releaseErr}
+		}
+		latest, loadErr := run.Load()
+		if loadErr == nil && latest.Meta.RunState != runstore.RunRunning {
+			return agentPreparation{}, &agentTerminalPreparationError{Cleanup: releaseErr}
+		}
 		return agentPreparation{}, errors.Join(
 			fmt.Errorf("координатор agent-graph: зарезервировать посещения: %w", err),
-			releaseAgentWork(prepared.Work),
+			releaseErr, loadErr,
 		)
 	}
 	return prepared, nil

--- a/internal/coordinator/agent_prepare_test.go
+++ b/internal/coordinator/agent_prepare_test.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	"context"
 	"encoding/json/v2"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -100,6 +101,47 @@ func TestPrepareAgentVisitsFIFOAndCapacity(t *testing.T) {
 	if err != nil || saved.Meta.Visits[1].State != scheduler.Starting || saved.Meta.Visits[1].CodexThreadID != "" {
 		t.Fatalf("launch не зарезервирован до сети: %+v, %v", saved.Meta.Visits, err)
 	}
+}
+
+// TestPrepareAgentVisitsFencesPoisonedContinuation воспроизводит конфликт,
+// появившийся после чтения Cancelled-кандидата, но до пустого ReserveVisits.
+// Даже волна без Pending обязана сначала сохранить failed и вернуть lease.
+func TestPrepareAgentVisitsFencesPoisonedContinuation(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"continuation-fence","start":["choice"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
+      "go":{"to":["target"]},"stop":{"finish":"failed"}}},
+    {"id":"target","type":"agent","prompt":"Цель","after":[]}
+  ]}`)
+	visitID := initial.Meta.Visits[0].VisitID
+	if err := run.ReserveVisits([]string{visitID}); err == nil {
+		completeAgentVisit(t, run, visitID, "chat-choice", scheduler.Cancelled, "остановлено")
+	} else {
+		t.Fatal(err)
+	}
+	if _, err := run.CommitDecision(visitID, "chat-choice", "turn-"+visitID, "go", "первый выбор", "call-first"); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := capacity.Configure(root, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	configure := func(_ runstore.Snapshot, _ *codex.Command) {
+		_, _ = run.CommitDecision(visitID, "chat-choice", "turn-"+visitID, "stop", "конфликт", "call-second")
+	}
+	prepared, err := prepareAgentVisits(run, root, pool, true, map[string]bool{}, configure)
+	if !errors.Is(err, errAgentRunBecameTerminal) || len(prepared.Work) != 0 {
+		t.Fatalf("poisoned continuation прошёл admission fence: %+v, %v", prepared, err)
+	}
+	saved, loadErr := run.Load()
+	if loadErr != nil || saved.Meta.RunState != runstore.RunFailed || saved.Meta.StopVisitID != visitID {
+		t.Fatalf("poison не завершён durable planner: %+v, %v", saved.Meta, loadErr)
+	}
+	lease, available, acquireErr := pool.TryAcquire()
+	if acquireErr != nil || !available {
+		t.Fatalf("terminal preparation удерживает capacity: available=%v, %v", available, acquireErr)
+	}
+	t.Cleanup(func() { _ = lease.Release() })
 }
 
 // TestAgentPromptContainsDurableVisitContext фиксирует полезный агенту контекст:

--- a/internal/runstore/visits_locked.go
+++ b/internal/runstore/visits_locked.go
@@ -13,16 +13,29 @@ import (
 	"github.com/stray-live-pixel/Lawa/internal/workflow"
 )
 
+// ErrAgentDecisionPoisoned сообщает coordinator, что после последнего planning
+// commit появился конфликт решения. Новую работу резервировать нельзя: сначала
+// AdvanceAgentGraph обязан атомарно сохранить terminal outcome.
+var ErrAgentDecisionPoisoned = errors.New("agent-graph содержит конфликтующее решение")
+
 // ReserveVisits атомарно фиксирует намерение запустить всю волну Pending-visits.
 // Метод принимает только visitId: stepId неоднозначен после первого прохода
 // цикла. До успешной публикации metadata сетевые запросы делать нельзя.
 func (r *LockedRun) ReserveVisits(visitIDs []string) error {
 	return r.mutateVisits((*os.File).Sync, func(s *Snapshot) (bool, error) {
-		if len(visitIDs) == 0 {
-			return false, nil
-		}
 		if s.Meta.RunState != RunRunning {
 			return false, fmt.Errorf("завершённый run не принимает новые посещения")
+		}
+		// Decision callback может завершиться между AdvanceAgentGraph и этим
+		// commit. Проверка выполняется даже для волны одних continuation: иначе
+		// пустой список позволил бы отправить новый turn после durable poison.
+		for _, visit := range s.Meta.Visits {
+			if visit.Decision != nil && visit.Decision.Error != "" {
+				return false, ErrAgentDecisionPoisoned
+			}
+		}
+		if len(visitIDs) == 0 {
+			return false, nil
 		}
 		indices := visitIndices(s.Meta.Visits)
 		seen := make(map[string]bool, len(visitIDs))
@@ -191,9 +204,11 @@ func (r *LockedRun) commitDecision(visitID, chat, turnID, key, explanation, call
 		}
 		conflict := fmt.Errorf("посещение %q уже сохранило другое решение", visitID)
 		// После применения или terminal нельзя менять даже диагностику. До этой
-		// границы сохраняем безопасный poison marker, чтобы resume не применил
+		// границы одним commit сохраняем poison marker, чтобы resume не применил
 		// первый маршрут после обнаруженного второго противоречивого tool call.
-		if visitTerminal(visit.State) || existing.Applied || existing.Error != "" {
+		// RunState меняет planner: callback не вправе завершить run, пока соседний
+		// уже созданный Codex-turn ещё сохраняет свой ID для адресного interrupt.
+		if s.Meta.RunState != RunRunning || visitTerminal(visit.State) || existing.Applied || existing.Error != "" {
 			return existing, conflict
 		}
 		existing.Error = "агент повторно вызвал решение с другим callId или payload"

--- a/internal/runstore/visits_locked_test.go
+++ b/internal/runstore/visits_locked_test.go
@@ -127,8 +127,16 @@ func TestCommitDecisionIdempotency(t *testing.T) {
 		t.Fatal("второе противоречивое решение принято")
 	}
 	stored, err := run.Load()
-	if err != nil || stored.Meta.Visits[0].Decision.Key != "go" || stored.Meta.Visits[0].Decision.To[0] != "work" || stored.Meta.Visits[0].Decision.Error == "" {
+	if err != nil || stored.Meta.Visits[0].Decision.Key != "go" || stored.Meta.Visits[0].Decision.To[0] != "work" || stored.Meta.Visits[0].Decision.Error == "" ||
+		stored.Meta.RunState != RunRunning || stored.Meta.StopVisitID != "" {
 		t.Fatalf("первый маршрут или poison marker потерян: %+v, %v", stored.Meta.Visits[0].Decision, err)
+	}
+	if err := run.ReserveVisits(nil); !errors.Is(err, ErrAgentDecisionPoisoned) {
+		t.Fatalf("poison не остановил пустую волну continuation: %v", err)
+	}
+	advanced, err := run.AdvanceAgentGraph()
+	if err != nil || advanced.Snapshot.Meta.RunState != RunFailed || advanced.Snapshot.Meta.StopVisitID != visitID {
+		t.Fatalf("planner не сохранил terminal poison: %+v, %v", advanced.Snapshot.Meta, err)
 	}
 	if err := run.UpdateVisit(visitID, scheduler.Succeeded, "chat", ""); err != nil {
 		t.Fatalf("технический результат poisoned turn не сохранён: %v", err)


### PR DESCRIPTION
Часть #50, stacked поверх #77.

Что сделано:
- конфликтующий повтор choose_decision сохраняется как durable poison, но не завершает run из callback до привязки соседних turn;
- ReserveVisits атомарно запрещает и Pending-запуски, и continuation-only волну после poison;
- подготовка применяет fatal planner, возвращает capacity leases и отдельно переносит cleanup error в execution;
- добавлены регрессии для пустой continuation-волны и durable terminal.

Проверено:
- go test -race -count=1 ./internal/coordinator ./internal/runstore
- go vet ./internal/coordinator ./internal/runstore
- git diff --check
- независимое ревью: APPROVE

Размер: 108 изменённых строк (101 добавлена, 7 удалено). Merge не выполнялся.