### PR TITLE
Подключить выполнение agent-графа

### DIFF
--- a/internal/coordinator/agent_execute.go
+++ b/internal/coordinator/agent_execute.go
@@ -1,0 +1,545 @@
+package coordinator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/stray-live-pixel/Lawa/internal/codex"
+	"github.com/stray-live-pixel/Lawa/internal/runstore"
+	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+)
+
+// agentLaunchResult адресуется только visitId. StepId намеренно отсутствует в
+// ключе: последующие итерации одного кубика являются разными исполнениями.
+type agentLaunchResult struct {
+	visitID string
+	result  codex.Result
+	err     error
+}
+
+// executeAgentGraph исполняет workflow v2 поверх append-only meta v4; допустимые
+// формы графа и пределы повторных посещений остаются ответственностью planner.
+// На каждой итерации сначала сверяются уже известные чаты, затем одним durable
+// commit применяется чистый план и лишь после этого резервируется новая работа.
+// Такой порядок не позволяет crash-resume повторно материализовать маршрут или
+// запустить Pending, если более раннее решение уже завершило весь run.
+func executeAgentGraph(ctx context.Context, run *runstore.LockedRun, options Options, initial runstore.Snapshot) (outcome Outcome, err error) {
+	observer := &sharedObserver{ctx: ctx, client: options.Client, cwd: initial.Meta.CWD}
+	defer func() { err = errors.Join(err, observer.Close()) }()
+
+	// В корректной metadata одновременно активно не больше одного visit каждого
+	// step, поэтому числа кубиков достаточно, чтобы завершение горутин никогда не
+	// зависело от читающего coordinator во время аварийного drain.
+	results := make(chan agentLaunchResult, max(1, len(initial.Workflow.Steps)))
+	active := map[string]*activeExecution{}
+	continued := map[string]bool{}
+	defer func() {
+		if cause := ctx.Err(); len(active) != 0 && (cause != nil || err != nil) {
+			err = interruptAgentActive(errors.Join(err, cause), run, active, results)
+		} else if len(active) != 0 {
+			err = drainAgentActive(err, run, active, results)
+		}
+		// Любая ошибка сначала останавливает и сохраняет все локальные turn. После
+		// этого callbacks уже не могут добавить новый poison, поэтому recovery
+		// детерминированно предпочитает durable conflict исходной transport-ошибке.
+		if err == nil || outcome.Terminal {
+			return
+		}
+		snapshot, loadErr := run.Load()
+		if loadErr != nil || !agentSnapshotPoisoned(snapshot) {
+			err = errors.Join(err, loadErr)
+			return
+		}
+		advanced, advanceErr := run.AdvanceAgentGraph()
+		if advanceErr != nil || advanced.Snapshot.Meta.RunState == runstore.RunRunning {
+			err = errors.Join(err, advanceErr, errors.New("координатор agent-graph: не удалось завершить сохранённый конфликт после остановки turn"))
+			return
+		}
+		terminalOutcome, terminalErr := finishAgentGraph(run, options, active, results)
+		outcome, err = terminalOutcome, errors.Join(err, terminalErr)
+	}()
+
+	pollTicker := options.NewTicker(options.PollInterval)
+	refreshTicker := options.NewTicker(options.RefreshInterval)
+	defer pollTicker.Stop()
+	defer refreshTicker.Stop()
+	lastStatus, periodicRefreshDue := "", false
+
+	for {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return outcome, ctxErr
+		}
+		snapshot, loadErr := run.Load()
+		if loadErr != nil {
+			return outcome, fmt.Errorf("координатор agent-graph: прочитать запуск: %w", loadErr)
+		}
+		if snapshot.Meta.RunState != runstore.RunRunning {
+			return finishAgentGraph(run, options, active, results)
+		}
+		// Poison имеет приоритет над неопределённым Starting после crash. Он уже
+		// доказывает failed всего run, поэтому повторять незавершённое создание не
+		// требуется: planner сначала публикует terminal и запрещает любую сеть.
+		if agentSnapshotPoisoned(snapshot) {
+			advanced, advanceErr := run.AdvanceAgentGraph()
+			if advanceErr != nil {
+				return outcome, fmt.Errorf("координатор agent-graph: завершить сохранённый конфликт: %w", advanceErr)
+			}
+			if advanced.Snapshot.Meta.RunState == runstore.RunRunning {
+				return outcome, errors.New("координатор agent-graph: planner не завершил сохранённый конфликт")
+			}
+			return finishAgentGraph(run, options, active, results)
+		}
+		if rejectErr := rejectAgentAmbiguous(snapshot, active); rejectErr != nil {
+			return outcome, rejectErr
+		}
+		if reconcileErr := reconcileAgentVisits(run, observer, active, continued); reconcileErr != nil {
+			return outcome, reconcileErr
+		}
+
+		advanced, advanceErr := run.AdvanceAgentGraph()
+		if advanceErr != nil {
+			return outcome, fmt.Errorf("координатор agent-graph: продвинуть граф: %w", advanceErr)
+		}
+		if advanced.Snapshot.Meta.RunState != runstore.RunRunning {
+			return finishAgentGraph(run, options, active, results)
+		}
+		prepared, prepareErr := prepareAgentVisits(
+			run, options.Root, options.Capacity, options.ContinueInterrupted, continued, options.ConfigureCommand,
+		)
+		if prepareErr != nil {
+			var terminalPrepare *agentTerminalPreparationError
+			if errors.As(prepareErr, &terminalPrepare) {
+				terminalOutcome, terminalErr := finishAgentGraph(run, options, active, results)
+				return terminalOutcome, errors.Join(terminalErr, terminalPrepare.Cleanup)
+			}
+			return outcome, prepareErr
+		}
+		for _, work := range prepared.Work {
+			turnCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+			execution := newActiveExecution(cancel, work.ThreadID, work.lease)
+			active[work.VisitID] = execution
+			if work.kind == agentWorkContinuation {
+				// Флаг публикуется только после регистрации active: с этого места
+				// lease и результат принадлежат общему shutdown-протоколу.
+				continued[work.VisitID] = true
+			}
+			startAgentWork(run, options.Client, turnCtx, work, execution, results)
+		}
+		// Все запросы одной уже зарезервированной волны должны пройти границу
+		// OnTurn (либо завершиться раньше), прежде чем coordinator применит finish
+		// из быстрого соседа. Иначе RunState успел бы стать terminal, а поздний
+		// SetVisitTurn параллельного visit уже нельзя было бы сохранить и адресно
+		// прервать. Это не сериализует сами turn: ожидание идёт после их запуска.
+		if readyErr := waitAgentExecutionsReady(ctx, active); readyErr != nil {
+			return outcome, readyErr
+		}
+
+		status, signature, statusErr := currentStatus(run)
+		if statusErr != nil {
+			return outcome, statusErr
+		}
+		status.WaitingForCapacity = append([]string(nil), prepared.WaitingForCapacity...)
+		signature += ";capacity=" + strings.Join(status.WaitingForCapacity, ",")
+		if signature != lastStatus || periodicRefreshDue {
+			if options.Notify != nil {
+				if notifyErr := options.Notify(status); notifyErr != nil {
+					return outcome, fmt.Errorf("координатор agent-graph: сообщить статус: %w", notifyErr)
+				}
+			}
+			lastStatus, periodicRefreshDue = signature, false
+		}
+
+		select {
+		case <-ctx.Done():
+			return outcome, ctx.Err()
+		case completed := <-results:
+			releaseErr := finishAgentExecution(active, completed.visitID)
+			saveErr := saveAgentLaunchResult(run, completed)
+			if resultErr := errors.Join(releaseErr, saveErr); resultErr != nil {
+				return outcome, fmt.Errorf("координатор agent-graph: завершить посещение %q: %w", completed.visitID, resultErr)
+			}
+		case <-pollTicker.C():
+		case <-refreshTicker.C():
+			periodicRefreshDue = true
+		}
+	}
+}
+
+// agentSnapshotPoisoned распознаёт только уже durable конфликт tool calls.
+func agentSnapshotPoisoned(snapshot runstore.Snapshot) bool {
+	for _, visit := range snapshot.Meta.Visits {
+		if visit.Decision != nil && visit.Decision.Error != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// waitAgentExecutionsReady закрывает гонку между двумя уже запущенными запросами:
+// возврат означает, что каждый из них либо сохранил turnId, либо уже дал Result.
+func waitAgentExecutionsReady(ctx context.Context, active map[string]*activeExecution) error {
+	for _, execution := range active {
+		select {
+		case <-execution.ready:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// finishAgentGraph прекращает оставшиеся параллельные turn после уже durable
+// terminal outcome. Их Cancelled/terminal результаты сохраняются для аудита,
+// но не могут изменить RunState или породить новые маршруты.
+func finishAgentGraph(run *runstore.LockedRun, options Options, active map[string]*activeExecution, results <-chan agentLaunchResult) (Outcome, error) {
+	snapshot, err := run.Load()
+	if err != nil {
+		return Outcome{}, fmt.Errorf("координатор agent-graph: прочитать terminal run: %w", err)
+	}
+	outcome := Outcome{Terminal: true, Successful: snapshot.Meta.RunState == runstore.RunSucceeded}
+	if len(active) != 0 {
+		err = interruptAgentActive(err, run, active, results)
+	}
+	status, _, statusErr := currentStatus(run)
+	err = errors.Join(err, statusErr)
+	if statusErr == nil && options.Notify != nil {
+		err = errors.Join(err, options.Notify(status))
+	}
+	if !outcome.Successful {
+		err = errors.Join(err, ErrRunUnsuccessful)
+	}
+	return outcome, err
+}
+
+// rejectAgentAmbiguous распознаёт только потерянный ответ создания после
+// рестарта. Локальная горутина остаётся в active и сама докажет через Result,
+// можно ли безопасно снять резервирование.
+func rejectAgentAmbiguous(snapshot runstore.Snapshot, active map[string]*activeExecution) error {
+	for _, visit := range snapshot.Meta.Visits {
+		if visit.State == scheduler.Starting && visit.CodexThreadID == "" && active[visit.VisitID] == nil {
+			return fmt.Errorf("координатор agent-graph: посещение %q шага %q: %w; сохранено Starting без codexThreadId — "+
+				"Codex мог создать чат, поэтому автоматический повтор запрещён; сообщите runId и visitId для диагностики",
+				visit.VisitID, visit.StepID, ErrAmbiguousStart)
+		}
+	}
+	return nil
+}
+
+// reconcileAgentVisits читает только неактивные и ещё не терминальные чаты.
+// Новый turn сначала сохраняется через SetVisitTurn и лишь затем его состояние:
+// crash между commit сохраняет Unknown/Cancelled, но никогда Succeeded без
+// доказанного turnId. Обнаруженный внешний turn считается продолжением этого
+// процесса и не разрешает вслед за ним отправить второй автоматический continue.
+func reconcileAgentVisits(run *runstore.LockedRun, observer Observer, active map[string]*activeExecution, continued map[string]bool) error {
+	snapshot, err := run.Load()
+	if err != nil {
+		return fmt.Errorf("координатор agent-graph: прочитать запуск перед сверкой: %w", err)
+	}
+	for _, visit := range snapshot.Meta.Visits {
+		if visit.CodexThreadID == "" || active[visit.VisitID] != nil || visit.State == scheduler.Succeeded || visit.State == scheduler.Failed ||
+			visit.Decision != nil && visit.Decision.Error != "" {
+			continue
+		}
+		observation, inspectErr := observer.Inspect(visit.CodexThreadID)
+		if inspectErr != nil {
+			return fmt.Errorf("координатор agent-graph: прочитать чат посещения %q: %w", visit.VisitID, inspectErr)
+		}
+		workStatus, statusErr := observation.Status()
+		if statusErr != nil {
+			return fmt.Errorf("координатор agent-graph: прочитать статус посещения %q: %w", visit.VisitID, statusErr)
+		}
+		state, stateErr := stateFromObservation(workStatus)
+		if stateErr != nil {
+			return fmt.Errorf("координатор agent-graph: посещение %q: %w", visit.VisitID, stateErr)
+		}
+		oldState := visit.State
+		if oldState == scheduler.Starting {
+			if err = run.UpdateVisit(visit.VisitID, scheduler.Unknown, visit.CodexThreadID, ""); err != nil {
+				return fmt.Errorf("координатор agent-graph: восстановить связь посещения %q: %w", visit.VisitID, err)
+			}
+			oldState = scheduler.Unknown
+		}
+		turnChanged := observation.LatestTurnID != "" && observation.LatestTurnID != visit.TurnID
+		if turnChanged {
+			if err = run.SetVisitTurn(visit.VisitID, observation.LatestTurnID); err != nil {
+				return fmt.Errorf("координатор agent-graph: сохранить внешний turn посещения %q: %w", visit.VisitID, err)
+			}
+			continued[visit.VisitID] = true
+		}
+		if observation.LatestTurnID == "" && (state == scheduler.Running || state == scheduler.WaitingForApproval || state == scheduler.Succeeded) {
+			return fmt.Errorf("координатор agent-graph: чат посещения %q сообщил %s без turnId", visit.VisitID, state)
+		}
+		diagnostic := agentTechnicalError(observation.LatestTurnError, nil)
+		if state != scheduler.Unknown && state != scheduler.Failed && state != scheduler.Cancelled {
+			diagnostic = ""
+		}
+		if state != oldState || turnChanged || diagnostic != visit.TechnicalError {
+			if err = run.UpdateVisit(visit.VisitID, state, visit.CodexThreadID, diagnostic); err != nil {
+				return fmt.Errorf("координатор agent-graph: сохранить сверку посещения %q: %w", visit.VisitID, err)
+			}
+			if err = run.AppendEvent(runstore.RuntimeEvent{
+				VisitID: visit.VisitID, StepID: visit.StepID, ThreadID: visit.CodexThreadID,
+				TurnID: observation.LatestTurnID, Kind: "thread_reconciled", State: string(state), Message: diagnostic,
+			}); err != nil {
+				return fmt.Errorf("координатор agent-graph: сохранить событие сверки посещения %q: %w", visit.VisitID, err)
+			}
+		}
+	}
+	return nil
+}
+
+// startAgentWork устанавливает callbacks одинаково для нового чата и continue.
+// Durable thread связывается до turn, durable turn — до Running и результата.
+func startAgentWork(run *runstore.LockedRun, client Client, ctx context.Context, work agentWork, execution *activeExecution, results chan<- agentLaunchResult) {
+	go func() {
+		defer execution.finish()
+		command := work.Command
+		threadID, turnID := work.ThreadID, ""
+		command.OnProcess = func(process codex.ProcessEvent) error {
+			return appendAgentProcessEvent(run, work.VisitID, work.StepID, threadID, turnID, process)
+		}
+		if work.kind == agentWorkLaunch {
+			command.OnThread = func(id string) error {
+				threadID = id
+				if err := run.UpdateVisit(work.VisitID, scheduler.Unknown, id, ""); err != nil {
+					return err
+				}
+				execution.setThread(id)
+				return run.AppendEvent(runstore.RuntimeEvent{VisitID: work.VisitID, StepID: work.StepID, ThreadID: id, Kind: "thread_started"})
+			}
+		}
+		command.OnTurn = func(id string, interrupt func(context.Context) error) error {
+			turnID = id
+			if err := run.SetVisitTurn(work.VisitID, id); err != nil {
+				return err
+			}
+			execution.setTurn(id, interrupt)
+			return run.AppendEvent(runstore.RuntimeEvent{VisitID: work.VisitID, StepID: work.StepID, ThreadID: threadID, TurnID: id, Kind: "turn_bound"})
+		}
+		command.Notify = func(event codex.Event) error {
+			if event.Method == "turn/started" {
+				if err := run.UpdateVisit(work.VisitID, scheduler.Running, threadID, ""); err != nil {
+					return err
+				}
+			}
+			return appendAgentCodexEvent(run, work.VisitID, work.StepID, threadID, turnID, event)
+		}
+		var result codex.Result
+		var err error
+		if work.kind == agentWorkContinuation {
+			result, err = client.Continue(ctx, work.ThreadID, command)
+		} else {
+			result, err = client.Run(ctx, command)
+		}
+		// ID из callback надёжнее частично заполненного результата с ошибкой и
+		// сохраняет durable-связь даже у упрощённого тестового транспорта.
+		if result.ThreadID == "" {
+			result.ThreadID = threadID
+		}
+		if result.TurnID == "" {
+			result.TurnID = turnID
+		}
+		results <- agentLaunchResult{visitID: work.VisitID, result: result, err: err}
+	}()
+}
+
+// saveAgentLaunchResult сохраняет известные IDs до состояния. Единственная
+// безопасная отмена Starting — локально подтверждённый CreationAttempted=false;
+// после потери ответа thread/start повтор остаётся неоднозначным.
+func saveAgentLaunchResult(run *runstore.LockedRun, completed agentLaunchResult) error {
+	result, runErr := completed.result, completed.err
+	if result.ThreadID == "" {
+		if result.CreationAttempted {
+			return fmt.Errorf("координатор agent-graph: посещение %q: %w; Codex мог создать чат, но не вернул его ID", completed.visitID, ErrAmbiguousStart)
+		}
+		if runErr == nil {
+			runErr = errors.New("Codex завершил операцию без результата и без причины")
+		}
+		failure := fmt.Errorf("координатор agent-graph: посещение %q: Codex не начал создание чата: %w", completed.visitID, runErr)
+		if releaseErr := run.ReleaseUnattemptedVisit(completed.visitID); releaseErr != nil {
+			return errors.Join(failure, fmt.Errorf("вернуть посещение в Pending: %w; автоматический повтор запрещён", releaseErr))
+		}
+		return fmt.Errorf("%w; посещение возвращено в Pending — повторите явный resume", failure)
+	}
+
+	snapshot, err := run.Load()
+	if err != nil {
+		return fmt.Errorf("координатор agent-graph: прочитать посещение %q перед результатом: %w", completed.visitID, err)
+	}
+	visit, exists := agentVisitByID(snapshot, completed.visitID)
+	if !exists {
+		return fmt.Errorf("координатор agent-graph: нет посещения %q", completed.visitID)
+	}
+	if visit.CodexThreadID == "" {
+		if err = run.UpdateVisit(completed.visitID, scheduler.Unknown, result.ThreadID, ""); err != nil {
+			return fmt.Errorf("координатор agent-graph: сохранить чат посещения %q: %w", completed.visitID, err)
+		}
+		visit.CodexThreadID = result.ThreadID
+	}
+	if result.TurnID != "" && result.TurnID != visit.TurnID {
+		if err = run.SetVisitTurn(completed.visitID, result.TurnID); err != nil {
+			return fmt.Errorf("координатор agent-graph: сохранить turn посещения %q: %w", completed.visitID, err)
+		}
+		visit.TurnID = result.TurnID
+	}
+
+	state := scheduler.Unknown
+	if runErr == nil {
+		state, err = stateFromResult(result)
+		if err != nil {
+			runErr = err
+			state = scheduler.Unknown
+		}
+	} else {
+		var interaction *codex.InteractionRequired
+		if errors.As(runErr, &interaction) {
+			state = scheduler.WaitingForApproval
+		}
+	}
+	if visit.TurnID == "" && (state == scheduler.Running || state == scheduler.WaitingForApproval || state == scheduler.Succeeded || state == scheduler.Failed || state == scheduler.Cancelled) {
+		state = scheduler.Unknown
+		if runErr == nil {
+			runErr = errors.New("Codex вернул terminal status без turnId")
+		}
+	}
+	diagnostic := agentTechnicalError(result.TurnError, runErr)
+	if state != scheduler.Unknown && state != scheduler.Failed && state != scheduler.Cancelled {
+		diagnostic = ""
+	}
+	if err = run.UpdateVisit(completed.visitID, state, result.ThreadID, diagnostic); err != nil {
+		return fmt.Errorf("координатор agent-graph: сохранить результат посещения %q: %w", completed.visitID, err)
+	}
+	event := runstore.RuntimeEvent{
+		VisitID: completed.visitID, StepID: visit.StepID, ThreadID: result.ThreadID, TurnID: visit.TurnID,
+		Kind: "visit_state", State: string(state), Message: diagnostic,
+	}
+	if err = run.AppendEvent(event); err != nil {
+		return fmt.Errorf("координатор agent-graph: сохранить событие результата посещения %q: %w", completed.visitID, err)
+	}
+	if runErr != nil && state != scheduler.WaitingForApproval {
+		return fmt.Errorf("координатор agent-graph: посещение %q, чат %q: %w", completed.visitID, result.ThreadID, runErr)
+	}
+	return nil
+}
+
+// agentVisitByID ищет точное посещение в append-only порядке snapshot.
+func agentVisitByID(snapshot runstore.Snapshot, visitID string) (runstore.Visit, bool) {
+	for _, visit := range snapshot.Meta.Visits {
+		if visit.VisitID == visitID {
+			return visit, true
+		}
+	}
+	return runstore.Visit{}, false
+}
+
+// agentTechnicalError превращает внешнюю диагностику в однострочное безопасное
+// поле meta. Raw codexErrorInfo не сохраняется: оно расширяемо и может содержать
+// произвольный payload. Рунная обрезка сохраняет корректный UTF-8.
+func agentTechnicalError(turnError *codex.TurnError, cause error) string {
+	parts := make([]string, 0, 3)
+	if turnError != nil {
+		parts = append(parts, turnError.Message)
+		if turnError.AdditionalDetails != nil {
+			parts = append(parts, *turnError.AdditionalDetails)
+		}
+	}
+	if cause != nil {
+		parts = append(parts, cause.Error())
+	}
+	var safe strings.Builder
+	for _, character := range strings.Join(parts, ": ") {
+		if unicode.IsControl(character) {
+			fmt.Fprintf(&safe, `\u%04X`, character)
+		} else {
+			safe.WriteRune(character)
+		}
+	}
+	value := strings.TrimSpace(safe.String())
+	const limit, suffix = 4096, "…"
+	if len(value) <= limit {
+		return value
+	}
+	cut := limit - len(suffix)
+	for cut > 0 && !utf8.RuneStart(value[cut]) {
+		cut--
+	}
+	return value[:cut] + suffix
+}
+
+// finishAgentExecution единожды снимает локальное владение turn и его lease.
+// Повторный поздний результат для уже удалённого ID не освобождает чужой slot.
+func finishAgentExecution(active map[string]*activeExecution, visitID string) error {
+	if execution := active[visitID]; execution != nil {
+		execution.cancel()
+		delete(active, visitID)
+		return execution.lease.Release()
+	}
+	return nil
+}
+
+// drainAgentActive сохраняет все уже запущенные результаты при внутренней ошибке,
+// не наблюдая чаты и не планируя новые переходы.
+func drainAgentActive(cause error, run *runstore.LockedRun, active map[string]*activeExecution, results <-chan agentLaunchResult) error {
+	for len(active) != 0 {
+		completed := <-results
+		cause = errors.Join(cause, finishAgentExecution(active, completed.visitID))
+		cause = errors.Join(cause, saveAgentLaunchResult(run, completed))
+	}
+	return cause
+}
+
+// interruptAgentActive повторяет проверенный legacy shutdown-протокол, но все
+// карты и ошибки адресует visitId. Lease освобождается только при удалении из
+// active, поэтому результат и timeout не могут вернуть один slot дважды.
+func interruptAgentActive(cause error, run *runstore.LockedRun, active map[string]*activeExecution, results <-chan agentLaunchResult) error {
+	shutdown, cancel := context.WithTimeout(context.Background(), interruptGracePeriod)
+	defer cancel()
+	interrupts := make(chan interruptResult, len(active))
+	for visitID, execution := range active {
+		go func(visitID string, execution *activeExecution) {
+			select {
+			case <-execution.ready:
+				threadID, turnID, interrupt, done := execution.snapshot()
+				if done {
+					interrupts <- interruptResult{stepID: visitID}
+					return
+				}
+				if threadID == "" || turnID == "" || interrupt == nil {
+					interrupts <- interruptResult{stepID: visitID, err: errors.New("активный turn не передал interrupt исходной сессии")}
+					return
+				}
+				interrupts <- interruptResult{stepID: visitID, err: interrupt(shutdown)}
+			case <-shutdown.Done():
+				interrupts <- interruptResult{stepID: visitID, err: shutdown.Err()}
+			}
+		}(visitID, execution)
+	}
+
+	interruptErrors := make(map[string]error, len(active))
+	for len(active) != 0 {
+		select {
+		case completed := <-results:
+			cause = errors.Join(cause, finishAgentExecution(active, completed.visitID))
+			delete(interruptErrors, completed.visitID)
+			cause = errors.Join(cause, saveAgentLaunchResult(run, completed))
+		case interrupted := <-interrupts:
+			if interrupted.err != nil && active[interrupted.stepID] != nil {
+				interruptErrors[interrupted.stepID] = interrupted.err
+			}
+		case <-shutdown.Done():
+			cause = errors.Join(cause, fmt.Errorf("координатор agent-graph: остановить активные turn: %w", shutdown.Err()))
+			for visitID, execution := range active {
+				if interruptErr := interruptErrors[visitID]; interruptErr != nil {
+					cause = errors.Join(cause, fmt.Errorf("координатор agent-graph: отменить turn посещения %q: %w", visitID, interruptErr))
+				}
+				execution.cancel()
+			}
+			return drainAgentActive(cause, run, active, results)
+		}
+	}
+	return cause
+}

--- a/internal/coordinator/agent_execute_test.go
+++ b/internal/coordinator/agent_execute_test.go
@@ -1,0 +1,568 @@
+package coordinator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stray-live-pixel/Lawa/internal/capacity"
+	"github.com/stray-live-pixel/Lawa/internal/codex"
+	"github.com/stray-live-pixel/Lawa/internal/runstore"
+	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+)
+
+// agentExecutionClient моделирует границы Codex по visitId, извлечённому из
+// служебного prompt. Это принципиально для тестов v4: stepId может повториться,
+// а thread/turn и счётчики должны оставаться раздельными.
+type agentExecutionClient struct {
+	mu                                    sync.Mutex
+	statuses, choices, secondChoices      map[string]string
+	turnErrors                            map[string]*codex.TurnError
+	resultErrors                          map[string]error
+	beforeCreate                          map[string][]error
+	releases, beforeTurn                  map[string]chan struct{}
+	released, interrupted                 map[string]bool
+	observations                          map[string]codex.Observation
+	runs, continues, interrupts, toolSets map[string]int
+	started                               chan string
+}
+
+func newAgentExecutionClient() *agentExecutionClient {
+	return &agentExecutionClient{
+		statuses: map[string]string{}, choices: map[string]string{}, secondChoices: map[string]string{}, turnErrors: map[string]*codex.TurnError{}, resultErrors: map[string]error{},
+		beforeCreate: map[string][]error{}, releases: map[string]chan struct{}{}, beforeTurn: map[string]chan struct{}{}, released: map[string]bool{},
+		interrupted: map[string]bool{}, observations: map[string]codex.Observation{}, runs: map[string]int{},
+		continues: map[string]int{}, interrupts: map[string]int{}, toolSets: map[string]int{}, started: make(chan string, 32),
+	}
+}
+
+func (c *agentExecutionClient) Run(ctx context.Context, command codex.Command) (codex.Result, error) {
+	return c.execute(ctx, "", command, true)
+}
+
+func (c *agentExecutionClient) Continue(ctx context.Context, threadID string, command codex.Command) (codex.Result, error) {
+	return c.execute(ctx, threadID, command, false)
+}
+
+func (c *agentExecutionClient) execute(ctx context.Context, threadID string, command codex.Command, create bool) (codex.Result, error) {
+	visitID, stepID := agentPromptField(command.Text, "visitId"), agentPromptField(command.Text, "stepId")
+	c.mu.Lock()
+	if create {
+		c.runs[stepID]++
+	} else {
+		c.continues[stepID]++
+	}
+	attempt := c.runs[stepID] + c.continues[stepID]
+	before := c.beforeCreate[stepID]
+	if create && len(before) != 0 {
+		c.beforeCreate[stepID] = before[1:]
+		c.mu.Unlock()
+		return codex.Result{}, before[0]
+	}
+	if threadID == "" {
+		threadID = "chat-" + visitID
+	}
+	turnID := fmt.Sprintf("turn-%s-%d", visitID, attempt)
+	status := c.statuses[stepID]
+	if status == "" {
+		status = "completed"
+	}
+	choice, secondChoice, turnError, resultError := c.choices[stepID], c.secondChoices[stepID], c.turnErrors[stepID], c.resultErrors[stepID]
+	release, beforeTurn := c.releases[stepID], c.beforeTurn[stepID]
+	c.toolSets[stepID] += len(command.DynamicTools)
+	c.mu.Unlock()
+
+	result := codex.Result{ThreadID: threadID, TurnID: turnID, CreationAttempted: create, TurnAttempted: true}
+	if create && command.OnThread != nil {
+		if err := command.OnThread(threadID); err != nil {
+			return result, err
+		}
+	}
+	if beforeTurn != nil {
+		select {
+		case <-beforeTurn:
+		case <-ctx.Done():
+			return result, ctx.Err()
+		}
+	}
+	if command.OnTurn != nil {
+		if err := command.OnTurn(turnID, func(interruptCtx context.Context) error {
+			if err := interruptCtx.Err(); err != nil {
+				return err
+			}
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			c.interrupts[stepID]++
+			c.interrupted[stepID] = true
+			if release != nil && !c.released[stepID] {
+				close(release)
+				c.released[stepID] = true
+			}
+			return nil
+		}); err != nil {
+			return result, err
+		}
+	}
+	if command.Notify != nil {
+		if err := command.Notify(codex.Event{Method: "turn/started"}); err != nil {
+			return result, err
+		}
+	}
+	if choice != "" {
+		if command.CallDynamicTool == nil {
+			return result, errors.New("choose_decision не настроен")
+		}
+		arguments, _ := json.Marshal(map[string]string{"decision": choice, "explanation": "выбрано тестом"})
+		if _, err := command.CallDynamicTool(ctx, codex.DynamicToolCall{
+			ThreadID: threadID, TurnID: turnID, CallID: "call-" + visitID, Tool: chooseDecisionToolName, Arguments: arguments,
+		}); err != nil {
+			return result, err
+		}
+		if secondChoice != "" {
+			arguments, _ = json.Marshal(map[string]string{"decision": secondChoice, "explanation": "повторный выбор"})
+			_, _ = command.CallDynamicTool(ctx, codex.DynamicToolCall{
+				ThreadID: threadID, TurnID: turnID, CallID: "call-second-" + visitID, Tool: chooseDecisionToolName, Arguments: arguments,
+			})
+		}
+	}
+	c.started <- stepID
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return result, ctx.Err()
+		}
+	}
+	c.mu.Lock()
+	if c.interrupted[stepID] {
+		status = "interrupted"
+	}
+	c.observations[threadID] = agentObservation(threadID, turnID, status, turnError)
+	c.mu.Unlock()
+	result.Status, result.TurnError = status, turnError
+	return result, resultError
+}
+
+func agentPromptField(prompt, field string) string {
+	prefix := "ID "
+	if field == "visitId" {
+		prefix += "посещения (visitId): "
+	} else {
+		prefix += "логического кубика (stepId): "
+	}
+	for _, line := range strings.Split(prompt, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	return ""
+}
+
+func agentObservation(threadID, turnID, status string, turnError *codex.TurnError) codex.Observation {
+	result := codex.Observation{ThreadID: threadID, ThreadStatus: "idle", LatestTurnID: turnID, LatestTurnError: turnError}
+	switch status {
+	case "completed":
+		result.LatestTurnStatus = "completed"
+	case "failed":
+		result.LatestTurnStatus = "failed"
+	case "interrupted":
+		result.LatestTurnStatus = "interrupted"
+	case "running":
+		result.ThreadStatus, result.LatestTurnStatus = "active", "inProgress"
+	}
+	return result
+}
+
+type agentExecutionObserver struct{ client *agentExecutionClient }
+
+func (c *agentExecutionClient) OpenObserver(context.Context, string) (Observer, error) {
+	return &agentExecutionObserver{client: c}, nil
+}
+
+func (o *agentExecutionObserver) Inspect(threadID string) (codex.Observation, error) {
+	o.client.mu.Lock()
+	defer o.client.mu.Unlock()
+	if observation, exists := o.client.observations[threadID]; exists {
+		return observation, nil
+	}
+	return codex.Observation{ThreadID: threadID, ThreadStatus: "idle"}, nil
+}
+
+func (*agentExecutionObserver) Close() error { return nil }
+
+func agentExecutionOptions(root string, client Client) Options {
+	return Options{Root: root, PollInterval: time.Millisecond, Client: client, ContinueInterrupted: true}
+}
+
+// TestExecuteAgentGraphRoutesFanoutAndAfter проходит полный DAG: decision
+// материализует две ветки, after ждёт обе, а каждый запрос и событие сохраняют
+// собственный visitId. Финальный статус показывает применённое решение.
+func TestExecuteAgentGraphRoutesFanoutAndAfter(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"route","start":["choice"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{"go":{"to":["left","right"]}}},
+    {"id":"left","type":"agent","prompt":"Лево","after":[]},
+    {"id":"right","type":"agent","prompt":"Право","after":[]},
+    {"id":"join","type":"agent","prompt":"Собери","after":["left","right"]}
+  ]}`)
+	client := newAgentExecutionClient()
+	client.choices["choice"] = "go"
+	var last Status
+	outcome, err := ExecuteWithOutcome(t.Context(), run, Options{
+		Root: root, PollInterval: time.Millisecond, Client: client,
+		Notify: func(status Status) error { last = status; return nil },
+	})
+	if err != nil || !outcome.Terminal || !outcome.Successful {
+		t.Fatalf("agent-graph не достиг успеха: outcome=%+v err=%v", outcome, err)
+	}
+	snapshot, err := run.Load()
+	if err != nil || snapshot.Meta.RunState != runstore.RunSucceeded || len(snapshot.Meta.Visits) != 4 {
+		t.Fatalf("маршрут сохранён неверно: %+v, %v", snapshot.Meta, err)
+	}
+	if snapshot.Meta.Visits[0].Decision == nil || !snapshot.Meta.Visits[0].Decision.Applied || snapshot.Meta.Visits[0].VisitID != initial.Meta.Visits[0].VisitID {
+		t.Fatalf("decision commit не применён: %+v", snapshot.Meta.Visits[0])
+	}
+	client.mu.Lock()
+	for _, stepID := range []string{"choice", "left", "right", "join"} {
+		if client.runs[stepID] != 1 {
+			t.Errorf("кубик %q запущен %d раз", stepID, client.runs[stepID])
+		}
+	}
+	client.mu.Unlock()
+	if !last.Terminal || last.RunState != runstore.RunSucceeded || len(last.Steps) != 4 || last.Steps[0].VisitID == "" {
+		t.Fatalf("visit-aware статус неполон: %+v", last)
+	}
+	events, err := runstore.ReadEvents(root, snapshot.Meta.RunID)
+	if err != nil || len(events) == 0 {
+		t.Fatalf("нет журнала v4: %v", err)
+	}
+	for _, event := range events {
+		if event.VisitID == "" || event.StepID == "" {
+			t.Fatalf("событие потеряло visit scope: %+v", event)
+		}
+	}
+}
+
+// TestExecuteAgentGraphFailedDecisionUsesAfter фиксирует различие технического
+// Failed и выбора route: target не запускается, но failed остаётся допустимым
+// terminal-токеном для after-проверяющего и весь граф может завершиться успешно.
+func TestExecuteAgentGraphFailedDecisionUsesAfter(t *testing.T) {
+	root, _, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"recover","start":["choice"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{"go":{"to":["target"]}}},
+    {"id":"target","type":"agent","prompt":"Не запускать","after":[]},
+    {"id":"recover","type":"agent","prompt":"Разбери сбой","after":["choice"]}
+  ]}`)
+	client := newAgentExecutionClient()
+	client.statuses["choice"] = "failed"
+	details := "код 503\nповтор позже"
+	client.turnErrors["choice"] = &codex.TurnError{Message: "backend\tunavailable", AdditionalDetails: &details}
+	outcome, err := ExecuteWithOutcome(t.Context(), run, agentExecutionOptions(root, client))
+	if err != nil || !outcome.Successful {
+		t.Fatalf("after не обработал technical Failed: %+v, %v", outcome, err)
+	}
+	client.mu.Lock()
+	targetRuns, recoverRuns := client.runs["target"], client.runs["recover"]
+	client.mu.Unlock()
+	if targetRuns != 0 || recoverRuns != 1 {
+		t.Fatalf("Failed ошибочно выбрал route: target=%d recover=%d", targetRuns, recoverRuns)
+	}
+	snapshot, _ := run.Load()
+	if diagnostic := snapshot.Meta.Visits[0].TechnicalError; strings.ContainsAny(diagnostic, "\n\t") || !strings.Contains(diagnostic, `\u0009`) {
+		t.Fatalf("диагностика не очищена: %q", diagnostic)
+	}
+}
+
+// TestExecuteAgentGraphMissingDecisionFails сохраняет понятный failed run вместо
+// молчаливого продолжения, если decision-agent завершил turn без инструмента.
+func TestExecuteAgentGraphMissingDecisionFails(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"missing","start":["choice"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{"go":{"to":["target"]}}},
+    {"id":"target","type":"agent","prompt":"Цель","after":[]}
+  ]}`)
+	client := newAgentExecutionClient()
+	outcome, err := ExecuteWithOutcome(t.Context(), run, agentExecutionOptions(root, client))
+	if !errors.Is(err, ErrRunUnsuccessful) || !outcome.Terminal || outcome.Successful {
+		t.Fatalf("отсутствующий выбор не завершил run ошибкой: %+v, %v", outcome, err)
+	}
+	snapshot, _ := run.Load()
+	if snapshot.Meta.RunState != runstore.RunFailed || snapshot.Meta.StopVisitID != initial.Meta.Visits[0].VisitID || !strings.Contains(snapshot.Meta.StopReason, "без choose_decision") {
+		t.Fatalf("причина failed не доказана посещением: %+v", snapshot.Meta)
+	}
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if client.runs["target"] != 0 {
+		t.Fatalf("после missing decision запущен target: %v", client.runs)
+	}
+}
+
+// TestExecuteAgentGraphPoisonedDecisionFails синхронизирует второй tool call
+// между Advance и Reserve: terminal commit обязан запретить новый launch,
+// прервать первый turn и вернуть оба root-wide capacity slot.
+func TestExecuteAgentGraphPoisonedDecisionFails(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"poison","start":["choice","helper","work"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{"left":{"to":["target"]},"stop":{"finish":"failed"}}},
+    {"id":"helper","type":"agent","prompt":"Освободи slot","after":[]},
+    {"id":"work","type":"agent","prompt":"Не запускать","after":[]},
+    {"id":"target","type":"agent","prompt":"Цель","after":[]}
+  ]}`)
+	client := newAgentExecutionClient()
+	client.choices["choice"], client.releases["choice"] = "left", make(chan struct{})
+	pool, err := capacity.Configure(root, "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	configure := func(snapshot runstore.Snapshot, command *codex.Command) {
+		if agentPromptField(command.Text, "stepId") != "work" || snapshot.Meta.Visits[0].Decision == nil {
+			return
+		}
+		visit := snapshot.Meta.Visits[0]
+		_, _ = run.CommitDecision(visit.VisitID, visit.CodexThreadID, visit.TurnID, "stop", "конфликт", "call-conflict")
+	}
+	outcome, err := ExecuteWithOutcome(t.Context(), run, Options{
+		Root: root, PollInterval: time.Millisecond, Client: client, ContinueInterrupted: true,
+		Capacity: pool, ConfigureCommand: configure,
+	})
+	if !errors.Is(err, ErrRunUnsuccessful) || !outcome.Terminal || outcome.Successful {
+		t.Fatalf("poisoned decision не завершил run: %+v, %v", outcome, err)
+	}
+	snapshot, _ := run.Load()
+	decision := snapshot.Meta.Visits[0].Decision
+	if snapshot.Meta.StopVisitID != initial.Meta.Visits[0].VisitID || decision == nil || decision.Error == "" || decision.Applied {
+		t.Fatalf("конфликт не сохранён как неприменённая причина: %+v", snapshot.Meta)
+	}
+	client.mu.Lock()
+	workRuns, targetRuns, interrupts := client.runs["work"], client.runs["target"], client.interrupts["choice"]
+	client.mu.Unlock()
+	if workRuns != 0 || targetRuns != 0 || interrupts != 1 {
+		t.Fatalf("poison пропустил работу или не остановил turn: work=%d target=%d interrupts=%d", workRuns, targetRuns, interrupts)
+	}
+	for slot := 0; slot < 2; slot++ {
+		lease, available, acquireErr := pool.TryAcquire()
+		if acquireErr != nil || !available {
+			t.Fatalf("capacity slot %d не освобождён: available=%v, %v", slot, available, acquireErr)
+		}
+		defer lease.Release()
+	}
+}
+
+// TestExecuteAgentGraphBindsParallelTurnBeforePoisonFinish задерживает OnTurn
+// соседа, затем возвращает transport error: durable poison всё равно должен
+// прервать первый turn и завершить run после сохранения обоих turnId.
+func TestExecuteAgentGraphBindsParallelTurnBeforePoisonFinish(t *testing.T) {
+	root, _, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"poison-wave","start":["choice","slow"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
+      "go":{"to":["target"]},"stop":{"finish":"failed"}}},
+    {"id":"slow","type":"agent","prompt":"Долго","after":[]},
+    {"id":"target","type":"agent","prompt":"Цель","after":[]}
+  ]}`)
+	client := newAgentExecutionClient()
+	client.choices["choice"], client.secondChoices["choice"] = "go", "stop"
+	client.releases["choice"], client.beforeTurn["slow"] = make(chan struct{}), make(chan struct{})
+	transportFailure := errors.New("stdio оборвался")
+	client.resultErrors["slow"] = transportFailure
+	type executionResult struct {
+		outcome Outcome
+		err     error
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	finished := make(chan executionResult, 1)
+	go func() {
+		outcome, err := ExecuteWithOutcome(ctx, run, agentExecutionOptions(root, client))
+		finished <- executionResult{outcome: outcome, err: err}
+	}()
+	for {
+		snapshot, err := run.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if snapshot.Meta.Visits[0].Decision != nil && snapshot.Meta.Visits[0].Decision.Error != "" {
+			break
+		}
+		select {
+		case result := <-finished:
+			t.Fatalf("execution завершился до durable poison: %+v, %v", result.outcome, result.err)
+		case <-time.After(time.Millisecond):
+		}
+	}
+	close(client.beforeTurn["slow"])
+	result := <-finished
+	if !errors.Is(result.err, ErrRunUnsuccessful) || !errors.Is(result.err, transportFailure) || !result.outcome.Terminal || result.outcome.Successful {
+		t.Fatalf("poison wave не завершила run: %+v, %v", result.outcome, result.err)
+	}
+	snapshot, _ := run.Load()
+	client.mu.Lock()
+	interrupts := client.interrupts["choice"]
+	client.mu.Unlock()
+	if snapshot.Meta.Visits[0].TurnID == "" || snapshot.Meta.Visits[1].TurnID == "" || snapshot.Meta.Visits[0].State != scheduler.Cancelled || interrupts != 1 {
+		t.Fatalf("параллельная волна потеряла turn или interrupt: %+v", snapshot.Meta.Visits)
+	}
+}
+
+// TestExecuteAgentGraphPrioritizesPoisonOverAmbiguousStart фиксирует resume
+// после crash между Reserve и OnThread: durable poison важнее Starting без ID,
+// поэтому run завершается без повторного сетевого запроса.
+func TestExecuteAgentGraphPrioritizesPoisonOverAmbiguousStart(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"poison-crash","start":["choice","slow"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
+      "go":{"finish":"succeeded"},"stop":{"finish":"failed"}}},
+    {"id":"slow","type":"agent","prompt":"Не повторять","after":[]}
+  ]}`)
+	choiceID := initial.Meta.Visits[0].VisitID
+	if err := run.ReserveVisits([]string{choiceID, initial.Meta.Visits[1].VisitID}); err == nil {
+		err = run.UpdateVisit(choiceID, scheduler.Unknown, "chat-choice", "")
+		if err == nil {
+			err = run.SetVisitTurn(choiceID, "turn-choice")
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal(err)
+	}
+	if _, err := run.CommitDecision(choiceID, "chat-choice", "turn-choice", "go", "первый", "call-first"); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = run.CommitDecision(choiceID, "chat-choice", "turn-choice", "stop", "конфликт", "call-second")
+	client := newAgentExecutionClient()
+	outcome, err := ExecuteWithOutcome(t.Context(), run, agentExecutionOptions(root, client))
+	snapshot, _ := run.Load()
+	if !errors.Is(err, ErrRunUnsuccessful) || !outcome.Terminal || snapshot.Meta.RunState != runstore.RunFailed || len(client.runs) != 0 {
+		t.Fatalf("resume предпочёл ambiguous повтор durable poison: %+v, runs=%v, %v", snapshot.Meta, client.runs, err)
+	}
+}
+
+// TestExecuteAgentGraphReconcilesExternalTurn проверяет crash-resume: внешний
+// completed turn сначала увеличивает Attempt, затем завершает исходный visit,
+// не вызывая ни Run, ни Continue повторно.
+func TestExecuteAgentGraphReconcilesExternalTurn(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"resume","start":["work"],"steps":[{"id":"work","type":"agent","prompt":"Работа","after":[]}]}`)
+	visitID := initial.Meta.Visits[0].VisitID
+	if err := run.ReserveVisits([]string{visitID}); err == nil {
+		err = run.UpdateVisit(visitID, scheduler.Unknown, "chat-existing", "")
+	} else {
+		t.Fatal(err)
+	}
+	if err := run.SetVisitTurn(visitID, "turn-old"); err != nil {
+		t.Fatal(err)
+	}
+	client := newAgentExecutionClient()
+	client.observations["chat-existing"] = agentObservation("chat-existing", "turn-external", "completed", nil)
+	outcome, err := ExecuteWithOutcome(t.Context(), run, agentExecutionOptions(root, client))
+	if err != nil || !outcome.Successful {
+		t.Fatalf("внешний turn не восстановлен: %+v, %v", outcome, err)
+	}
+	snapshot, _ := run.Load()
+	visit := snapshot.Meta.Visits[0]
+	client.mu.Lock()
+	runs, continues := client.runs["work"], client.continues["work"]
+	client.mu.Unlock()
+	if visit.Attempt != 2 || visit.TurnID != "turn-external" || visit.State != scheduler.Succeeded || runs != 0 || continues != 0 {
+		t.Fatalf("reconcile создал дубль или нарушил порядок: visit=%+v runs=%d continues=%d", visit, runs, continues)
+	}
+}
+
+// TestExecuteAgentGraphKeepsCommittedChoiceOnCancelledResume доказывает, что
+// повторный turn не получает choose_decision и один процесс не продолжает снова
+// посещение, которое второй раз завершилось interrupted.
+func TestExecuteAgentGraphKeepsCommittedChoiceOnCancelledResume(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"choice-resume","start":["choice"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{"done":{"finish":"succeeded"}}}
+  ]}`)
+	visitID := initial.Meta.Visits[0].VisitID
+	if err := run.ReserveVisits([]string{visitID}); err == nil {
+		err = run.UpdateVisit(visitID, scheduler.Unknown, "chat-choice", "")
+	} else {
+		t.Fatal(err)
+	}
+	if err := run.SetVisitTurn(visitID, "turn-old"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run.CommitDecision(visitID, "chat-choice", "turn-old", "done", "готово", "call-old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(visitID, scheduler.Cancelled, "chat-choice", "остановлен"); err != nil {
+		t.Fatal(err)
+	}
+	client := newAgentExecutionClient()
+	client.statuses["choice"] = "interrupted"
+	client.observations["chat-choice"] = agentObservation("chat-choice", "turn-old", "interrupted", nil)
+	ctx, cancel := context.WithTimeout(t.Context(), 35*time.Millisecond)
+	defer cancel()
+	err := Execute(ctx, run, agentExecutionOptions(root, client))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ожидалась остановка polling после одного continue: %v", err)
+	}
+	client.mu.Lock()
+	continues, tools := client.continues["choice"], client.toolSets["choice"]
+	client.mu.Unlock()
+	if continues != 1 || tools != 0 {
+		t.Fatalf("сохранённый выбор переигран или continue повторён: continues=%d tools=%d", continues, tools)
+	}
+}
+
+// TestExecuteAgentGraphFinishInterruptsParallelVisit проверяет атомарный finish:
+// решение завершает run сразу, а уже активная соседняя ветка адресно прерывается
+// и не удерживает capacity lease после возврата.
+func TestExecuteAgentGraphFinishInterruptsParallelVisit(t *testing.T) {
+	root, _, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"finish","start":["choice","long"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Реши","after":[],"decisions":{"done":{"finish":"succeeded"}}},
+    {"id":"long","type":"agent","prompt":"Долго","after":[]}
+  ]}`)
+	client := newAgentExecutionClient()
+	client.choices["choice"] = "done"
+	client.releases["long"] = make(chan struct{})
+	outcome, err := ExecuteWithOutcome(t.Context(), run, agentExecutionOptions(root, client))
+	if err != nil || !outcome.Successful {
+		t.Fatalf("finish не завершил параллельный run: %+v, %v", outcome, err)
+	}
+	client.mu.Lock()
+	interrupts := client.interrupts["long"]
+	client.mu.Unlock()
+	snapshot, _ := run.Load()
+	longState := scheduler.State("")
+	for _, visit := range snapshot.Meta.Visits {
+		if visit.StepID == "long" {
+			longState = visit.State
+		}
+	}
+	if interrupts != 1 || longState != scheduler.Cancelled || snapshot.Meta.RunState != runstore.RunSucceeded {
+		t.Fatalf("параллельный visit не остановлен: interrupts=%d state=%s meta=%+v", interrupts, longState, snapshot.Meta)
+	}
+}
+
+// TestExecuteAgentGraphReleasesOnlyUnattemptedStart отличает локальный отказ до
+// thread/start от сохранённого Starting после рестарта.
+func TestExecuteAgentGraphReleasesOnlyUnattemptedStart(t *testing.T) {
+	root, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"start","start":["work"],"steps":[{"id":"work","type":"agent","prompt":"Работа","after":[]}]}`)
+	client := newAgentExecutionClient()
+	failure := errors.New("initialize unavailable")
+	client.beforeCreate["work"] = []error{failure}
+	if err := Execute(t.Context(), run, agentExecutionOptions(root, client)); !errors.Is(err, failure) {
+		t.Fatalf("потеряна исходная ошибка: %v", err)
+	}
+	snapshot, _ := run.Load()
+	if snapshot.Meta.Visits[0].State != scheduler.Pending {
+		t.Fatalf("неотправленный launch не возвращён: %+v", snapshot.Meta.Visits[0])
+	}
+	if err := run.ReserveVisits([]string{initial.Meta.Visits[0].VisitID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Execute(t.Context(), run, agentExecutionOptions(root, client)); !errors.Is(err, ErrAmbiguousStart) {
+		t.Fatalf("Starting после рестарта был повторён: %v", err)
+	}
+}

--- a/internal/coordinator/events.go
+++ b/internal/coordinator/events.go
@@ -14,9 +14,21 @@ import (
 // appendProcessEvent переводит жизненный цикл дочернего App Server в устойчивый
 // журнал Lawa. Командная строка, env и stderr намеренно не копируются.
 func appendProcessEvent(run *runstore.LockedRun, stepID, threadID, turnID string, process codex.ProcessEvent) error {
+	return appendScopedProcessEvent(run, "", stepID, threadID, turnID, process)
+}
+
+// appendAgentProcessEvent сохраняет тот же безопасный lifecycle, но связывает
+// его с конкретным посещением v4. Один stepId может встретиться многократно,
+// поэтому журнал нового runtime нельзя адресовать только логическим кубиком.
+func appendAgentProcessEvent(run *runstore.LockedRun, visitID, stepID, threadID, turnID string, process codex.ProcessEvent) error {
+	return appendScopedProcessEvent(run, visitID, stepID, threadID, turnID, process)
+}
+
+// appendScopedProcessEvent — общая запись lifecycle для legacy и v4 scope.
+func appendScopedProcessEvent(run *runstore.LockedRun, visitID, stepID, threadID, turnID string, process codex.ProcessEvent) error {
 	kind := "process_" + process.Kind
 	return run.AppendEvent(runstore.RuntimeEvent{
-		Time: process.Time, StepID: stepID, ThreadID: threadID, TurnID: turnID,
+		Time: process.Time, VisitID: visitID, StepID: stepID, ThreadID: threadID, TurnID: turnID,
 		Kind: kind, PID: process.PID, ExitCode: process.ExitCode, Signal: process.Signal,
 	})
 }
@@ -29,6 +41,17 @@ func appendProcessEvent(run *runstore.LockedRun, stepID, threadID, turnID string
 // секреты из рабочего процесса. Сырые reasoning, аргументы/result инструментов
 // и неизвестные payload не сериализуются даже частично.
 func appendCodexEvent(run *runstore.LockedRun, stepID, threadID, turnID string, event codex.Event) error {
+	return appendScopedCodexEvent(run, "", stepID, threadID, turnID, event)
+}
+
+// appendAgentCodexEvent добавляет visitId к нормализованному событию v4,
+// сохраняя один фильтр содержимого для обоих форматов журнала.
+func appendAgentCodexEvent(run *runstore.LockedRun, visitID, stepID, threadID, turnID string, event codex.Event) error {
+	return appendScopedCodexEvent(run, visitID, stepID, threadID, turnID, event)
+}
+
+// appendScopedCodexEvent нормализует один протокольный event до durable scope.
+func appendScopedCodexEvent(run *runstore.LockedRun, visitID, stepID, threadID, turnID string, event codex.Event) error {
 	if event.Method == "item/reasoning/textDelta" || event.Method == "item/reasoning/delta" {
 		return nil
 	}
@@ -46,7 +69,7 @@ func appendCodexEvent(run *runstore.LockedRun, stepID, threadID, turnID string, 
 	if err != nil {
 		return fmt.Errorf("нормализовать событие %s: %w", event.Method, err)
 	}
-	normalized := runstore.RuntimeEvent{StepID: stepID, ThreadID: threadID, TurnID: turnID}
+	normalized := runstore.RuntimeEvent{VisitID: visitID, StepID: stepID, ThreadID: threadID, TurnID: turnID}
 	switch event.Method {
 	case "turn/started":
 		normalized.Kind, normalized.State = "turn_started", "running"

--- a/internal/coordinator/execute.go
+++ b/internal/coordinator/execute.go
@@ -110,6 +110,9 @@ type StepStatus struct {
 	ID, ThreadID, CodexThreadID string
 	State                       scheduler.State
 	DependsOn                   []string
+	// VisitID заполнен только для meta v4. ID при этом остаётся
+	// логическим stepId, чтобы старые потребители статуса не теряли подписи.
+	VisitID string
 }
 
 // Status — целостный снимок для терминала или другого интерфейса. Waiting
@@ -120,6 +123,10 @@ type Status struct {
 	Waiting            []string
 	WaitingForCapacity []string
 	Complete           bool
+	// RunState является авторитетным итогом meta v4. Terminal отделён от
+	// Complete: failed agent-graph завершён, но не является успешным.
+	RunState runstore.RunState
+	Terminal bool
 }
 
 // Ticker скрывает реальное время за минимальной границей. Production использует
@@ -167,7 +174,7 @@ type Options struct {
 
 // ErrRunUnsuccessful отличает терминальный failed/interrupted от сбоя самого
 // координатора. В обоих случаях серия останавливается, но причина остаётся явной.
-var ErrRunUnsuccessful = errors.New("run завершён неуспешно; серия остановлена по политике stop-on-failure")
+var ErrRunUnsuccessful = errors.New("run завершён неуспешно")
 
 // Outcome сообщает управляющему циклу, достиг ли сохранённый run терминала.
 // Ошибка ExecuteWithOutcome описывает причину остановки координатора, но сама по
@@ -278,6 +285,9 @@ func ExecuteWithOutcome(ctx context.Context, run *runstore.LockedRun, options Op
 	initial, err := run.Load()
 	if err != nil {
 		return Outcome{}, fmt.Errorf("координатор: прочитать запуск: %w", err)
+	}
+	if initial.Meta.Version == 4 {
+		return executeAgentGraph(ctx, run, options, initial)
 	}
 	observer := &sharedObserver{ctx: ctx, client: options.Client, cwd: initial.Meta.CWD}
 	// Закрытие наблюдения регистрируется до defer активных turn ниже. На Ctrl+C
@@ -426,6 +436,9 @@ func ExecuteWithOutcome(ctx context.Context, run *runstore.LockedRun, options Op
 // Неуспешный шаг является терминалом только для автоматической серии; обычный
 // run оставляет тот же чат доступным для ручного продолжения.
 func terminalOutcome(status Status, returnOnFailure bool) Outcome {
+	if status.RunState != "" {
+		return Outcome{Terminal: status.Terminal, Successful: status.RunState == runstore.RunSucceeded}
+	}
 	if status.Complete {
 		return Outcome{Terminal: true, Successful: true}
 	}
@@ -767,8 +780,23 @@ func currentStatus(run *runstore.LockedRun) (Status, string, error) {
 	if err != nil {
 		return Status{}, "", fmt.Errorf("координатор: прочитать статус запуска: %w", err)
 	}
-	states := make(map[string]scheduler.State, len(snapshot.Meta.Steps))
 	status := Status{RunID: snapshot.Meta.RunID, WorkflowID: snapshot.Workflow.ID}
+	if snapshot.Meta.Version == 4 {
+		status.RunState = snapshot.Meta.RunState
+		status.Terminal = snapshot.Meta.RunState != runstore.RunRunning
+		status.Complete = snapshot.Meta.RunState == runstore.RunSucceeded
+		var signature strings.Builder
+		for _, visit := range snapshot.Meta.Visits {
+			status.Steps = append(status.Steps, StepStatus{
+				ID: visit.StepID, VisitID: visit.VisitID, CodexThreadID: visit.CodexThreadID, State: visit.State,
+			})
+			fmt.Fprintf(&signature, "%q/%q=%q:%q:%q;", visit.StepID, visit.VisitID, visit.State, visit.CodexThreadID, visit.TurnID)
+		}
+		fmt.Fprintf(&signature, "run=%s", status.RunState)
+		return status, signature.String(), nil
+	}
+
+	states := make(map[string]scheduler.State, len(snapshot.Meta.Steps))
 	dependencies := make(map[string][]string, len(snapshot.Workflow.Steps))
 	for _, step := range snapshot.Workflow.Steps {
 		dependencies[step.ID] = step.DependsOn


### PR DESCRIPTION
Часть #50, stacked поверх #78.

Что сделано:
- ExecuteWithOutcome исполняет metadata v4 по visitId с параллельными волнами и root-wide capacity;
- durable thread/turn/result сохраняются в безопасном порядке, события получают visitId;
- поддержаны reconcile, Cancelled resume без повторного выбора и защита ambiguous Starting;
- terminal outcome прерывает и дренирует активные turn, освобождая leases ровно один раз;
- durable poison имеет приоритет над transport error и crash-неопределённостью;
- добавлены регрессии fanout/after, Failed decision, missing/poison, external turn, resume, interrupt и границы создания.

Проверено на чистом снимке:
- go test ./...
- go test -race ./internal/runstore ./internal/coordinator
- focused poison-регрессии 25 раз и под race 10 раз
- go vet ./internal/coordinator ./cmd/lawa
- независимое ревью: APPROVE

Размер: 1172 изменённые строки (1168 добавлено, 4 удалено). Это крупнее ориентира 500 строк, но ниже блокирующего предела 1200; execution и его сквозные регрессии оставлены одной production-safe частью. Merge не выполнялся.