### PR TITLE
Добавить ограниченные циклы agent-графа

### DIFF
--- a/internal/runstore/advance.go
+++ b/internal/runstore/advance.go
@@ -84,6 +84,16 @@ func (r *LockedRun) advanceAgentGraph(syncFile func(*os.File) error) (AgentAdvan
 		}
 		snapshot.Meta.StopReason = compactAgentStopReason(plan.Terminal.Reason)
 		snapshot.Meta.StopVisitID = plan.Terminal.CauseVisitID
+		snapshot.Meta.StopLimitStepID = plan.Terminal.LimitStepID
+		if plan.Terminal.LimitStepID != "" {
+			trigger := VisitTrigger{
+				Kind:           TriggerKind(plan.Terminal.LimitTrigger.Kind),
+				SourceVisitIDs: slices.Clone(plan.Terminal.LimitTrigger.SourceVisitIDs),
+				DecisionKey:    plan.Terminal.LimitTrigger.DecisionKey,
+			}
+			snapshot.Meta.StopLimitTrigger = &trigger
+			snapshot.Meta.StopLimitIteration = plan.Terminal.LimitIteration
+		}
 		// Защитный fallback сохраняет проверяемую причину даже при регрессии
 		// planner: штатный explicit finish уже возвращает свой CauseVisitID.
 		if snapshot.Meta.StopVisitID == "" && len(plan.ApplyDecisionVisitIDs) == 1 {
@@ -181,26 +191,6 @@ func materializeAgentVisits(history []Visit, decision, after []scheduler.AgentAc
 		})
 	}
 	return created
-}
-
-// agentVisitViews копирует только семантику, которой владеет scheduler. Внешние
-// thread/turn, память и диагностика остаются деталями persistence/coordinator.
-func agentVisitViews(visits []Visit) []scheduler.AgentVisitView {
-	views := make([]scheduler.AgentVisitView, 0, len(visits))
-	for _, visit := range visits {
-		view := scheduler.AgentVisitView{
-			VisitID: visit.VisitID, StepID: visit.StepID, Iteration: visit.Iteration, State: visit.State,
-			Trigger: scheduler.AgentTriggerView{
-				Kind: scheduler.AgentTriggerKind(visit.Trigger.Kind), SourceVisitIDs: slices.Clone(visit.Trigger.SourceVisitIDs),
-				DecisionKey: visit.Trigger.DecisionKey,
-			},
-		}
-		if visit.Decision != nil {
-			view.Decision = &scheduler.AgentDecisionView{Key: visit.Decision.Key, Applied: visit.Decision.Applied, Error: visit.Decision.Error}
-		}
-		views = append(views, view)
-	}
-	return views
 }
 
 // createAgentVisitMemories синхронизирует каждый inode и затем имя в memory/.

--- a/internal/runstore/advance_test.go
+++ b/internal/runstore/advance_test.go
@@ -9,11 +9,13 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"syscall"
 	"testing"
 
 	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
 )
 
 // advanceInput даёт fanout из одного решения и общий after-barrier. Второй
@@ -34,6 +36,24 @@ func advanceInput(t *testing.T) Input {
     {"id":"join","type":"agent","prompt":"Объединить","after":["left","right"]}
   ]
 }`), Task: "Продвинуть граф", Comment: "Тест persistence bridge", CWD: t.TempDir()}
+}
+
+// boundedLoopInput оставляет параллельный Pending visit, чтобы остановка по
+// квоте доказывала семантику всего run, а не только естественную quiescence.
+func boundedLoopInput(t *testing.T, successfulLimit bool) Input {
+	t.Helper()
+	limit := `"maxVisits":2`
+	if successfulLimit {
+		limit += `,"onLimit":"succeeded"`
+	}
+	workflowJSON := strings.Replace(`{
+  "version":2,"id":"bounded-loop","start":["loop","parallel"],"steps":[
+    {"id":"loop","type":"agent","prompt":"Повтори","after":[],"maxVisits":2,"decisions":{
+      "repeat":{"to":["loop"]},"done":{"finish":"succeeded"}}},
+    {"id":"parallel","type":"agent","prompt":"Параллельно","after":[]}
+  ]
+}`, `"maxVisits":2`, limit, 1)
+	return Input{WorkflowJSON: []byte(workflowJSON), Task: "Проверить ограниченный цикл", CWD: t.TempDir()}
 }
 
 func testAdvanceRun(t *testing.T) (string, Snapshot, *LockedRun) {
@@ -57,16 +77,17 @@ func testAdvanceRun(t *testing.T) (string, Snapshot, *LockedRun) {
 
 func finishDecisionVisit(t *testing.T, run *LockedRun, visitID, key string) {
 	t.Helper()
+	chatID, turnID, callID := "chat-"+visitID, "turn-"+visitID, "call-"+visitID
 	if err := run.ReserveVisits([]string{visitID}); err == nil {
-		err = run.UpdateVisit(visitID, scheduler.Unknown, "chat-decision", "")
+		err = run.UpdateVisit(visitID, scheduler.Unknown, chatID, "")
 		if err == nil {
-			err = run.SetVisitTurn(visitID, "turn-decision")
+			err = run.SetVisitTurn(visitID, turnID)
 		}
 		if err == nil {
-			_, err = run.CommitDecision(visitID, "chat-decision", "turn-decision", key, "выбран маршрут", "call-decision")
+			_, err = run.CommitDecision(visitID, chatID, turnID, key, "выбран маршрут", callID)
 		}
 		if err == nil {
-			err = run.UpdateVisit(visitID, scheduler.Succeeded, "chat-decision", "")
+			err = run.UpdateVisit(visitID, scheduler.Succeeded, chatID, "")
 		}
 		if err != nil {
 			t.Fatal(err)
@@ -74,6 +95,100 @@ func finishDecisionVisit(t *testing.T, run *LockedRun, visitID, key string) {
 	} else {
 		t.Fatal(err)
 	}
+}
+
+// finishPlainVisit проводит обычное посещение через те же durable-фазы, что и
+// coordinator. Тесты переходов не подменяют metadata напрямую, поэтому каждый
+// промежуточный снимок проходит production-валидацию.
+func finishPlainVisit(t *testing.T, run *LockedRun, visitID string) {
+	t.Helper()
+	chatID, turnID := "chat-"+visitID, "turn-"+visitID
+	if err := run.ReserveVisits([]string{visitID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(visitID, scheduler.Unknown, chatID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.SetVisitTurn(visitID, turnID); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(visitID, scheduler.Succeeded, chatID, ""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// runDecisionVisit сохраняет выбор, но оставляет turn активным. Это позволяет
+// воспроизвести окно, в котором tool уже commit-нул route, а финальный Result
+// Codex ещё не сделал decision visit технически завершённым.
+func runDecisionVisit(t *testing.T, run *LockedRun, visitID, key string) string {
+	t.Helper()
+	chatID, turnID := "chat-"+visitID, "turn-"+visitID
+	if err := run.ReserveVisits([]string{visitID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(visitID, scheduler.Unknown, chatID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.SetVisitTurn(visitID, turnID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run.CommitDecision(visitID, chatID, turnID, key, "выбран маршрут", "call-"+visitID); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(visitID, scheduler.Running, chatID, ""); err != nil {
+		t.Fatal(err)
+	}
+	return chatID
+}
+
+// runDecisionlessVisit оставляет обычный turn Running для проверки terminal
+// drain: после остановки такой уже начатый внешний запрос ещё может сообщить
+// финальное техническое состояние, но не вправе изменить исход всего run.
+func runDecisionlessVisit(t *testing.T, run *LockedRun, visitID string) string {
+	t.Helper()
+	chatID, turnID := "chat-"+visitID, "turn-"+visitID
+	if err := run.ReserveVisits([]string{visitID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(visitID, scheduler.Unknown, chatID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.SetVisitTurn(visitID, turnID); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(visitID, scheduler.Running, chatID, ""); err != nil {
+		t.Fatal(err)
+	}
+	return chatID
+}
+
+// testBoundedLoopAtLimit создаёт оба разрешённых посещения и сохраняет решение
+// repeat у второго, но намеренно не вызывает последний Advance. Возвращённый
+// snapshot остаётся Running, а следующий переход обязан быть limit-terminal.
+func testBoundedLoopAtLimit(t *testing.T, successfulLimit bool) (string, Snapshot, *LockedRun, Visit) {
+	t.Helper()
+	root := t.TempDir()
+	initial, err := CreateAgentGraph(root, boundedLoopInput(t, successfulLimit))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := run.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	finishDecisionVisit(t, run, initial.Meta.Visits[0].VisitID, "repeat")
+	first, err := run.AdvanceAgentGraph()
+	if err != nil || len(first.CreatedVisits) != 1 || first.CreatedVisits[0].StepID != "loop" || first.CreatedVisits[0].Visit != 2 || first.CreatedVisits[0].Iteration != 2 {
+		t.Fatalf("второе посещение цикла не создано: %+v, %v", first, err)
+	}
+	second := first.CreatedVisits[0]
+	finishDecisionVisit(t, run, second.VisitID, "repeat")
+	return root, initial, run, second
 }
 
 // TestAdvanceAgentGraphRouteAndAfter проверяет два последовательных durable
@@ -297,8 +412,240 @@ func TestAdvanceAgentGraphMemoryBeforeMetadata(t *testing.T) {
 	}
 }
 
-// TestAdvanceAgentGraphGuards отклоняет legacy, циклическую и повреждённую
-// историю до любой новой памяти или metadata.
+// TestAdvanceAgentGraphBoundedLoop проверяет durable-границу квоты. Ошибка Sync
+// до Rename не публикует частичный terminal, а reopen детерминированно строит тот
+// же StopVisitID/StopLimitStepID без третьего visit и без Applied у решения.
+func TestAdvanceAgentGraphBoundedLoop(t *testing.T) {
+	t.Run("default failed survives crash and reopen", func(t *testing.T) {
+		root, initial, run, second := testBoundedLoopAtLimit(t, false)
+		result, err := run.advanceAgentGraph(func(*os.File) error { return syscall.EIO })
+		if !errors.Is(err, syscall.EIO) || !reflect.DeepEqual(result, AgentAdvance{}) {
+			t.Fatalf("отказ записи limit-terminal не воспроизведён: %+v, %v", result, err)
+		}
+		onDisk, err := Load(root, initial.Meta.RunID)
+		if err != nil || onDisk.Meta.RunState != RunRunning || onDisk.Meta.StopReason != "" || onDisk.Meta.StopVisitID != "" ||
+			onDisk.Meta.StopLimitStepID != "" || onDisk.Meta.StopLimitTrigger != nil || onDisk.Meta.StopLimitIteration != 0 ||
+			len(onDisk.Meta.Visits) != 3 || onDisk.Meta.Visits[2].Decision.Applied {
+			t.Fatalf("Sync до Rename частично опубликовал limit: %+v, %v", onDisk.Meta, err)
+		}
+		if err := run.Close(); err != nil {
+			t.Fatal(err)
+		}
+		reopened, err := OpenLocked(root, initial.Meta.RunID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer reopened.Close()
+		result, err = reopened.AdvanceAgentGraph()
+		if err != nil || !result.Changed || result.Snapshot.Meta.RunState != RunFailed ||
+			result.Snapshot.Meta.StopVisitID != second.VisitID || result.Snapshot.Meta.StopLimitStepID != "loop" ||
+			result.Snapshot.Meta.StopLimitTrigger == nil || result.Snapshot.Meta.StopLimitTrigger.Kind != TriggerDecision ||
+			!slices.Equal(result.Snapshot.Meta.StopLimitTrigger.SourceVisitIDs, []string{second.VisitID}) ||
+			result.Snapshot.Meta.StopLimitTrigger.DecisionKey != "repeat" || result.Snapshot.Meta.StopLimitIteration != 3 ||
+			result.Plan.Terminal == nil || result.Plan.Terminal.LimitStepID != "loop" ||
+			result.Plan.Terminal.LimitTrigger.Kind != scheduler.AgentTriggerDecision ||
+			!slices.Equal(result.Plan.Terminal.LimitTrigger.SourceVisitIDs, []string{second.VisitID}) ||
+			result.Plan.Terminal.LimitTrigger.DecisionKey != "repeat" || result.Plan.Terminal.LimitIteration != 3 || len(result.CreatedVisits) != 0 ||
+			len(result.Snapshot.Meta.Visits) != 3 ||
+			result.Snapshot.Meta.Visits[2].Decision.Applied {
+			t.Fatalf("reopen не опубликовал точный limit-terminal: %+v, %v", result, err)
+		}
+
+		// Каждая подмена ломает отдельную часть структурного proof: тип причины,
+		// последний разрешённый visit, onLimit outcome либо сам предел N.
+		for name, mutate := range map[string]func(*Snapshot){
+			"missing marker":       func(s *Snapshot) { s.Meta.StopLimitStepID = "" },
+			"missing trigger":      func(s *Snapshot) { s.Meta.StopLimitTrigger = nil },
+			"missing iteration":    func(s *Snapshot) { s.Meta.StopLimitIteration = 0 },
+			"step without limit":   func(s *Snapshot) { s.Meta.StopLimitStepID = "parallel" },
+			"wrong stop visit":     func(s *Snapshot) { s.Meta.StopVisitID = initial.Meta.Visits[0].VisitID },
+			"wrong outcome":        func(s *Snapshot) { s.Meta.RunState = RunSucceeded },
+			"wrong trigger source": func(s *Snapshot) { s.Meta.StopLimitTrigger.SourceVisitIDs = []string{initial.Meta.Visits[0].VisitID} },
+			"wrong trigger key":    func(s *Snapshot) { s.Meta.StopLimitTrigger.DecisionKey = "done" },
+			"wrong iteration":      func(s *Snapshot) { s.Meta.StopLimitIteration = 4 },
+			"open decision wave": func(s *Snapshot) {
+				s.Workflow.Steps = slices.Clone(s.Workflow.Steps)
+				outcome := workflow.OutcomeSucceeded
+				s.Workflow.Steps[1].Decisions = map[string]workflow.Route{"done": {Finish: &outcome}}
+			},
+			"no pending activation": func(s *Snapshot) {
+				s.Meta.Visits[2].State, s.Meta.Visits[2].Decision = scheduler.Failed, nil
+				s.Meta.Visits[2].TechnicalError = "цикл завершился до новой активации"
+			},
+			"visit beyond limit": func(s *Snapshot) {
+				s.Meta.Visits = append(s.Meta.Visits, Visit{
+					VisitID: newID(), StepID: "loop", Visit: 3, Iteration: 3, State: scheduler.Pending,
+					Trigger: VisitTrigger{Kind: TriggerDecision, SourceVisitIDs: []string{second.VisitID}, DecisionKey: "repeat"},
+				})
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				damaged := cloneSnapshotMetadata(t, result.Snapshot)
+				mutate(&damaged)
+				if err := damaged.validate(damaged.Meta.RunID); err == nil {
+					t.Fatal("повреждённое доказательство maxVisits принято")
+				}
+			})
+		}
+	})
+
+	t.Run("explicit onLimit succeeds with active visit", func(t *testing.T) {
+		_, _, run, second := testBoundedLoopAtLimit(t, true)
+		result, err := run.AdvanceAgentGraph()
+		if err != nil || result.Snapshot.Meta.RunState != RunSucceeded || result.Snapshot.Meta.StopVisitID != second.VisitID ||
+			result.Snapshot.Meta.StopLimitStepID != "loop" || result.Snapshot.Meta.StopLimitTrigger == nil ||
+			result.Snapshot.Meta.StopLimitIteration != 3 || result.Plan.Terminal == nil ||
+			result.Plan.Terminal.Outcome != workflow.OutcomeSucceeded || result.Snapshot.Meta.Visits[1].State != scheduler.Pending {
+			t.Fatalf("onLimit не завершил run при активной параллельной ветке: %+v, %v", result, err)
+		}
+	})
+}
+
+// TestAdvanceAgentGraphLimitWaitsForDecisionWave воспроизводит гонку между
+// готовой after-активацией N+1 и уже сохранённым, но ещё не завершившимся
+// choose_decision. Пока Result второго агента не получен, limit не публикуется;
+// после Result явный finish обязан победить независимо от скорости callback.
+func TestAdvanceAgentGraphLimitWaitsForDecisionWave(t *testing.T) {
+	root := t.TempDir()
+	input := Input{WorkflowJSON: []byte(`{
+  "version":2,"id":"limit-versus-decision","start":["first","second"],"steps":[
+    {"id":"first","type":"agent","prompt":"Первый источник","after":[],"decisions":{"go":{"to":["source"]}}},
+    {"id":"second","type":"agent","prompt":"Второй источник","after":[],"decisions":{"go":{"to":["source"]}}},
+    {"id":"source","type":"agent","prompt":"Источник","after":[]},
+    {"id":"limited","type":"agent","prompt":"Ограниченная ветка","after":["source"],"maxVisits":1},
+    {"id":"choice","type":"agent","prompt":"Финальное решение","after":["source"],"decisions":{"done":{"finish":"succeeded"}}}
+  ]
+}`), Task: "Проверить барьер решений перед лимитом", CWD: t.TempDir()}
+	initial, err := CreateAgentGraph(root, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+
+	finishDecisionVisit(t, run, initial.Meta.Visits[0].VisitID, "go")
+	finishDecisionVisit(t, run, initial.Meta.Visits[1].VisitID, "go")
+	firstWave, err := run.AdvanceAgentGraph()
+	if err != nil || len(firstWave.CreatedVisits) != 1 || firstWave.CreatedVisits[0].StepID != "source" {
+		t.Fatalf("первая волна не сериализовала общий target: %+v, %v", firstWave, err)
+	}
+	finishPlainVisit(t, run, firstWave.CreatedVisits[0].VisitID)
+
+	secondWave, err := run.AdvanceAgentGraph()
+	if err != nil || len(secondWave.CreatedVisits) != 3 {
+		t.Fatalf("вторая волна не создала source и обе after-ветки: %+v, %v", secondWave, err)
+	}
+	created := make(map[string]Visit, len(secondWave.CreatedVisits))
+	for _, visit := range secondWave.CreatedVisits {
+		created[visit.StepID] = visit
+	}
+	for _, stepID := range []string{"source", "limited", "choice"} {
+		if created[stepID].VisitID == "" {
+			t.Fatalf("во второй волне нет шага %q: %+v", stepID, secondWave.CreatedVisits)
+		}
+	}
+	finishPlainVisit(t, run, created["source"].VisitID)
+	finishPlainVisit(t, run, created["limited"].VisitID)
+	choiceChatID := runDecisionVisit(t, run, created["choice"].VisitID, "done")
+
+	waiting, err := run.AdvanceAgentGraph()
+	if err != nil || waiting.Changed || waiting.Snapshot.Meta.RunState != RunRunning || waiting.Plan.Terminal != nil {
+		t.Fatalf("after-limit обошёл незавершённую decision-wave: %+v, %v", waiting, err)
+	}
+	if err := run.UpdateVisit(created["choice"].VisitID, scheduler.Succeeded, choiceChatID, ""); err != nil {
+		t.Fatal(err)
+	}
+	finished, err := run.AdvanceAgentGraph()
+	if err != nil || !finished.Changed || finished.Snapshot.Meta.RunState != RunSucceeded ||
+		finished.Snapshot.Meta.StopVisitID != created["choice"].VisitID || finished.Snapshot.Meta.StopLimitStepID != "" ||
+		finished.Snapshot.Meta.StopLimitTrigger != nil || finished.Snapshot.Meta.StopLimitIteration != 0 ||
+		finished.Plan.Terminal == nil || finished.Plan.Terminal.Outcome != workflow.OutcomeSucceeded {
+		t.Fatalf("завершённая decision-wave не выбрала explicit finish: %+v, %v", finished, err)
+	}
+}
+
+// TestAgentLimitProofSurvivesTerminalDrain фиксирует монотонность durable
+// maxVisits-proof. После публикации limit-a независимый Running source-b может
+// завершиться и открыть более ранний по Workflow limit-b с другим onLimit.
+// Сохранённый исход уже необратим и проверяется своей локальной причиной, а не
+// повторным планированием изменившегося глобального frontier.
+func TestAgentLimitProofSurvivesTerminalDrain(t *testing.T) {
+	root := t.TempDir()
+	input := Input{WorkflowJSON: []byte(`{
+  "version":2,"id":"stable-limit-proof","start":["a1","a2","b1","b2"],"steps":[
+    {"id":"a1","type":"agent","prompt":"A1","after":[],"decisions":{"go":{"to":["source-a"]}}},
+    {"id":"a2","type":"agent","prompt":"A2","after":[],"decisions":{"go":{"to":["source-a"]}}},
+    {"id":"b1","type":"agent","prompt":"B1","after":[],"decisions":{"go":{"to":["source-b"]}}},
+    {"id":"b2","type":"agent","prompt":"B2","after":[],"decisions":{"go":{"to":["source-b"]}}},
+    {"id":"source-a","type":"agent","prompt":"Источник A","after":[]},
+    {"id":"source-b","type":"agent","prompt":"Источник B","after":[]},
+    {"id":"limit-b","type":"agent","prompt":"Лимит B","after":["source-b"],"maxVisits":1,"onLimit":"succeeded"},
+    {"id":"limit-a","type":"agent","prompt":"Лимит A","after":["source-a"],"maxVisits":1}
+  ]
+}`), Task: "Проверить стабильность причины лимита", CWD: t.TempDir()}
+	initial, err := CreateAgentGraph(root, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+	for _, visit := range initial.Meta.Visits {
+		finishDecisionVisit(t, run, visit.VisitID, "go")
+	}
+
+	firstWave, err := run.AdvanceAgentGraph()
+	if err != nil || len(firstWave.CreatedVisits) != 2 {
+		t.Fatalf("первые общие targets не созданы: %+v, %v", firstWave, err)
+	}
+	for _, visit := range firstWave.CreatedVisits {
+		finishPlainVisit(t, run, visit.VisitID)
+	}
+	secondWave, err := run.AdvanceAgentGraph()
+	if err != nil || len(secondWave.CreatedVisits) != 4 {
+		t.Fatalf("вторые sources и первые limit-visits не созданы: %+v, %v", secondWave, err)
+	}
+	created := make(map[string]Visit, len(secondWave.CreatedVisits))
+	for _, visit := range secondWave.CreatedVisits {
+		created[visit.StepID] = visit
+	}
+	for _, stepID := range []string{"source-a", "source-b", "limit-a", "limit-b"} {
+		if created[stepID].VisitID == "" {
+			t.Fatalf("во второй волне нет шага %q: %+v", stepID, secondWave.CreatedVisits)
+		}
+	}
+	finishPlainVisit(t, run, created["source-a"].VisitID)
+	sourceBChatID := runDecisionlessVisit(t, run, created["source-b"].VisitID)
+	finishPlainVisit(t, run, created["limit-a"].VisitID)
+	finishPlainVisit(t, run, created["limit-b"].VisitID)
+
+	limited, err := run.AdvanceAgentGraph()
+	if err != nil || !limited.Changed || limited.Snapshot.Meta.RunState != RunFailed ||
+		limited.Snapshot.Meta.StopLimitStepID != "limit-a" || limited.Snapshot.Meta.StopLimitTrigger == nil ||
+		!slices.Equal(limited.Snapshot.Meta.StopLimitTrigger.SourceVisitIDs, []string{created["source-a"].VisitID}) {
+		t.Fatalf("готовый limit-a не опубликован: %+v, %v", limited, err)
+	}
+	if err := run.UpdateVisit(created["source-b"].VisitID, scheduler.Succeeded, sourceBChatID, ""); err != nil {
+		t.Fatalf("terminal drain инвалидировал сохранённый limit-proof: %v", err)
+	}
+	drained, err := run.Load()
+	if err != nil || drained.Meta.RunState != RunFailed || drained.Meta.StopLimitStepID != "limit-a" {
+		t.Fatalf("terminal drain изменил опубликованный исход: %+v, %v", drained.Meta, err)
+	}
+	replanned, err := scheduler.PlanAgentGraph(drained.Workflow, agentVisitViews(drained.Meta.Visits))
+	if err != nil || replanned.Terminal == nil || replanned.Terminal.LimitStepID != "limit-b" ||
+		replanned.Terminal.Outcome != workflow.OutcomeSucceeded {
+		t.Fatalf("fixture не открыла конкурирующий limit-b после drain: %+v, %v", replanned, err)
+	}
+}
+
+// TestAdvanceAgentGraphGuards отклоняет legacy и повреждённую историю до любой
+// новой памяти или metadata.
 func TestAdvanceAgentGraphGuards(t *testing.T) {
 	t.Run("legacy", func(t *testing.T) {
 		root := t.TempDir()
@@ -313,25 +660,6 @@ func TestAdvanceAgentGraphGuards(t *testing.T) {
 		defer run.Close()
 		if _, err := run.AdvanceAgentGraph(); err == nil {
 			t.Fatal("legacy run принят visit-aware bridge")
-		}
-	})
-	t.Run("cycle", func(t *testing.T) {
-		input := advanceInput(t)
-		input.WorkflowJSON = []byte(`{"version":2,"id":"cycle","start":["loop"],"steps":[
-          {"id":"loop","type":"agent","prompt":"Повтори","after":[],"maxVisits":2,
-           "decisions":{"repeat":{"to":["loop"]},"done":{"finish":"succeeded"}}}]}`)
-		root := t.TempDir()
-		snapshot, err := CreateAgentGraph(root, input)
-		if err != nil {
-			t.Fatal(err)
-		}
-		run, err := OpenLocked(root, snapshot.Meta.RunID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer run.Close()
-		if _, err := run.AdvanceAgentGraph(); !errors.Is(err, scheduler.ErrAgentGraphCycle) {
-			t.Fatalf("циклический workflow прошёл первый runtime: %v", err)
 		}
 	})
 	t.Run("tampered", func(t *testing.T) {

--- a/internal/runstore/store.go
+++ b/internal/runstore/store.go
@@ -70,18 +70,24 @@ type Input struct {
 // v2; пустое значение у прежнего v1 означает корень дерева. ChildRequestID есть
 // у app-server детей v3/v4 и не содержит исходный callId. Steps принадлежат лишь
 // legacy v1-v3, а v4 хранит общий RunState и append-only Visits.
+// StopLimit-поля присутствуют только при terminal maxVisits: StopVisitID
+// указывает на последний разрешённый visit, а trigger/iteration описывают
+// следующую активацию N+1, которую planner намеренно не материализовал.
 type Metadata struct {
-	Version           int      `json:"version"`
-	RunID             string   `json:"runId"`
-	ParentRunID       string   `json:"parentRunId,omitempty"`
-	ChildRequestID    string   `json:"childRequestId,omitempty"`
-	CWD               string   `json:"cwd"`
-	InitiatorThreadID string   `json:"initiatorThreadId,omitempty"` // Только чтение форматов v1/v2.
-	Steps             []Step   `json:"steps,omitempty"`
-	RunState          RunState `json:"runState,omitempty"`
-	StopReason        string   `json:"stopReason,omitempty"`
-	StopVisitID       string   `json:"stopVisitId,omitempty"`
-	Visits            []Visit  `json:"visits,omitempty"`
+	Version            int           `json:"version"`
+	RunID              string        `json:"runId"`
+	ParentRunID        string        `json:"parentRunId,omitempty"`
+	ChildRequestID     string        `json:"childRequestId,omitempty"`
+	CWD                string        `json:"cwd"`
+	InitiatorThreadID  string        `json:"initiatorThreadId,omitempty"` // Только чтение форматов v1/v2.
+	Steps              []Step        `json:"steps,omitempty"`
+	RunState           RunState      `json:"runState,omitempty"`
+	StopReason         string        `json:"stopReason,omitempty"`
+	StopVisitID        string        `json:"stopVisitId,omitempty"`
+	StopLimitStepID    string        `json:"stopLimitStepId,omitempty"`
+	StopLimitTrigger   *VisitTrigger `json:"stopLimitTrigger,omitempty"`
+	StopLimitIteration int           `json:"stopLimitIteration,omitzero"`
+	Visits             []Visit       `json:"visits,omitempty"`
 }
 
 // Step связывает legacy ID из графа с отдельным файлом памяти, thread и последним
@@ -554,7 +560,8 @@ func validateMetadataShape(data []byte, metadata Metadata) error {
 		}
 		return nil
 	}
-	if metadata.Version >= 1 && metadata.Version <= 3 && (has("runState") || has("stopReason") || has("stopVisitId") || has("visits")) {
+	if metadata.Version >= 1 && metadata.Version <= 3 && (has("runState") || has("stopReason") || has("stopVisitId") || has("stopLimitStepId") ||
+		has("stopLimitTrigger") || has("stopLimitIteration") || has("visits")) {
 		return fmt.Errorf("legacy metadata не может содержать поля v4")
 	}
 	return nil
@@ -575,7 +582,8 @@ func (s Snapshot) validate(runID string) error {
 		m.ChildRequestID != "" && (m.Version != 3 || m.ParentRunID == "" || !validID(m.ChildRequestID)) ||
 		!filepath.IsAbs(m.CWD) || !validText(m.CWD) || strings.ContainsRune(m.CWD, 0) ||
 		oldFormat && !validText(m.InitiatorThreadID) || m.Version == 3 && m.InitiatorThreadID != "" ||
-		m.RunState != "" || m.StopReason != "" || m.StopVisitID != "" || m.Visits != nil ||
+		m.RunState != "" || m.StopReason != "" || m.StopVisitID != "" || m.StopLimitStepID != "" || m.StopLimitTrigger != nil ||
+		m.StopLimitIteration != 0 || m.Visits != nil ||
 		len(m.Steps) != len(s.Workflow.Steps) {
 		return fmt.Errorf("повреждены входы, версия или состав meta.json")
 	}

--- a/internal/runstore/visits.go
+++ b/internal/runstore/visits.go
@@ -94,8 +94,9 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 	if err := s.Workflow.Validate(); err != nil {
 		return fmt.Errorf("workflow v4: %w", err)
 	}
+	hasLimitProof := m.StopLimitStepID != "" || m.StopLimitTrigger != nil || m.StopLimitIteration != 0
 	if m.RunState != RunRunning && m.RunState != RunSucceeded && m.RunState != RunFailed ||
-		m.RunState == RunRunning && (m.StopReason != "" || m.StopVisitID != "") ||
+		m.RunState == RunRunning && (m.StopReason != "" || m.StopVisitID != "" || hasLimitProof) ||
 		m.RunState != RunRunning && !safeStoredText(m.StopReason, true) {
 		return fmt.Errorf("runState не соответствует безопасной причине остановки")
 	}
@@ -119,6 +120,9 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 		numbers[visit.StepID]++
 		if visit.Visit != numbers[visit.StepID] || visit.Iteration < 1 || visit.Attempt < 0 {
 			return fmt.Errorf("посещение %q: нарушена нумерация visit/iteration/attempt", visit.VisitID)
+		}
+		if step.MaxVisits != nil && visit.Visit > *step.MaxVisits {
+			return fmt.Errorf("посещение %q превышает maxVisits=%d шага %q", visit.VisitID, *step.MaxVisits, visit.StepID)
 		}
 		if err := validateVisitState(visit, chats); err != nil {
 			return fmt.Errorf("посещение %q: %w", visit.VisitID, err)
@@ -171,14 +175,62 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 	if matchingFinishID != "" && m.StopVisitID != matchingFinishID {
 		return fmt.Errorf("terminal finish требует свой visitId как причину остановки")
 	}
+	limitTerminal := false
+	if hasLimitProof {
+		if m.StopLimitStepID == "" || m.StopLimitTrigger == nil || m.StopLimitIteration < 1 {
+			return fmt.Errorf("остановка по maxVisits требует полный trigger и iteration")
+		}
+		limitedStep, exists := steps[m.StopLimitStepID]
+		if !exists || limitedStep.MaxVisits == nil {
+			return fmt.Errorf("stopLimitStepId не ссылается на шаг с maxVisits")
+		}
+		if !hasStopVisit || stopVisit.StepID != limitedStep.ID || stopVisit.Visit != *limitedStep.MaxVisits || numbers[limitedStep.ID] != *limitedStep.MaxVisits {
+			return fmt.Errorf("остановка по maxVisits требует последний разрешённый visit ограниченного шага")
+		}
+		outcome, expected := workflow.OutcomeFailed, RunFailed
+		if limitedStep.OnLimit != nil {
+			outcome = *limitedStep.OnLimit
+		}
+		if outcome == workflow.OutcomeSucceeded {
+			expected = RunSucceeded
+		}
+		if m.RunState != expected {
+			return fmt.Errorf("onLimit шага %q не совпадает с runState", limitedStep.ID)
+		}
+		if matchingFinishID != "" {
+			return fmt.Errorf("остановка по maxVisits не может одновременно содержать applied finish")
+		}
+		// Planner допускает route/after/limit только после закрытия текущей
+		// decision-wave. Это свойство монотонно после terminal: новые visits и
+		// turns запрещены, а незавершённые внешние Result могут лишь закрыть волну.
+		if err := validateLimitDecisionBarrier(m.Visits, steps); err != nil {
+			return fmt.Errorf("остановка по maxVisits обошла decision-wave: %w", err)
+		}
+		// Проверяем сохранённую неслучившуюся активацию локально. Полный planner
+		// переигрывать нельзя: terminal drain может завершить независимый visit и
+		// открыть более ранний маршрут, не меняя уже опубликованный исход.
+		if err := validateLimitTrigger(
+			limitedStep, *m.StopLimitTrigger, m.StopLimitIteration, m.Visits,
+			seen, steps, numbers, active, afterUses, decisionUses,
+		); err != nil {
+			return fmt.Errorf("остановка по maxVisits не подтверждена trigger: %w", err)
+		}
+		limitTerminal = true
+	}
 	fatalDecision := false
 	if hasStopVisit {
 		step := steps[stopVisit.StepID]
 		fatalDecision = len(step.Decisions) != 0 && (stopVisit.Decision != nil && stopVisit.Decision.Error != "" ||
 			stopVisit.Decision == nil && stopVisit.State == scheduler.Succeeded)
 	}
+	if limitTerminal && fatalDecision {
+		return fmt.Errorf("остановка по maxVisits не может одновременно ссылаться на ошибку решения")
+	}
 	if m.RunState != RunRunning && matchingFinishID == "" {
 		switch {
+		case limitTerminal:
+			// Структурное доказательство проверено выше; активные независимые
+			// visits допустимы, потому что limit, как и finish, завершает весь run.
 		case fatalDecision:
 			if m.RunState != RunFailed {
 				return fmt.Errorf("ошибка решения может завершить run только как failed")
@@ -198,10 +250,117 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 			}
 		}
 	}
-	if m.RunState != RunRunning && len(active) != 0 && matchingFinishID == "" && !fatalDecision {
-		return fmt.Errorf("терминальный run с незавершёнными visits требует применённый finish или ошибку решения")
+	if m.RunState != RunRunning && len(active) != 0 && matchingFinishID == "" && !fatalDecision && !limitTerminal {
+		return fmt.Errorf("терминальный run с незавершёнными visits требует finish, maxVisits или ошибку решения")
 	}
 	return nil
+}
+
+// validateLimitDecisionBarrier сохраняет только те приоритеты planner, которые
+// можно доказать и после terminal drain. Незавершённое решение, fatal marker или
+// explicit finish обязательно предшествовали бы limit; обычные route допустимы,
+// поскольку planner мог отбросить уже собранные activations ради атомарного итога.
+func validateLimitDecisionBarrier(history []Visit, steps map[string]workflow.Step) error {
+	for _, visit := range history {
+		step := steps[visit.StepID]
+		if len(step.Decisions) == 0 || visit.Decision != nil && visit.Decision.Applied {
+			continue
+		}
+		if visit.Decision != nil && visit.Decision.Error != "" {
+			return fmt.Errorf("посещение %q содержит приоритетную ошибку решения", visit.VisitID)
+		}
+		if !visitTerminal(visit.State) {
+			return fmt.Errorf("посещение %q ещё не завершило decision-wave", visit.VisitID)
+		}
+		if visit.State != scheduler.Succeeded {
+			continue
+		}
+		if visit.Decision == nil {
+			return fmt.Errorf("посещение %q завершилось без обязательного решения", visit.VisitID)
+		}
+		if route := step.Decisions[visit.Decision.Key]; route.Finish != nil {
+			return fmt.Errorf("посещение %q содержит более приоритетный explicit finish", visit.VisitID)
+		}
+	}
+	return nil
+}
+
+// validateLimitTrigger доказывает конкретную неслучившуюся активацию N+1, не
+// сравнивая её с глобальным приоритетом изменившегося после terminal frontier.
+// Terminal visits неизменяемы, а новые visits после остановки запрещены, поэтому
+// локальные source/route/FIFO-связи остаются истинными после drain соседей.
+func validateLimitTrigger(
+	step workflow.Step,
+	trigger VisitTrigger,
+	iteration int,
+	history []Visit,
+	seen map[string]Visit,
+	steps map[string]workflow.Step,
+	numbers map[string]int,
+	active map[string]bool,
+	afterUses map[afterCause]bool,
+	decisionUses map[decisionCause]bool,
+) error {
+	if active[step.ID] {
+		return fmt.Errorf("ограниченный шаг ещё имеет активное посещение")
+	}
+	switch trigger.Kind {
+	case TriggerAfter:
+		proof := Visit{VisitID: "limit-proof", StepID: step.ID, Iteration: iteration, Trigger: trigger}
+		return validateTrigger(len(history), proof, step, nil, history, seen, afterUses, decisionUses)
+	case TriggerDecision:
+		if len(trigger.SourceVisitIDs) != 1 || trigger.DecisionKey == "" {
+			return fmt.Errorf("decision-limit требует один источник и ключ")
+		}
+		source, exists := seen[trigger.SourceVisitIDs[0]]
+		if !exists || source.State != scheduler.Succeeded || source.Decision == nil || source.Decision.Applied || source.Decision.Error != "" ||
+			source.Decision.Key != trigger.DecisionKey {
+			return fmt.Errorf("decision-limit ссылается не на готовое неприменённое решение")
+		}
+		route, exists := steps[source.StepID].Decisions[trigger.DecisionKey]
+		if !exists || route.Finish != nil || !slices.Contains(route.To, step.ID) ||
+			decisionUses[decisionCause{step.ID, source.VisitID}] || iteration != source.Iteration+1 {
+			return fmt.Errorf("decision-limit не совпадает с маршрутом, target или iteration")
+		}
+		firstLimited := ""
+		for _, target := range route.To {
+			if active[target] {
+				return fmt.Errorf("fanout decision-limit заблокирован активным target %q", target)
+			}
+			targetStep := steps[target]
+			if firstLimited == "" && targetStep.MaxVisits != nil && numbers[target] >= *targetStep.MaxVisits {
+				firstLimited = target
+			}
+		}
+		if firstLimited != step.ID {
+			return fmt.Errorf("decision-limit не является первой исчерпанной целью route.to")
+		}
+		return nil
+	default:
+		return fmt.Errorf("maxVisits не может быть вызван trigger %q", trigger.Kind)
+	}
+}
+
+// agentVisitViews копирует только семантику, которой владеет scheduler. Внешние
+// thread/turn, память и диагностика остаются деталями persistence/coordinator.
+// Helper живёт рядом с полной проверкой исходной истории, которую затем передаёт
+// pure planner атомарная операция AdvanceAgentGraph.
+func agentVisitViews(visits []Visit) []scheduler.AgentVisitView {
+	views := make([]scheduler.AgentVisitView, 0, len(visits))
+	for _, visit := range visits {
+		view := scheduler.AgentVisitView{
+			VisitID: visit.VisitID, StepID: visit.StepID, Iteration: visit.Iteration, State: visit.State,
+			Trigger: scheduler.AgentTriggerView{
+				Kind: scheduler.AgentTriggerKind(visit.Trigger.Kind), SourceVisitIDs: slices.Clone(visit.Trigger.SourceVisitIDs),
+				DecisionKey: visit.Trigger.DecisionKey,
+			},
+		}
+		if visit.Decision != nil {
+			view.Decision = &scheduler.AgentDecisionView{Key: visit.Decision.Key, Applied: visit.Decision.Applied, Error: visit.Decision.Error}
+		}
+		views = append(views, view)
+	}
+	return views
 }
 
 // Причины активации сравниваются составными ключами без склейки пользовательских

--- a/internal/runstore/visits_test.go
+++ b/internal/runstore/visits_test.go
@@ -137,9 +137,12 @@ func TestLegacyMetadataRejectsV4Fields(t *testing.T) {
 		t.Fatal(err)
 	}
 	for name, mutate := range map[string]func(*Metadata){
-		"runState":    func(meta *Metadata) { meta.RunState = RunRunning },
-		"stopReason":  func(meta *Metadata) { meta.StopReason = "неожиданное поле" },
-		"stopVisitId": func(meta *Metadata) { meta.StopVisitID = newID() },
+		"runState":           func(meta *Metadata) { meta.RunState = RunRunning },
+		"stopReason":         func(meta *Metadata) { meta.StopReason = "неожиданное поле" },
+		"stopVisitId":        func(meta *Metadata) { meta.StopVisitID = newID() },
+		"stopLimitStepId":    func(meta *Metadata) { meta.StopLimitStepID = "work" },
+		"stopLimitTrigger":   func(meta *Metadata) { meta.StopLimitTrigger = &VisitTrigger{Kind: TriggerAfter} },
+		"stopLimitIteration": func(meta *Metadata) { meta.StopLimitIteration = 1 },
 		"visits": func(meta *Metadata) {
 			meta.Visits = []Visit{{VisitID: newID(), StepID: "чужой"}}
 		},

--- a/internal/scheduler/agent.go
+++ b/internal/scheduler/agent.go
@@ -1,20 +1,11 @@
 package scheduler
 
 import (
-	"errors"
 	"fmt"
 	"slices"
-	"sort"
 
 	"github.com/stray-live-pixel/Lawa/internal/workflow"
 )
-
-// ErrAgentGraphCycle отмечает намеренное ограничение первого visit-aware runtime:
-// схема version=2 уже умеет описывать ограниченные циклы, но до появления учёта
-// maxVisits планировщик не должен запускать из такой схемы ни одного агента.
-// Вызывающий код проверяет ошибку через errors.Is; следующий срез runtime сможет
-// снять ограничение, не меняя остальные ошибки входного контракта.
-var ErrAgentGraphCycle = errors.New("visit-aware планировщик пока не поддерживает циклы")
 
 // AgentTriggerKind описывает сохранённую причину появления посещения. Тип живёт в
 // scheduler, а не в runstore, чтобы чистое ядро не зависело от файлового формата.
@@ -67,14 +58,21 @@ type AgentActivation struct {
 }
 
 // AgentTerminal — итог всего run. CauseVisitID связывает failed frontier, fatal
-// decision либо explicit finish с конкретным durable visit. Это структурированное
-// доказательство позволяет runstore проверить причину остановки, не разбирая
+// decision, explicit finish либо исчерпанный лимит с конкретным durable visit.
+// LimitStepID дополнительно отличает остановку maxVisits от естественного исхода:
+// runstore сможет проверить шаг, квоту и onLimit, не разбирая диагностический
 // Reason. Пустой CauseVisitID допустим только у естественного успешного исхода,
 // для которого единственного причинного посещения может не существовать.
 type AgentTerminal struct {
 	Outcome      workflow.TerminalOutcome
 	Reason       string
 	CauseVisitID string
+	LimitStepID  string
+	// LimitTrigger и LimitIteration фиксируют не созданную N+1 активацию. Они
+	// позволяют persistence проверять причину после drain соседних active visits,
+	// не переигрывая изменившийся глобальный frontier.
+	LimitTrigger   AgentTriggerView
+	LimitIteration int
 }
 
 // AgentPlan — детерминированный следующий атомарный переход. Decision-активации
@@ -88,16 +86,18 @@ type AgentPlan struct {
 }
 
 // PlanAgentGraph вычисляет следующий переход version=2 без I/O и не изменяет
-// workflow либо visits. Первый срез runtime исполняет только полный DAG: наличие
-// любого цикла, включая decision-route, возвращает ErrAgentGraphCycle до анализа
-// состояний, то есть до возможного запуска Codex.
+// workflow либо visits. Циклы допустимы только через decision-route и ограничены
+// MaxVisits на каждом входящем в цикл шаге решения — это заранее проверяет
+// Workflow.Validate. Планировщик считает все созданные visits целевого шага и
+// перед созданием N+1 атомарно завершает весь run с OnLimit (по умолчанию failed).
 //
-// Приоритеты намеренны. Сначала в порядке Visits выбирается terminal decision:
-// missing/poison завершает run ошибкой, finish — указанным исходом. Такой переход
-// не смешивается с новыми visits. Затем независимые route fanout применяются
-// атомарно, после них строятся FIFO after-barriers. Если действий и active visits
-// нет, исход определяет фактический terminal frontier: Failed на его границе даёт
-// failed, иначе граф естественно завершился успешно.
+// Приоритеты намеренны. Durable Decision.Error, отсутствующий выбор и неизвестный
+// ключ немедленно завершают run. Валидные решения ждут, пока все уже существующие
+// non-applied decision-visits достигнут Failed/Succeeded: итог параллельной волны
+// тогда зависит от порядка Visits, а не скорости ответов. После барьера terminal
+// decision не смешивается с новыми visits; обычные route fanout применяются
+// атомарно, затем строятся FIFO after. Без действий и active visits исход
+// определяет фактический terminal frontier.
 func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, error) {
 	if err := w.Validate(); err != nil {
 		return AgentPlan{}, fmt.Errorf("visit-aware планировщик: %w", err)
@@ -105,16 +105,18 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 	if w.EffectiveVersion() != workflow.VersionAgentGraph {
 		return AgentPlan{}, fmt.Errorf("visit-aware планировщик требует workflow version=2")
 	}
-	if agentGraphHasCycle(w) {
-		return AgentPlan{}, fmt.Errorf("%w: workflow %q", ErrAgentGraphCycle, w.ID)
-	}
-
 	context, err := validateAgentVisitViews(w, visits)
 	if err != nil {
 		return AgentPlan{}, fmt.Errorf("visit-aware планировщик: %w", err)
 	}
-	if terminal, exists := firstDecisionTerminal(context.steps, visits); exists {
+	if terminal, exists := firstDecisionFatal(context.steps, visits); exists {
 		return terminal, nil
+	}
+	decisionWaveComplete := agentDecisionWaveComplete(context.steps, visits)
+	if decisionWaveComplete {
+		if terminal, exists := firstDecisionTerminal(context.steps, visits); exists {
+			return terminal, nil
+		}
 	}
 
 	plan := AgentPlan{}
@@ -127,6 +129,9 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 	// занята, нельзя применить только свободную часть: повтор после crash иначе не
 	// сможет отличить полный маршрут от частично материализованного.
 	for _, visit := range visits {
+		if !decisionWaveComplete {
+			break
+		}
 		step := context.steps[visit.StepID]
 		decision := visit.Decision
 		if len(step.Decisions) == 0 || visit.State != Succeeded || decision == nil || decision.Applied || decision.Error != "" {
@@ -149,6 +154,15 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 		if blocked {
 			continue
 		}
+		// Проверяем квоты всего fanout до Applied и первой активации. Если хотя
+		// бы одна цель исчерпана, маршрут целиком остаётся unapplied, а terminal
+		// commit не может оставить частично созданные соседние targets.
+		for _, target := range route.To {
+			trigger := AgentTriggerView{Kind: AgentTriggerDecision, SourceVisitIDs: []string{visit.VisitID}, DecisionKey: decision.Key}
+			if terminal, reached := agentVisitLimitTerminal(context.steps[target], visit.Iteration+1, trigger, context); reached {
+				return AgentPlan{Terminal: terminal}, nil
+			}
+		}
 		plan.ApplyDecisionVisitIDs = append(plan.ApplyDecisionVisitIDs, visit.VisitID)
 		for _, target := range route.To {
 			plan.DecisionActivations = append(plan.DecisionActivations, AgentActivation{
@@ -157,6 +171,12 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 			})
 			projectedActive[target] = true
 		}
+	}
+	// After также ждёт decision-wave. Иначе параллельный Running decision мог бы
+	// завершиться между сохранением limit-terminal и drain: повторная проверка
+	// того же журнала выбрала бы его finish и сделала итог зависимым от timing.
+	if !decisionWaveComplete {
+		return AgentPlan{}, nil
 	}
 
 	// After рассматривается только после direct routes: если оба механизма хотят
@@ -169,6 +189,12 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 		sources, iteration, ready := nextAfterSources(step, context)
 		if !ready {
 			continue
+		}
+		trigger := AgentTriggerView{Kind: AgentTriggerAfter, SourceVisitIDs: sources}
+		if terminal, reached := agentVisitLimitTerminal(step, iteration, trigger, context); reached {
+			// Terminal нельзя смешивать с routes/after, уже накопленными выше:
+			// runstore публикует либо весь обычный переход, либо один итог.
+			return AgentPlan{Terminal: terminal}, nil
 		}
 		plan.AfterActivations = append(plan.AfterActivations, AgentActivation{
 			StepID: step.ID, Iteration: iteration,
@@ -206,6 +232,8 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 type agentPlanningContext struct {
 	steps          map[string]workflow.Step
 	active         map[string]bool
+	visitCount     map[string]int
+	lastVisit      map[string]AgentVisitView
 	terminalByStep map[string][]AgentVisitView
 	usedAfter      map[agentAfterCause]bool
 	advanced       map[string]bool
@@ -228,6 +256,7 @@ type agentDecisionCause struct {
 func validateAgentVisitViews(w workflow.Workflow, visits []AgentVisitView) (agentPlanningContext, error) {
 	context := agentPlanningContext{
 		steps: make(map[string]workflow.Step, len(w.Steps)), active: make(map[string]bool),
+		visitCount: make(map[string]int), lastVisit: make(map[string]AgentVisitView),
 		terminalByStep: make(map[string][]AgentVisitView), usedAfter: make(map[agentAfterCause]bool),
 		advanced: make(map[string]bool),
 	}
@@ -251,6 +280,11 @@ func validateAgentVisitViews(w workflow.Workflow, visits []AgentVisitView) (agen
 		if !knownAgentState(visit.State) {
 			return agentPlanningContext{}, fmt.Errorf("посещение %q: неизвестное состояние %q", visit.VisitID, visit.State)
 		}
+		context.visitCount[visit.StepID]++
+		if step.MaxVisits != nil && context.visitCount[visit.StepID] > *step.MaxVisits {
+			return agentPlanningContext{}, fmt.Errorf("посещение %q превышает maxVisits=%d шага %q", visit.VisitID, *step.MaxVisits, visit.StepID)
+		}
+		context.lastVisit[visit.StepID] = visit
 		if context.active[visit.StepID] {
 			return agentPlanningContext{}, fmt.Errorf("посещение %q появилось до завершения предыдущего visit шага %q", visit.VisitID, visit.StepID)
 		}
@@ -373,10 +407,10 @@ func validateAgentDecisionTrigger(visit AgentVisitView, seen map[string]AgentVis
 	return nil
 }
 
-// firstDecisionTerminal возвращает только terminal-переход. Обычные routes здесь
-// не материализуются: если более поздний visit уже требует немедленного завершения,
-// незаписанные активации более раннего route безопасно отбрасываются.
-func firstDecisionTerminal(steps map[string]workflow.Step, visits []AgentVisitView) (AgentPlan, bool) {
+// firstDecisionFatal ищет доказанную ошибку до wave-barrier. Durable poison,
+// отсутствующий choose_decision и неизвестный ключ не являются конкурирующими
+// исходами волны, поэтому не должны ждать зависший параллельный агент.
+func firstDecisionFatal(steps map[string]workflow.Step, visits []AgentVisitView) (AgentPlan, bool) {
 	for _, visit := range visits {
 		step := steps[visit.StepID]
 		if len(step.Decisions) == 0 {
@@ -384,7 +418,7 @@ func firstDecisionTerminal(steps map[string]workflow.Step, visits []AgentVisitVi
 		}
 		decision := visit.Decision
 		if decision != nil && decision.Error != "" {
-			return fatalDecisionPlan(visit, "durable решение содержит конфликт: "+decision.Error), true
+			return fatalDecisionPlan(visit, "durable решение содержит конфликт: "+visit.Decision.Error), true
 		}
 		if visit.State != Succeeded {
 			continue
@@ -392,13 +426,44 @@ func firstDecisionTerminal(steps map[string]workflow.Step, visits []AgentVisitVi
 		if decision == nil {
 			return fatalDecisionPlan(visit, "успешный turn завершился без choose_decision"), true
 		}
-		if decision.Applied {
-			continue
-		}
-		route, exists := step.Decisions[decision.Key]
-		if !exists {
+		if _, exists := step.Decisions[decision.Key]; !exists {
 			return fatalDecisionPlan(visit, fmt.Sprintf("сохранён неизвестный ключ решения %q", decision.Key)), true
 		}
+	}
+	return AgentPlan{}, false
+}
+
+// agentDecisionWaveComplete отделяет порядок Visits от скорости внешних Result.
+// Applied visits принадлежат прошлым волнам; каждый текущий decision visit должен
+// дойти именно до Failed/Succeeded. Cancelled и промежуточные состояния ещё можно
+// продолжить новым turn, поэтому они сохраняют барьер закрытым.
+func agentDecisionWaveComplete(steps map[string]workflow.Step, visits []AgentVisitView) bool {
+	for _, visit := range visits {
+		if len(steps[visit.StepID].Decisions) == 0 || visit.Decision != nil && visit.Decision.Applied {
+			continue
+		}
+		if !agentVisitTerminal(visit.State) {
+			return false
+		}
+	}
+	return true
+}
+
+// firstDecisionTerminal вызывается только для завершённой decision-wave и
+// возвращает её первый terminal-переход в порядке Visits. Обычные routes здесь
+// не материализуются: если visit требует завершения, накопление активаций даже
+// более раннего route безопасно не начинается.
+func firstDecisionTerminal(steps map[string]workflow.Step, visits []AgentVisitView) (AgentPlan, bool) {
+	for _, visit := range visits {
+		step := steps[visit.StepID]
+		if len(step.Decisions) == 0 {
+			continue
+		}
+		decision := visit.Decision
+		if visit.State != Succeeded || decision == nil || decision.Applied {
+			continue
+		}
+		route := step.Decisions[decision.Key]
 		if route.Finish != nil {
 			outcome := *route.Finish
 			return AgentPlan{
@@ -447,6 +512,30 @@ func nextAfterSources(step workflow.Step, context agentPlanningContext) ([]strin
 	return sources, maxIteration, true
 }
 
+// agentVisitLimitTerminal вызывается только непосредственно перед созданием
+// очередного посещения step и после проверки no-overlap. Поэтому count==limit
+// означает отказ именно от N+1, а CauseVisitID всегда указывает на последний
+// разрешённый visit N. Положительность лимита уже доказана Workflow.Validate.
+func agentVisitLimitTerminal(step workflow.Step, nextIteration int, trigger AgentTriggerView, context agentPlanningContext) (*AgentTerminal, bool) {
+	if step.MaxVisits == nil || context.visitCount[step.ID] < *step.MaxVisits {
+		return nil, false
+	}
+	last := context.lastVisit[step.ID]
+	outcome := workflow.OutcomeFailed
+	reason := fmt.Sprintf("шаг %q достиг maxVisits=%d; посещение %d с iteration=%d не создано; onLimit не задан, workflow завершён как %q",
+		step.ID, *step.MaxVisits, context.visitCount[step.ID]+1, nextIteration, outcome)
+	if step.OnLimit != nil {
+		outcome = *step.OnLimit
+		reason = fmt.Sprintf("шаг %q достиг maxVisits=%d; посещение %d с iteration=%d не создано; применён onLimit %q",
+			step.ID, *step.MaxVisits, context.visitCount[step.ID]+1, nextIteration, outcome)
+	}
+	trigger.SourceVisitIDs = slices.Clone(trigger.SourceVisitIDs)
+	return &AgentTerminal{
+		Outcome: outcome, Reason: reason, CauseVisitID: last.VisitID, LimitStepID: step.ID,
+		LimitTrigger: trigger, LimitIteration: nextIteration,
+	}, true
+}
+
 func knownAgentState(state State) bool {
 	switch state {
 	case Pending, Starting, Unknown, Running, WaitingForApproval, Failed, Cancelled, Succeeded:
@@ -458,61 +547,4 @@ func knownAgentState(state State) bool {
 
 func agentVisitTerminal(state State) bool {
 	return state == Failed || state == Succeeded
-}
-
-// agentGraphHasCycle проверяет объединение after и всех возможных route.to.
-// Рёбра дедуплицируются, а очередь Кана строится в порядке Steps. Решения map
-// обходятся по отсортированным ключам, поэтому даже внутренний порядок проверки
-// воспроизводим и не зависит от рантайма Go.
-func agentGraphHasCycle(w workflow.Workflow) bool {
-	indices := make(map[string]int, len(w.Steps))
-	for index, step := range w.Steps {
-		indices[step.ID] = index
-	}
-	graph := make([][]int, len(w.Steps))
-	remaining := make([]int, len(w.Steps))
-	seen := make([]map[int]bool, len(w.Steps))
-	addEdge := func(source, target int) {
-		if seen[source] == nil {
-			seen[source] = make(map[int]bool)
-		}
-		if seen[source][target] {
-			return
-		}
-		seen[source][target] = true
-		graph[source] = append(graph[source], target)
-		remaining[target]++
-	}
-	for target, step := range w.Steps {
-		for _, dependency := range step.After {
-			addEdge(indices[dependency], target)
-		}
-	}
-	for source, step := range w.Steps {
-		keys := make([]string, 0, len(step.Decisions))
-		for key := range step.Decisions {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			for _, target := range step.Decisions[key].To {
-				addEdge(source, indices[target])
-			}
-		}
-	}
-	queue := make([]int, 0, len(w.Steps))
-	for node, count := range remaining {
-		if count == 0 {
-			queue = append(queue, node)
-		}
-	}
-	for head := 0; head < len(queue); head++ {
-		for _, target := range graph[queue[head]] {
-			remaining[target]--
-			if remaining[target] == 0 {
-				queue = append(queue, target)
-			}
-		}
-	}
-	return len(queue) != len(w.Steps)
 }

--- a/internal/scheduler/agent_test.go
+++ b/internal/scheduler/agent_test.go
@@ -1,8 +1,8 @@
 package scheduler
 
 import (
-	"errors"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -184,6 +184,80 @@ func TestPlanAgentGraphDecisionFailures(t *testing.T) {
 	}
 }
 
+// TestPlanAgentGraphDecisionWaveBarrier фиксирует детерминизм параллельной
+// волны. Ни ранний, ни поздний finish не применяется, пока второй decision visit
+// ещё можно продолжить. После завершения обоих всегда побеждает порядок Visits;
+// только durable конфликт обходит барьер как уже доказанная fatal-ошибка.
+func TestPlanAgentGraphDecisionWaveBarrier(t *testing.T) {
+	w := agentWorkflow([]string{"first", "second"},
+		agentStep("first", nil, map[string]workflow.Route{"done": {Finish: agentOutcome(workflow.OutcomeSucceeded)}}),
+		agentStep("second", nil, map[string]workflow.Route{"stop": {Finish: agentOutcome(workflow.OutcomeFailed)}}),
+	)
+	firstDone := agentStartVisit("first-1", "first", Succeeded, 1, &AgentDecisionView{Key: "done"})
+	secondDone := agentStartVisit("second-1", "second", Succeeded, 1, &AgentDecisionView{Key: "stop"})
+	partials := [][]AgentVisitView{
+		{agentStartVisit("first-1", "first", Running, 1, nil), secondDone},
+		{firstDone, agentStartVisit("second-1", "second", Running, 1, nil)},
+	}
+	for _, visits := range partials {
+		if got, err := PlanAgentGraph(w, visits); err != nil || !reflect.DeepEqual(got, AgentPlan{}) {
+			t.Fatalf("частично завершённая decision-wave изменила run: %#v, %v", got, err)
+		}
+	}
+	got, err := PlanAgentGraph(w, []AgentVisitView{firstDone, secondDone})
+	if err != nil || got.Terminal == nil || got.Terminal.Outcome != workflow.OutcomeSucceeded || got.Terminal.CauseVisitID != "first-1" {
+		t.Fatalf("полная волна выбрала finish не по Visits: %#v, %v", got, err)
+	}
+	for _, fatal := range []struct {
+		name     string
+		state    State
+		decision *AgentDecisionView
+	}{
+		{name: "poison", state: Running, decision: &AgentDecisionView{Key: "stop", Error: "конфликт"}},
+		{name: "missing", state: Succeeded},
+		{name: "unknown", state: Succeeded, decision: &AgentDecisionView{Key: "other"}},
+	} {
+		t.Run(fatal.name, func(t *testing.T) {
+			visits := []AgentVisitView{
+				agentStartVisit("first-1", "first", Running, 1, nil),
+				agentStartVisit("second-1", "second", fatal.state, 1, fatal.decision),
+			}
+			fatalPlan, fatalErr := PlanAgentGraph(w, visits)
+			if fatalErr != nil || fatalPlan.Terminal == nil || fatalPlan.Terminal.Outcome != workflow.OutcomeFailed || fatalPlan.Terminal.CauseVisitID != "second-1" {
+				t.Fatalf("доказанная fatal-ошибка стала ждать барьер: %#v, %v", fatalPlan, fatalErr)
+			}
+		})
+	}
+}
+
+// TestPlanAgentGraphRouteWaitsForDecisionWave не даёт готовому route создать
+// target, пока параллельный decision visit Running. После его Failed барьер
+// закрыт, и маршрут материализуется обычным атомарным переходом.
+func TestPlanAgentGraphRouteWaitsForDecisionWave(t *testing.T) {
+	w := agentWorkflow([]string{"route", "gate", "source"},
+		agentStep("route", nil, map[string]workflow.Route{"go": {To: []string{"work"}}}),
+		agentStep("gate", nil, map[string]workflow.Route{"done": {Finish: agentOutcome(workflow.OutcomeSucceeded)}}),
+		agentStep("work", nil, nil),
+		agentStep("source", nil, nil),
+		agentStep("after", []string{"source"}, nil),
+	)
+	visits := []AgentVisitView{
+		agentStartVisit("route-1", "route", Succeeded, 1, &AgentDecisionView{Key: "go"}),
+		agentStartVisit("gate-1", "gate", Running, 1, nil),
+		agentStartVisit("source-1", "source", Succeeded, 1, nil),
+	}
+	if got, err := PlanAgentGraph(w, visits); err != nil || !reflect.DeepEqual(got, AgentPlan{}) {
+		t.Fatalf("route или after материализован до полного decision-wave: %#v, %v", got, err)
+	}
+	visits[1].State = Failed
+	got, err := PlanAgentGraph(w, visits)
+	if err != nil || !reflect.DeepEqual(got.ApplyDecisionVisitIDs, []string{"route-1"}) ||
+		len(got.DecisionActivations) != 1 || got.DecisionActivations[0].StepID != "work" ||
+		len(got.AfterActivations) != 1 || got.AfterActivations[0].StepID != "after" {
+		t.Fatalf("route и after не применены после закрытия барьера: %#v, %v", got, err)
+	}
+}
+
 // TestPlanAgentGraphFinishIsImmediate не позволяет параллельному Running visit
 // задержать явный finish или добавить в тот же атомарный commit обычные routes.
 func TestPlanAgentGraphFinishIsImmediate(t *testing.T) {
@@ -315,46 +389,107 @@ func TestPlanAgentGraphNaturalQuiescence(t *testing.T) {
 	})
 }
 
-// TestPlanAgentGraphRejectsCycles проверяет временную production-границу PR3a.
-// Оба workflow валидны по публичному v2-контракту благодаря maxVisits/onLimit,
-// однако pure planner возвращает узнаваемый sentinel до проверки visits.
-func TestPlanAgentGraphRejectsCycles(t *testing.T) {
+// TestPlanAgentGraphBoundedSelfLoop проверяет точную границу maxVisits. Второе
+// посещение ещё создаётся, но попытка третьего не применяет source decision и
+// сохраняет последний разрешённый visit как структурированную причину. Отдельно
+// проверяем безопасный failed по умолчанию, явный onLimit и повреждённый N+1.
+func TestPlanAgentGraphBoundedSelfLoop(t *testing.T) {
 	limit := 2
-	onLimit := workflow.OutcomeFailed
-	tests := []struct {
-		name  string
-		start []string
-		steps []workflow.Step
-	}{
-		{
-			name: "self loop", start: []string{"loop"},
-			steps: []workflow.Step{{
-				ID: "loop", Type: "agent", Prompt: "Повтори", After: []string{}, MaxVisits: &limit, OnLimit: &onLimit,
-				Decisions: map[string]workflow.Route{"again": {To: []string{"loop"}}},
-			}},
-		},
-		{
-			name: "two nodes", start: []string{"first"},
-			steps: []workflow.Step{
-				{ID: "first", Type: "agent", Prompt: "Первый", After: []string{}, MaxVisits: &limit, OnLimit: &onLimit,
-					Decisions: map[string]workflow.Route{"next": {To: []string{"second"}}}},
-				{ID: "second", Type: "agent", Prompt: "Второй", After: []string{}, MaxVisits: &limit, OnLimit: &onLimit,
-					Decisions: map[string]workflow.Route{"again": {To: []string{"first"}}}},
-			},
-		},
+	step := agentStep("loop", nil, map[string]workflow.Route{
+		"again": {To: []string{"loop"}}, "done": {Finish: agentOutcome(workflow.OutcomeSucceeded)},
+	})
+	step.MaxVisits = &limit
+	w := agentWorkflow([]string{"loop"}, step)
+	visits := []AgentVisitView{agentStartVisit("loop-1", "loop", Succeeded, 1, &AgentDecisionView{Key: "again"})}
+
+	got, err := PlanAgentGraph(w, visits)
+	if err != nil || !reflect.DeepEqual(got.ApplyDecisionVisitIDs, []string{"loop-1"}) || len(got.DecisionActivations) != 1 ||
+		got.DecisionActivations[0].StepID != "loop" || got.DecisionActivations[0].Iteration != 2 {
+		t.Fatalf("разрешённое второе посещение не создано: %#v, %v", got, err)
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			version := workflow.VersionAgentGraph
-			w := workflow.Workflow{Version: &version, ID: "cycle", Start: tc.start, Steps: tc.steps}
-			if err := w.Validate(); err != nil {
-				t.Fatalf("fixture обязан быть допустимым будущим v2-графом: %v", err)
-			}
-			got, err := PlanAgentGraph(w, nil)
-			if !errors.Is(err, ErrAgentGraphCycle) || !reflect.DeepEqual(got, AgentPlan{}) {
-				t.Fatalf("цикл не остановлен sentinel-ошибкой: %#v, %v", got, err)
-			}
-		})
+	visits[0].Decision.Applied = true
+	visits = append(visits, agentDecisionVisit("loop-2", "loop", Succeeded, 2, "loop-1", "again", &AgentDecisionView{Key: "again"}))
+	got, err = PlanAgentGraph(w, visits)
+	if err != nil || got.Terminal == nil || got.Terminal.Outcome != workflow.OutcomeFailed ||
+		got.Terminal.CauseVisitID != "loop-2" || got.Terminal.LimitStepID != "loop" ||
+		got.Terminal.LimitTrigger.Kind != AgentTriggerDecision ||
+		!slices.Equal(got.Terminal.LimitTrigger.SourceVisitIDs, []string{"loop-2"}) ||
+		got.Terminal.LimitTrigger.DecisionKey != "again" || got.Terminal.LimitIteration != 3 ||
+		len(got.ApplyDecisionVisitIDs) != 0 || len(got.DecisionActivations) != 0 || !strings.Contains(got.Terminal.Reason, "посещение 3") {
+		t.Fatalf("граница self-loop не дала атомарный failed: %#v, %v", got, err)
+	}
+
+	onLimit := workflow.OutcomeSucceeded
+	w.Steps[0].OnLimit = &onLimit
+	got, err = PlanAgentGraph(w, visits)
+	if err != nil || got.Terminal == nil || got.Terminal.Outcome != workflow.OutcomeSucceeded || !strings.Contains(got.Terminal.Reason, "onLimit") {
+		t.Fatalf("явный onLimit не определил исход: %#v, %v", got, err)
+	}
+
+	visits[1].Decision.Applied = true
+	visits = append(visits, agentDecisionVisit("loop-3", "loop", Pending, 3, "loop-2", "again", nil))
+	if got, err = PlanAgentGraph(w, visits); err == nil || !strings.Contains(err.Error(), "превышает maxVisits=2") || !reflect.DeepEqual(got, AgentPlan{}) {
+		t.Fatalf("сохранённое N+1 посещение прошло проверку: %#v, %v", got, err)
+	}
+}
+
+// TestPlanAgentGraphLimitKeepsFanoutAtomic фиксирует порядок route.to и
+// no-overlap. Пока beta активна, весь fanout ждёт. После её завершения первая
+// исчерпанная цель выбирает outcome, а source остаётся unapplied и ни alpha, ни
+// свободный target не материализуются частично.
+func TestPlanAgentGraphLimitKeepsFanoutAtomic(t *testing.T) {
+	limit := 1
+	succeeded := workflow.OutcomeSucceeded
+	choice := agentStep("choice", nil, map[string]workflow.Route{"go": {To: []string{"beta", "alpha", "free"}}})
+	beta, alpha := agentStep("beta", nil, nil), agentStep("alpha", nil, nil)
+	beta.MaxVisits, beta.OnLimit, alpha.MaxVisits = &limit, &succeeded, &limit
+	w := agentWorkflow([]string{"choice", "beta", "alpha"}, choice, beta, alpha, agentStep("free", nil, nil))
+	visits := []AgentVisitView{
+		agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "go"}),
+		agentStartVisit("beta-1", "beta", Running, 1, nil),
+		agentStartVisit("alpha-1", "alpha", Succeeded, 1, nil),
+	}
+	if got, err := PlanAgentGraph(w, visits); err != nil || !reflect.DeepEqual(got, AgentPlan{}) {
+		t.Fatalf("занятый fanout не был отложен целиком: %#v, %v", got, err)
+	}
+	visits[1].State = Succeeded
+	got, err := PlanAgentGraph(w, visits)
+	if err != nil || got.Terminal == nil || got.Terminal.Outcome != workflow.OutcomeSucceeded ||
+		got.Terminal.LimitStepID != "beta" || got.Terminal.CauseVisitID != "beta-1" ||
+		got.Terminal.LimitTrigger.Kind != AgentTriggerDecision ||
+		!slices.Equal(got.Terminal.LimitTrigger.SourceVisitIDs, []string{"choice-1"}) ||
+		got.Terminal.LimitTrigger.DecisionKey != "go" || got.Terminal.LimitIteration != 2 ||
+		len(got.ApplyDecisionVisitIDs) != 0 || len(got.DecisionActivations) != 0 {
+		t.Fatalf("limit fanout нарушил порядок или атомарность: %#v, %v", got, err)
+	}
+}
+
+// TestPlanAgentGraphMultiStepCycleIterations воспроизводит цикл
+// test -> checker -> fix -> test. FIFO after сохраняет номер волны, decision
+// увеличивает его, а третья готовая проверка останавливается на квоте checker=2.
+func TestPlanAgentGraphMultiStepCycleIterations(t *testing.T) {
+	limit := 2
+	testStep := agentStep("test", []string{"fix"}, nil)
+	checker := agentStep("checker", []string{"test"}, map[string]workflow.Route{
+		"repeat": {To: []string{"fix"}}, "done": {Finish: agentOutcome(workflow.OutcomeSucceeded)},
+	})
+	checker.MaxVisits = &limit
+	w := agentWorkflow([]string{"test"}, testStep, checker, agentStep("fix", nil, nil))
+	visits := []AgentVisitView{
+		agentStartVisit("test-1", "test", Succeeded, 1, nil),
+		agentAfterVisit("checker-1", "checker", Succeeded, 1, []string{"test-1"}, &AgentDecisionView{Key: "repeat", Applied: true}),
+		agentDecisionVisit("fix-1", "fix", Succeeded, 2, "checker-1", "repeat", nil),
+		agentAfterVisit("test-2", "test", Succeeded, 2, []string{"fix-1"}, nil),
+		agentAfterVisit("checker-2", "checker", Succeeded, 2, []string{"test-2"}, &AgentDecisionView{Key: "repeat", Applied: true}),
+		agentDecisionVisit("fix-2", "fix", Succeeded, 3, "checker-2", "repeat", nil),
+		agentAfterVisit("test-3", "test", Succeeded, 3, []string{"fix-2"}, nil),
+	}
+	got, err := PlanAgentGraph(w, visits)
+	if err != nil || got.Terminal == nil || got.Terminal.LimitStepID != "checker" || got.Terminal.CauseVisitID != "checker-2" ||
+		got.Terminal.LimitTrigger.Kind != AgentTriggerAfter ||
+		!slices.Equal(got.Terminal.LimitTrigger.SourceVisitIDs, []string{"test-3"}) || got.Terminal.LimitIteration != 3 ||
+		!strings.Contains(got.Terminal.Reason, "iteration=3") || len(got.AfterActivations) != 0 {
+		t.Fatalf("многошаговый цикл потерял квоту или iteration: %#v, %v", got, err)
 	}
 }
 
@@ -382,6 +517,13 @@ func agentDecisionVisit(visitID, stepID string, state State, iteration int, sour
 		VisitID: visitID, StepID: stepID, Iteration: iteration, State: state,
 		Trigger:  AgentTriggerView{Kind: AgentTriggerDecision, SourceVisitIDs: []string{sourceID}, DecisionKey: key},
 		Decision: decision,
+	}
+}
+
+func agentAfterVisit(visitID, stepID string, state State, iteration int, sourceIDs []string, decision *AgentDecisionView) AgentVisitView {
+	return AgentVisitView{
+		VisitID: visitID, StepID: stepID, Iteration: iteration, State: state,
+		Trigger: AgentTriggerView{Kind: AgentTriggerAfter, SourceVisitIDs: sourceIDs}, Decision: decision,
 	}
 }
 


### PR DESCRIPTION
Часть #50, поверх PR #79.

Что готово:
- maxVisits разрешает ровно N отдельных visits и останавливает попытку N+1;
- onLimit задаёт succeeded/failed, по умолчанию используется failed;
- decision fanout остаётся атомарным, повторные visits не пересекаются;
- незавершённая параллельная decision-wave удерживает route, after и limit до детерминированного выбора;
- metadata сохраняет step, trigger и iteration несозданной активации, поэтому crash/reopen и поздний terminal drain не переигрывают исход;
- legacy metadata явно отвергает новые поля v4.

Проверки:
- go test ./...
- go test -race -count=1 ./internal/scheduler ./internal/runstore
- go vet ./internal/scheduler ./internal/runstore
- ключевые runstore-регрессии повторены 10 раз на чистом снимке
- независимое ревью: APPROVE

Размер PR: 854 добавления, 192 удаления, всего 1046 изменённых строк. Это выше ориентира 500 строк, но ниже блокирующего предела 1200; крупный объём обусловлен законченными runtime-инвариантами, durable-валидацией и регрессионными сценариями.