### PR TITLE
Показать историю посещений agent-графа

### DIFF
--- a/cmd/lawa/main_test.go
+++ b/cmd/lawa/main_test.go
@@ -212,6 +212,33 @@ func TestStatusPublisherUpdatesFilesButThrottlesChat(t *testing.T) {
 	}
 }
 
+// TestStatusPublisherPrintsFailedAgentTerminalImmediately проверяет, что
+// Terminal обходит пятиминутный throttle и для неуспешного agent-графа, где
+// Complete заведомо остаётся false.
+func TestStatusPublisherPrintsFailedAgentTerminalImmediately(t *testing.T) {
+	runDir := t.TempDir()
+	now := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	var out bytes.Buffer
+	publisher := newStatusPublisher(t.Context(), &out, runDir, successfulCLIRenderer(), 5*time.Minute, func() time.Time { return now })
+	status := coordinator.Status{
+		RunID: "run-v4", WorkflowID: "flow", RunState: runstore.RunRunning,
+		Steps: []coordinator.StepStatus{{ID: "cube", VisitID: "visit-1", Visit: 1, State: scheduler.Running}},
+	}
+	if err := publisher.Publish(status); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Minute)
+	status.RunState, status.Terminal = runstore.RunFailed, true
+	status.StopReason, status.Steps[0].State = "решение остановило workflow", scheduler.Failed
+	if err := publisher.Publish(status); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); strings.Count(got, "Всего:") != 2 ||
+		!strings.Contains(got, "Run run-v4 завершён: failed.") || !strings.Contains(got, "Причина: решение остановило workflow") {
+		t.Fatalf("неуспешный terminal задержан или описан неверно: %q", got)
+	}
+}
+
 // TestStatusPublisherKeepsWorkflowAliveWithoutPlantUML фиксирует границу отказа:
 // renderer может отсутствовать, но подробный Markdown и короткая чат-сводка
 // остаются доступны; координатору возвращается только ошибка самого stdout.

--- a/cmd/lawa/status.go
+++ b/cmd/lawa/status.go
@@ -18,8 +18,8 @@ const defaultChatInterval = 5 * time.Minute
 // вызывается координатором последовательно, поэтому mutex не нужен: сначала
 // атомарно обновляются Markdown и PlantUML, затем при наступлении отдельного
 // пятиминутного срока печатается только короткая статистика и VS Code-ссылка.
-// Первый снимок и общий успех видны сразу, иначе пользователь мог бы пять минут
-// не знать runId или не получить своевременное подтверждение завершения.
+// Первый снимок и любой терминальный исход видны сразу, иначе пользователь мог
+// бы пять минут не знать runId или не получить подтверждение ошибки agent-графа.
 type statusPublisher struct {
 	ctx          context.Context
 	out          io.Writer
@@ -60,7 +60,7 @@ func newStatusPublisher(
 func (p *statusPublisher) Publish(status coordinator.Status) error {
 	_, artifactErr := statusreport.WriteReport(p.ctx, p.runDir, status, p.renderer)
 	now := p.now()
-	chatDue := !p.chatPrinted || status.Complete || !now.Before(p.lastChat.Add(p.chatInterval))
+	chatDue := !p.chatPrinted || status.Terminal || status.Complete || !now.Before(p.lastChat.Add(p.chatInterval))
 	if !chatDue {
 		return nil
 	}

--- a/internal/coordinator/execute.go
+++ b/internal/coordinator/execute.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stray-live-pixel/Lawa/internal/codex"
 	"github.com/stray-live-pixel/Lawa/internal/runstore"
 	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
 )
 
 // DefaultRefreshInterval ограничивает паузу между повторными снимками активного
@@ -105,14 +106,29 @@ func (c ProductionClient) OpenObserver(ctx context.Context, cwd string) (Observe
 	return codex.OpenObserver(ctx, codex.Connection{Executable: c.Executable, CWD: cwd, Stderr: c.Stderr, Directory: c.Directory})
 }
 
+// DecisionRouteStatus — статический разрешённый выход decision-кубика. Порядок
+// элементов в StepStatus детерминирован ключом, To сохраняет порядок workflow.
+type DecisionRouteStatus struct {
+	Key    string
+	To     []string
+	Finish *workflow.TerminalOutcome
+}
+
 // StepStatus — компактная строка отчёта без prompt, task.md и содержимого памяти.
 type StepStatus struct {
 	ID, ThreadID, CodexThreadID string
 	State                       scheduler.State
 	DependsOn                   []string
-	// VisitID заполнен только для meta v4. ID при этом остаётся
+	// VisitID и следующие durable-поля заполнены только для meta v4. ID остаётся
 	// логическим stepId, чтобы старые потребители статуса не теряли подписи.
-	VisitID string
+	VisitID                   string
+	Visit, Iteration, Attempt int
+	TechnicalError            string
+	Trigger                   runstore.VisitTrigger
+	Decision                  *runstore.DecisionRecord
+	DecisionRoutes            []DecisionRouteStatus
+	MaxVisits                 *int
+	OnLimit                   *workflow.TerminalOutcome
 }
 
 // Status — целостный снимок для терминала или другого интерфейса. Waiting
@@ -125,8 +141,10 @@ type Status struct {
 	Complete           bool
 	// RunState является авторитетным итогом meta v4. Terminal отделён от
 	// Complete: failed agent-graph завершён, но не является успешным.
-	RunState runstore.RunState
-	Terminal bool
+	RunState    runstore.RunState
+	StopReason  string
+	StopVisitID string
+	Terminal    bool
 }
 
 // Ticker скрывает реальное время за минимальной границей. Production использует
@@ -782,17 +800,39 @@ func currentStatus(run *runstore.LockedRun) (Status, string, error) {
 	}
 	status := Status{RunID: snapshot.Meta.RunID, WorkflowID: snapshot.Workflow.ID}
 	if snapshot.Meta.Version == 4 {
-		status.RunState = snapshot.Meta.RunState
+		status.RunState, status.StopReason, status.StopVisitID = snapshot.Meta.RunState, snapshot.Meta.StopReason, snapshot.Meta.StopVisitID
 		status.Terminal = snapshot.Meta.RunState != runstore.RunRunning
 		status.Complete = snapshot.Meta.RunState == runstore.RunSucceeded
+		steps := make(map[string]workflow.Step, len(snapshot.Workflow.Steps))
+		for _, step := range snapshot.Workflow.Steps {
+			steps[step.ID] = step
+		}
 		var signature strings.Builder
 		for _, visit := range snapshot.Meta.Visits {
+			step := steps[visit.StepID]
+			trigger := visit.Trigger
+			trigger.SourceVisitIDs = append([]string(nil), trigger.SourceVisitIDs...)
+			decision := cloneStatusDecision(visit.Decision)
+			maxVisits, onLimit := cloneOptionalInt(step.MaxVisits), cloneOptionalOutcome(step.OnLimit)
+			routes := statusDecisionRoutes(step)
 			status.Steps = append(status.Steps, StepStatus{
-				ID: visit.StepID, VisitID: visit.VisitID, CodexThreadID: visit.CodexThreadID, State: visit.State,
+				ID: visit.StepID, VisitID: visit.VisitID, CodexThreadID: visit.CodexThreadID,
+				State: visit.State, Visit: visit.Visit, Iteration: visit.Iteration, Attempt: visit.Attempt,
+				TechnicalError: visit.TechnicalError, Trigger: trigger, Decision: decision,
+				DecisionRoutes: routes, MaxVisits: maxVisits, OnLimit: onLimit,
 			})
-			fmt.Fprintf(&signature, "%q/%q=%q:%q:%q;", visit.StepID, visit.VisitID, visit.State, visit.CodexThreadID, visit.TurnID)
+			fmt.Fprintf(&signature, "%q/%q=%q:%q:%q:%d:%d:%d:trigger=%q/%q/%q:error=%q:max=%s:limit=%s;",
+				visit.StepID, visit.VisitID, visit.State, visit.CodexThreadID, visit.TurnID, visit.Visit, visit.Iteration, visit.Attempt,
+				trigger.Kind, trigger.SourceVisitIDs, trigger.DecisionKey, visit.TechnicalError, optionalIntText(maxVisits), optionalOutcomeText(onLimit))
+			if decision != nil {
+				fmt.Fprintf(&signature, "decision=%q:%q:%q:%s:%q:%t:%q;", decision.Key, decision.Explanation, decision.To,
+					optionalOutcomeText(decision.Finish), decision.Skipped, decision.Applied, decision.Error)
+			}
+			for _, route := range routes {
+				fmt.Fprintf(&signature, "route=%q:%q:%s;", route.Key, route.To, optionalOutcomeText(route.Finish))
+			}
 		}
-		fmt.Fprintf(&signature, "run=%s", status.RunState)
+		fmt.Fprintf(&signature, "run=%s;stop=%s:%s", status.RunState, status.StopVisitID, status.StopReason)
 		return status, signature.String(), nil
 	}
 
@@ -817,4 +857,62 @@ func currentStatus(run *runstore.LockedRun) (Status, string, error) {
 	status.Waiting, status.Complete = plan.Waiting, plan.Complete
 	fmt.Fprintf(&signature, "waiting=%s;complete=%t", strings.Join(plan.Waiting, ","), plan.Complete)
 	return status, signature.String(), nil
+}
+
+// cloneStatusDecision не отдаёт Notify срезы и указатель исходного Snapshot:
+// обработчик статуса может хранить или менять значение после возврата.
+func cloneStatusDecision(source *runstore.DecisionRecord) *runstore.DecisionRecord {
+	if source == nil {
+		return nil
+	}
+	result := *source
+	result.To = append([]string(nil), source.To...)
+	result.Skipped = append([]string(nil), source.Skipped...)
+	result.Finish = cloneOptionalOutcome(source.Finish)
+	return &result
+}
+
+// statusDecisionRoutes строит стабильную копию статических веток для Notify.
+func statusDecisionRoutes(step workflow.Step) []DecisionRouteStatus {
+	keys := sortedAgentDecisionKeys(step.Decisions)
+	result := make([]DecisionRouteStatus, 0, len(keys))
+	for _, key := range keys {
+		route := step.Decisions[key]
+		result = append(result, DecisionRouteStatus{Key: key, To: append([]string(nil), route.To...), Finish: cloneOptionalOutcome(route.Finish)})
+	}
+	return result
+}
+
+// cloneOptionalInt отделяет mutable указатель снимка от потребителя статуса.
+func cloneOptionalInt(source *int) *int {
+	if source == nil {
+		return nil
+	}
+	value := *source
+	return &value
+}
+
+// cloneOptionalOutcome копирует optional outcome для той же границы владения.
+func cloneOptionalOutcome(source *workflow.TerminalOutcome) *workflow.TerminalOutcome {
+	if source == nil {
+		return nil
+	}
+	value := *source
+	return &value
+}
+
+// optionalIntText даёт детерминированное значение без адреса указателя.
+func optionalIntText(value *int) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprint(*value)
+}
+
+// optionalOutcomeText даёт детерминированную сигнатуру terminal outcome.
+func optionalOutcomeText(value *workflow.TerminalOutcome) string {
+	if value == nil {
+		return ""
+	}
+	return string(*value)
 }

--- a/internal/coordinator/status_agent_test.go
+++ b/internal/coordinator/status_agent_test.go
@@ -1,0 +1,42 @@
+package coordinator
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stray-live-pixel/Lawa/internal/runstore"
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
+)
+
+// TestCurrentAgentStatusIncludesStaticAndDurableDetails проверяет границу между
+// snapshot и интерфейсами: статус получает причинность visit, лимит и все
+// статические маршруты в стабильном порядке, не возвращая указатели хранилища.
+func TestCurrentAgentStatusIncludesStaticAndDurableDetails(t *testing.T) {
+	_, initial, run := createAgentPreparationRun(t, `{
+  "version":2,"id":"status","start":["choice"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"maxVisits":2,"onLimit":"failed","decisions":{
+      "stop":{"finish":"succeeded"},"again":{"to":["choice"]}
+    }}
+  ]}`)
+	status, signature, err := currentStatus(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	visit := status.Steps[0]
+	succeeded := workflow.OutcomeSucceeded
+	if status.RunState != runstore.RunRunning || status.Terminal || status.StopReason != "" || status.StopVisitID != "" ||
+		visit.VisitID != initial.Meta.Visits[0].VisitID || visit.Visit != 1 || visit.Iteration != 1 || visit.Attempt != 0 ||
+		visit.Trigger.Kind != runstore.TriggerStart || visit.MaxVisits == nil || *visit.MaxVisits != 2 ||
+		visit.OnLimit == nil || *visit.OnLimit != workflow.OutcomeFailed ||
+		!reflect.DeepEqual(visit.DecisionRoutes, []DecisionRouteStatus{
+			{Key: "again", To: []string{"choice"}}, {Key: "stop", Finish: &succeeded},
+		}) {
+		t.Fatalf("статус v4 потерял поля посещения: %+v, signature=%q", status, signature)
+	}
+	for _, fragment := range []string{"max=2", "limit=failed", `route="again":["choice"]:`, `route="stop":[]:succeeded`} {
+		if !strings.Contains(signature, fragment) {
+			t.Fatalf("сигнатура не учитывает %q по значению: %q", fragment, signature)
+		}
+	}
+}

--- a/internal/statusreport/report.go
+++ b/internal/statusreport/report.go
@@ -64,6 +64,10 @@ func (r CommandRenderer) Render(ctx context.Context, source []byte) ([]byte, err
 	defer cancel()
 
 	command := exec.CommandContext(renderContext, executable, "-pipe")
+	// Даже после текстового экранирования запрещаем renderer читать локальные
+	// файлы и сеть через include/img. Наследуем остальное окружение процесса,
+	// заменяя только официальный профиль безопасности PlantUML.
+	command.Env = append(os.Environ(), "PLANTUML_SECURITY_PROFILE=SANDBOX")
 	command.Stdin = bytes.NewReader(source)
 	var stdout, stderr bytes.Buffer
 	command.Stdout, command.Stderr = &stdout, &stderr
@@ -148,16 +152,19 @@ func writeVisualization(ctx context.Context, runDir string, status coordinator.S
 	return artifacts, nil
 }
 
-// DetailedReport строит содержимое локального workflow-status.md. Каждый кубик
-// появляется ровно один раз и в порядке meta.json. Пустой codexThreadId никогда
-// не подменяется ссылкой на инициатора или другой чат. Успешный PNG подключается
-// относительной Markdown-ссылкой и отображается прямо при просмотре файла.
+// DetailedReport строит содержимое локального workflow-status.md. Для legacy
+// каждый кубик появляется один раз, для v4 каждое посещение — отдельной строкой
+// в порядке meta.json. Пустой codexThreadId никогда не подменяется другим чатом.
 func DetailedReport(status coordinator.Status, runDir string, artifacts Artifacts, visualizationErr error) string {
 	var message strings.Builder
 	waitingForCapacity := stringSet(status.WaitingForCapacity)
 	fmt.Fprintf(&message, "# Статус workflow \"%s\"\n\n", markdownText(status.WorkflowID))
 	for _, step := range status.Steps {
-		label := markdownText(step.ID)
+		labelText, capacityKey := step.ID, step.ID
+		if isAgentStatus(status) {
+			labelText, capacityKey = fmt.Sprintf("%s#%d", step.ID, step.Visit), step.VisitID
+		}
+		label := markdownText(labelText)
 		if step.CodexThreadID != "" {
 			label = fmt.Sprintf("[%s](%s)", label, codexThreadURL(step.CodexThreadID))
 		}
@@ -165,12 +172,24 @@ func DetailedReport(status coordinator.Status, runDir string, artifacts Artifact
 		if step.CodexThreadID == "" {
 			message.WriteString(" (чат ещё не создан)")
 		}
-		if waitingForCapacity[step.ID] {
+		if waitingForCapacity[capacityKey] {
 			message.WriteString(" (ждёт свободный слот общего лимита)")
 		}
 		message.WriteByte('\n')
+		if isAgentStatus(status) {
+			writeAgentVisitDetails(&message, step)
+		}
 	}
-	if status.Complete {
+	if isAgentStatus(status) && status.Terminal {
+		message.WriteByte('\n')
+		fmt.Fprintf(&message, "Run %s завершён: %s.\n", markdownText(status.RunID), markdownText(string(status.RunState)))
+		if status.StopVisitID != "" {
+			fmt.Fprintf(&message, "Остановившее посещение: %s.\n", markdownText(status.StopVisitID))
+		}
+		if status.StopReason != "" {
+			fmt.Fprintf(&message, "Причина остановки: %s\n", markdownText(status.StopReason))
+		}
+	} else if status.Complete {
 		message.WriteByte('\n')
 		fmt.Fprintf(&message, "Run %s успешно завершён.\n", markdownText(status.RunID))
 	}
@@ -192,6 +211,42 @@ func DetailedReport(status coordinator.Status, runDir string, artifacts Artifact
 	return message.String()
 }
 
+// writeAgentVisitDetails раскрывает durable-поля одного посещения отдельными
+// строками. Пропущенные ключи остаются свойством решения: отчёт не создаёт для
+// них фиктивные посещения и не приписывает состояние целевым step.
+func writeAgentVisitDetails(message *strings.Builder, step coordinator.StepStatus) {
+	fmt.Fprintf(message, "  - visitId: %s; итерация: %d; попытка: %d\n",
+		markdownText(step.VisitID), step.Iteration, step.Attempt)
+	if trigger := visitTriggerText(step); trigger != "" {
+		fmt.Fprintf(message, "  - причина запуска: %s\n", markdownText(trigger))
+	}
+	if step.MaxVisits != nil {
+		fmt.Fprintf(message, "  - предел: maxVisits=%d", *step.MaxVisits)
+		if step.OnLimit != nil {
+			fmt.Fprintf(message, "; onLimit=%s", markdownText(string(*step.OnLimit)))
+		}
+		message.WriteByte('\n')
+	}
+	if step.TechnicalError != "" {
+		fmt.Fprintf(message, "  - техническая ошибка: %s\n", markdownText(step.TechnicalError))
+	}
+	if step.Decision != nil {
+		fmt.Fprintf(message, "  - решение: %s; применено: %t\n", markdownText(step.Decision.Key), step.Decision.Applied)
+		if step.Decision.Explanation != "" {
+			fmt.Fprintf(message, "  - объяснение решения: %s\n", markdownText(step.Decision.Explanation))
+		}
+		if step.Decision.Error != "" {
+			fmt.Fprintf(message, "  - ошибка решения: %s\n", markdownText(step.Decision.Error))
+		}
+		if len(step.Decision.Skipped) != 0 {
+			fmt.Fprintf(message, "  - пропущенные ключи решений: %s\n", markdownText(strings.Join(step.Decision.Skipped, ", ")))
+		}
+	}
+	if routes := decisionRoutesText(step.DecisionRoutes); routes != "" {
+		fmt.Fprintf(message, "  - маршруты: %s\n", markdownText(routes))
+	}
+}
+
 // Summary строит короткий блок для редкой публикации в чат. Состояния, которые
 // нельзя честно назвать готовыми, работающими или ожидающими зависимости, не
 // скрываются: ошибки, отмена, неизвестность и ожидание подтверждения получают
@@ -209,7 +264,12 @@ func Summary(status coordinator.Status, runDir string, artifactErr error) string
 	if len(status.WaitingForCapacity) != 0 {
 		fmt.Fprintf(&message, "Свободный слот общего лимита ждут: %d.\n", len(status.WaitingForCapacity))
 	}
-	if status.Complete {
+	if isAgentStatus(status) && status.Terminal {
+		fmt.Fprintf(&message, "Run %s завершён: %s.\n", markdownText(status.RunID), markdownText(string(status.RunState)))
+		if status.StopReason != "" {
+			fmt.Fprintf(&message, "Причина: %s\n", markdownText(status.StopReason))
+		}
+	} else if status.Complete {
 		fmt.Fprintf(&message, "Run %s успешно завершён.\n", markdownText(status.RunID))
 	}
 	fmt.Fprintf(&message, "[Открыть статус в VS Code](%s)\n", vscodeFolderURL(runDir))
@@ -260,6 +320,15 @@ func countStates(status coordinator.Status) stateStatistics {
 // его нельзя спутать с succeeded. Алиасы step_N не используют внешние ID и тем
 // самым не дают содержимому workflow изменить синтаксис связей.
 func PlantUML(status coordinator.Status) ([]byte, error) {
+	if isAgentStatus(status) {
+		return agentPlantUML(status)
+	}
+	return legacyPlantUML(status)
+}
+
+// legacyPlantUML сохраняет прежнее представление v1-v3: узлом остаётся step,
+// а рёбрами — статические dependsOn. Это исключает визуальную миграцию старых run.
+func legacyPlantUML(status coordinator.Status) ([]byte, error) {
 	indices := make(map[string]int, len(status.Steps))
 	for index, step := range status.Steps {
 		if _, exists := indices[step.ID]; exists {
@@ -269,11 +338,7 @@ func PlantUML(status coordinator.Status) ([]byte, error) {
 	}
 
 	var source strings.Builder
-	source.WriteString("@startuml\n")
-	source.WriteString("skinparam shadowing false\n")
-	source.WriteString("skinparam defaultTextAlignment center\n")
-	source.WriteString("left to right direction\n")
-	fmt.Fprintf(&source, "title Workflow: %s\n", plantText(status.WorkflowID))
+	writePlantHeader(&source, status.WorkflowID)
 	for index, step := range status.Steps {
 		fmt.Fprintf(&source, "rectangle \"%s\\n%s\" as step_%d %s\n",
 			plantText(step.ID), plantText(string(step.State)), index, colorFor(step.State))
@@ -287,17 +352,146 @@ func PlantUML(status coordinator.Status) ([]byte, error) {
 			fmt.Fprintf(&source, "step_%d --> step_%d\n", parent, index)
 		}
 	}
+	writePlantLegend(&source)
+	source.WriteString("@enduml\n")
+	return []byte(source.String()), nil
+}
+
+// agentPlantUML строит историю v4 по VisitID. Причинные рёбра ссылаются только
+// на реально созданные посещения, поэтому невыбранные маршруты не выглядят как
+// запущенные или пропущенные узлы.
+func agentPlantUML(status coordinator.Status) ([]byte, error) {
+	indices := make(map[string]int, len(status.Steps))
+	for index, step := range status.Steps {
+		if step.VisitID == "" {
+			return nil, fmt.Errorf("посещение step %q не содержит visitId", step.ID)
+		}
+		if _, exists := indices[step.VisitID]; exists {
+			return nil, fmt.Errorf("повторный visitId %q в статусе", step.VisitID)
+		}
+		indices[step.VisitID] = index
+	}
+
+	var source strings.Builder
+	writePlantHeader(&source, status.WorkflowID)
+	for index, step := range status.Steps {
+		fmt.Fprintf(&source, "rectangle \"%s\" as visit_%d %s\n", plantText(agentVisitLabel(step)), index, colorFor(step.State))
+	}
+	for index, step := range status.Steps {
+		for _, sourceVisitID := range step.Trigger.SourceVisitIDs {
+			parent, exists := indices[sourceVisitID]
+			if !exists {
+				return nil, fmt.Errorf("посещение %q ссылается на отсутствующий sourceVisitId %q", step.VisitID, sourceVisitID)
+			}
+			fmt.Fprintf(&source, "visit_%d --> visit_%d : %s\n", parent, index, plantText(triggerEdgeText(step.Trigger)))
+		}
+	}
+	if status.StopVisitID != "" || status.StopReason != "" {
+		source.WriteString("note bottom\n")
+		fmt.Fprintf(&source, "Run: %s\nStop visit: %s\nReason: %s\n",
+			plantText(string(status.RunState)), plantText(status.StopVisitID), plantText(status.StopReason))
+		source.WriteString("end note\n")
+	}
+	writePlantLegend(&source)
+	source.WriteString("@enduml\n")
+	return []byte(source.String()), nil
+}
+
+// agentVisitLabel собирает полную подпись узла до единственного экранирования.
+func agentVisitLabel(step coordinator.StepStatus) string {
+	lines := []string{
+		fmt.Sprintf("%s#%d", step.ID, step.Visit),
+		"visitId: " + step.VisitID,
+		fmt.Sprintf("iteration: %d; attempt: %d", step.Iteration, step.Attempt),
+		string(step.State),
+	}
+	if step.MaxVisits != nil {
+		limit := fmt.Sprintf("maxVisits: %d", *step.MaxVisits)
+		if step.OnLimit != nil {
+			limit += "; onLimit: " + string(*step.OnLimit)
+		}
+		lines = append(lines, limit)
+	}
+	if step.TechnicalError != "" {
+		lines = append(lines, "technicalError: "+step.TechnicalError)
+	}
+	if step.Decision != nil {
+		lines = append(lines, fmt.Sprintf("decision: %s; applied: %t", step.Decision.Key, step.Decision.Applied))
+		if step.Decision.Explanation != "" {
+			lines = append(lines, "decision explanation: "+step.Decision.Explanation)
+		}
+		if len(step.Decision.Skipped) != 0 {
+			lines = append(lines, "skipped keys: "+strings.Join(step.Decision.Skipped, ", "))
+		}
+		if step.Decision.Error != "" {
+			lines = append(lines, "decision error: "+step.Decision.Error)
+		}
+	}
+	if routes := decisionRoutesText(step.DecisionRoutes); routes != "" {
+		lines = append(lines, "routes: "+routes)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// writePlantHeader сохраняет общие настройки схем legacy и v4 побайтно
+// одинаковыми, чтобы смена модели узлов не затрагивала оформление.
+func writePlantHeader(source *strings.Builder, workflowID string) {
+	source.WriteString("@startuml\n")
+	source.WriteString("skinparam shadowing false\n")
+	source.WriteString("skinparam defaultTextAlignment center\n")
+	source.WriteString("left to right direction\n")
+	fmt.Fprintf(source, "title Workflow: %s\n", plantText(workflowID))
+}
+
+// writePlantLegend перечисляет стабильные цвета обоих форматов статуса.
+func writePlantLegend(source *strings.Builder) {
 	source.WriteString("legend left\n")
 	source.WriteString("|= Цвет |= Состояние |\n")
 	for _, state := range []scheduler.State{
 		scheduler.Pending, scheduler.Starting, scheduler.Running,
 		scheduler.Succeeded, scheduler.Failed, scheduler.Unknown,
 	} {
-		fmt.Fprintf(&source, "|<%s> | %s |\n", colorFor(state), state)
+		fmt.Fprintf(source, "|<%s> | %s |\n", colorFor(state), state)
 	}
 	source.WriteString("endlegend\n")
-	source.WriteString("@enduml\n")
-	return []byte(source.String()), nil
+}
+
+// isAgentStatus отличает v4 по авторитетному RunState. У legacy это поле всегда
+// пусто, включая завершённые снимки, поэтому их формат остаётся неизменным.
+func isAgentStatus(status coordinator.Status) bool { return status.RunState != "" }
+
+// visitTriggerText описывает durable-причину запуска для Markdown.
+func visitTriggerText(step coordinator.StepStatus) string {
+	trigger := string(step.Trigger.Kind)
+	if step.Trigger.DecisionKey != "" {
+		trigger += ":" + step.Trigger.DecisionKey
+	}
+	if len(step.Trigger.SourceVisitIDs) != 0 {
+		trigger += " от " + strings.Join(step.Trigger.SourceVisitIDs, ", ")
+	}
+	return trigger
+}
+
+// triggerEdgeText оставляет на ребре тип перехода и выбранный decision-key.
+func triggerEdgeText(trigger runstore.VisitTrigger) string {
+	label := string(trigger.Kind)
+	if trigger.DecisionKey != "" {
+		label += ":" + trigger.DecisionKey
+	}
+	return label
+}
+
+// decisionRoutesText показывает статические выходы как атрибут visit, не узлы.
+func decisionRoutesText(routes []coordinator.DecisionRouteStatus) string {
+	formatted := make([]string, 0, len(routes))
+	for _, route := range routes {
+		destination := strings.Join(route.To, ", ")
+		if route.Finish != nil {
+			destination = "finish:" + string(*route.Finish)
+		}
+		formatted = append(formatted, route.Key+" → "+destination)
+	}
+	return strings.Join(formatted, "; ")
 }
 
 // colorFor задаёт стабильную легенду известных состояний. Нейтральный fallback
@@ -338,7 +532,8 @@ func vscodeFolderURL(path string) string {
 
 // markdownText оставляет видимый текст узнаваемым, но заменяет переносы и прочие
 // управляющие символы печатной записью. Скобки экранируются, чтобы ID не закрыл
-// собственную Markdown-ссылку и не подменил её адрес.
+// собственную Markdown-ссылку; HTML-границы кодируются, чтобы model-controlled
+// пояснение не добавило тег с локальным либо сетевым ресурсом.
 func markdownText(value string) string {
 	var result strings.Builder
 	for _, character := range value {
@@ -346,12 +541,18 @@ func markdownText(value string) string {
 		case '\\', '[', ']':
 			result.WriteByte('\\')
 			result.WriteRune(character)
+		case '&':
+			result.WriteString("&amp;")
+		case '<':
+			result.WriteString("&lt;")
+		case '>':
+			result.WriteString("&gt;")
 		case '\n':
 			result.WriteString(`\n`)
 		case '\r':
 			result.WriteString(`\r`)
 		default:
-			if unicode.IsControl(character) {
+			if unicode.IsControl(character) || unicode.In(character, unicode.Zl, unicode.Zp) {
 				fmt.Fprintf(&result, `\u%04X`, character)
 			} else {
 				result.WriteRune(character)
@@ -361,24 +562,26 @@ func markdownText(value string) string {
 	return result.String()
 }
 
-// plantText не позволяет данным workflow завершить строку или кавычки PlantUML.
-// Переводы строк сохраняются как видимый `\n` внутри подписи узла.
+// plantText не позволяет данным workflow попасть в синтаксис, preprocessor или
+// Creole/HTML PlantUML. Вся ASCII-пунктуация кодируется numeric entity и при
+// рендере выглядит исходным символом, но `%chr`, `<img>`, ссылки и embedded
+// diagrams не распознаются как разметка. Переводы строк остаются безопасным
+// `\n` внутри одной директивы; Unicode Zl/Zp печатаются как видимый код.
 func plantText(value string) string {
 	var result strings.Builder
 	for _, character := range value {
-		switch character {
-		case '\\':
-			result.WriteString(`\\`)
-		case '"':
-			result.WriteString(`\"`)
-		case '\n', '\r':
+		switch {
+		case character == '\n' || character == '\r':
 			result.WriteString(`\n`)
+		case unicode.IsControl(character) || unicode.In(character, unicode.Zl, unicode.Zp):
+			fmt.Fprintf(&result, `\u%04X`, character)
+		case character <= unicode.MaxASCII && character != ' ' &&
+			(character < '0' || character > '9') &&
+			(character < 'A' || character > 'Z') &&
+			(character < 'a' || character > 'z'):
+			fmt.Fprintf(&result, "&#%d;", character)
 		default:
-			if unicode.IsControl(character) {
-				fmt.Fprintf(&result, `\u%04X`, character)
-			} else {
-				result.WriteRune(character)
-			}
+			result.WriteRune(character)
 		}
 	}
 	return result.String()

--- a/internal/statusreport/report_test.go
+++ b/internal/statusreport/report_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 
 	"github.com/stray-live-pixel/Lawa/internal/coordinator"
+	"github.com/stray-live-pixel/Lawa/internal/runstore"
 	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
 )
 
 // rendererFunc позволяет тесту задать renderer без отдельной служебной структуры.
@@ -132,7 +134,7 @@ func TestPlantUMLContainsGraphStatesAndLegend(t *testing.T) {
 		"@startuml",
 		`rectangle "scope\nsucceeded" as step_0 #86EFAC`,
 		`rectangle "criterion\nrunning" as step_1 #93C5FD`,
-		`rectangle "future\npaused_by_host" as step_2 #D1D5DB`,
+		`rectangle "future\npaused&#95;by&#95;host" as step_2 #D1D5DB`,
 		"step_0 --> step_1",
 		"step_1 --> step_2",
 		"|<#F3F4F6> | pending |",
@@ -146,6 +148,122 @@ func TestPlantUMLContainsGraphStatesAndLegend(t *testing.T) {
 		if !strings.Contains(text, fragment) {
 			t.Errorf("в PlantUML отсутствует %q:\n%s", fragment, text)
 		}
+	}
+}
+
+// TestTextEscapingCoversUnicodeLineSeparators фиксирует U+2028/U+2029 отдельно
+// от ASCII-переносов. Go не относит категории Zl/Zp к control-символам, однако
+// PlantUML воспринимает их как границу строки и возвращает syntax error.
+func TestTextEscapingCoversUnicodeLineSeparators(t *testing.T) {
+	value := "line\u2028paragraph\u2029end"
+	want := `line\u2028paragraph\u2029end`
+	if got := markdownText(value); got != want {
+		t.Fatalf("Markdown сохранил структурные Unicode-разделители: %q", got)
+	}
+	if got := plantText(value); got != want {
+		t.Fatalf("PlantUML сохранил структурные Unicode-разделители: %q", got)
+	}
+	source, err := PlantUML(coordinator.Status{
+		WorkflowID: value,
+		Steps:      []coordinator.StepStatus{{ID: value, State: scheduler.Succeeded}},
+	})
+	if err != nil || strings.ContainsRune(string(source), '\u2028') || strings.ContainsRune(string(source), '\u2029') ||
+		!strings.Contains(string(source), `title Workflow: line\u2028paragraph\u2029end`) {
+		t.Fatalf("PlantUML source сохранил разделитель строки: %q, %v", source, err)
+	}
+}
+
+// TestPlantTextDisablesPreprocessor не позволяет валидной строке workflow
+// выполнить функцию PlantUML до парсинга диаграммы. Простое экранирование
+// обратной косой чертой здесь не помогает, поэтому процент кодируется entity.
+func TestPlantTextDisablesPreprocessor(t *testing.T) {
+	value := "safe%chr(10)rectangle injected as evil #FF0000"
+	escaped := "safe&#37;chr&#40;10&#41;rectangle injected as evil &#35;FF0000"
+	if got := plantText(value); got != escaped {
+		t.Fatalf("PlantUML preprocessor не обезврежен: %q", got)
+	}
+	source, err := PlantUML(coordinator.Status{
+		WorkflowID: value,
+		Steps:      []coordinator.StepStatus{{ID: value, State: scheduler.Succeeded}},
+	})
+	if err != nil || strings.Contains(string(source), value) || strings.Count(string(source), escaped) != 2 {
+		t.Fatalf("PlantUML source содержит исполняемый preprocessor payload: %q, %v", source, err)
+	}
+}
+
+// TestAgentReportAndPlantUMLUseVisits фиксирует представление v4: два прохода
+// одного step остаются разными узлами, связи идут по sourceVisitIds, а
+// невыбранный ключ виден только в атрибутах durable-решения.
+func TestAgentReportAndPlantUMLUseVisits(t *testing.T) {
+	maxVisits := 3
+	failed := workflow.OutcomeFailed
+	explanation := "нужна <img:/private/secret.png> %date()"
+	status := coordinator.Status{
+		RunID: "run-v4", WorkflowID: "repair", RunState: runstore.RunFailed, Terminal: true,
+		StopVisitID: "check-visit-2", StopReason: "исчерпан предел проверок",
+		WaitingForCapacity: []string{"work-visit-1"},
+		Steps: []coordinator.StepStatus{
+			{
+				ID: "check", VisitID: "check-visit-1", Visit: 1, Iteration: 1, Attempt: 2,
+				State: scheduler.Succeeded, Trigger: runstore.VisitTrigger{Kind: runstore.TriggerStart},
+				MaxVisits: &maxVisits, OnLimit: &failed,
+				Decision: &runstore.DecisionRecord{
+					Key: "retry", Explanation: explanation, To: []string{"work"},
+					Skipped: []string{"stop"}, Applied: true,
+				},
+				DecisionRoutes: []coordinator.DecisionRouteStatus{
+					{Key: "retry", To: []string{"work"}}, {Key: "stop", Finish: &failed},
+				},
+			},
+			{
+				ID: "work", VisitID: "work-visit-1", Visit: 1, Iteration: 2, Attempt: 1,
+				State: scheduler.Succeeded, Trigger: runstore.VisitTrigger{
+					Kind: runstore.TriggerDecision, SourceVisitIDs: []string{"check-visit-1"}, DecisionKey: "retry",
+				},
+			},
+			{
+				ID: "check", VisitID: "check-visit-2", Visit: 2, Iteration: 3, Attempt: 1,
+				State: scheduler.Failed, TechnicalError: "агент недоступен", MaxVisits: &maxVisits, OnLimit: &failed,
+				Trigger: runstore.VisitTrigger{Kind: runstore.TriggerAfter, SourceVisitIDs: []string{"work-visit-1"}},
+			},
+		},
+	}
+
+	report := DetailedReport(status, t.TempDir(), Artifacts{}, errors.New("renderer unavailable"))
+	for _, fragment := range []string{
+		"check#1 — succeeded", "visitId: check-visit-1; итерация: 1; попытка: 2",
+		"предел: maxVisits=3; onLimit=failed", "решение: retry; применено: true",
+		"объяснение решения: нужна &lt;img:/private/secret.png&gt; %date()", "пропущенные ключи решений: stop",
+		"маршруты: retry → work; stop → finish:failed", "work#1 — succeeded (чат ещё не создан) (ждёт свободный слот общего лимита)",
+		"причина запуска: decision:retry от check-visit-1", "check#2 — failed",
+		"техническая ошибка: агент недоступен", "Run run-v4 завершён: failed.",
+		"Остановившее посещение: check-visit-2.", "Причина остановки: исчерпан предел проверок",
+	} {
+		if !strings.Contains(report, fragment) {
+			t.Errorf("в Markdown отсутствует %q:\n%s", fragment, report)
+		}
+	}
+
+	source, err := PlantUML(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	for _, fragment := range []string{
+		`rectangle "check&#35;1\nvisitId&#58; check&#45;visit&#45;1\niteration&#58; 1&#59; attempt&#58; 2\nsucceeded\nmaxVisits&#58; 3&#59; onLimit&#58; failed\ndecision&#58; retry&#59; applied&#58; true\ndecision explanation&#58; нужна &#60;img&#58;&#47;private&#47;secret&#46;png&#62; &#37;date&#40;&#41;\nskipped keys&#58; stop\nroutes&#58; retry → work&#59; stop → finish&#58;failed" as visit_0`,
+		`rectangle "check&#35;2\nvisitId&#58; check&#45;visit&#45;2\niteration&#58; 3&#59; attempt&#58; 1\nfailed\nmaxVisits&#58; 3&#59; onLimit&#58; failed\ntechnicalError&#58; агент недоступен" as visit_2`,
+		"visit_0 --> visit_1 : decision&#58;retry", "visit_1 --> visit_2 : after",
+		"Run: failed", "Stop visit: check&#45;visit&#45;2", "Reason: исчерпан предел проверок",
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Errorf("в PlantUML отсутствует %q:\n%s", fragment, text)
+		}
+	}
+	if count := strings.Count(text, "rectangle \""); count != len(status.Steps) {
+		t.Fatalf("невыбранный маршрут создал фиктивный узел: узлов=%d, посещений=%d\n%s", count, len(status.Steps), text)
+	}
+	if strings.Contains(text, "<img:") || strings.Contains(text, "%date()") {
+		t.Fatalf("model-controlled explanation попал в Creole или preprocessor: %s", text)
 	}
 }
 
@@ -204,5 +322,15 @@ func TestPlantUMLRejectsBrokenDependencies(t *testing.T) {
 	}}})
 	if err == nil || !strings.Contains(err.Error(), "missing") {
 		t.Fatalf("повреждённая зависимость не объяснена: %v", err)
+	}
+	_, err = PlantUML(coordinator.Status{
+		RunState: runstore.RunRunning,
+		Steps: []coordinator.StepStatus{{
+			ID: "child", VisitID: "child-visit", State: scheduler.Pending,
+			Trigger: runstore.VisitTrigger{Kind: runstore.TriggerAfter, SourceVisitIDs: []string{"missing-visit"}},
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing-visit") {
+		t.Fatalf("повреждённая причинная ссылка v4 не объяснена: %v", err)
 	}
 }


### PR DESCRIPTION
Часть #50, поверх PR #80.

Что готово:
- статус v4 показывает отдельные visits с visitId, номером посещения, iteration, attempt и технической ошибкой;
- отображаются причины активации, выбранное решение, explanation, applied, детерминированные skipped keys и статические routes;
- maxVisits/onLimit и terminal run reason видны в Markdown и PlantUML;
- PlantUML строит только реальные visits и causal edges, не создавая фиктивные узлы невыбранных маршрутов;
- failed terminal немедленно обходит чатовый throttle;
- legacy v1-v3 сохраняет прежнее представление;
- model-controlled строки не могут включить PlantUML preprocessor или Creole/HTML: ASCII-пунктуация кодируется entity, renderer работает с SANDBOX profile, Markdown блокирует HTML-границы.

Проверки:
- go test ./...
- go test -race -count=1 ./cmd/lawa ./internal/coordinator ./internal/statusreport
- go vet ./...
- реальный PlantUML 1.2026.7: preprocessor, SANDBOX resource isolation и PNG render
- независимое ревью: APPROVE

Размер PR: 541 добавление, 43 удаления, всего 584 изменённые строки. Это немного выше ориентира 500 строк, но ниже блокирующего предела 1200; срез остаётся самостоятельным и включает обязательные проверки безопасного рендера.