### PR TITLE
Добавить CLI-наблюдаемость workflow v2

### DIFF
--- a/cmd/lawa/main.go
+++ b/cmd/lawa/main.go
@@ -38,8 +38,8 @@ const help = `Lawa — выполнение JSON-workflow через Codex App S
       Сверить сохранённые thread и продолжить interrupted-кубики.
   lawa status <run-id>
       Показать состояния, thread/turn, процесс и последнюю активность кубиков.
-  lawa logs <run-id> [step-id] [--follow]
-      Показать краткий журнал событий всего run или одного кубика.
+  lawa logs <run-id> [step-id] [--visit <visit-id>] [--follow]
+      Показать журнал всего run, логического шага или точного посещения v2.
   lawa serve [--root <путь>] [--listen <адрес>]
       Запустить read-only dashboard; по умолчанию http://127.0.0.1:60800.
   lawa series-status <series-id>
@@ -80,6 +80,8 @@ const help = `Lawa — выполнение JSON-workflow через Codex App S
 
 Параметры status/logs:
   --root <путь>                То же хранилище run.
+  --visit <visit-id>           Для logs: одно точное посещение workflow v2;
+                               взаимоисключающе с позиционным step-id.
   --follow                     Для logs: ждать новые события до завершения или сигнала.
 
 Параметры serve:

--- a/cmd/lawa/observability.go
+++ b/cmd/lawa/observability.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/stray-live-pixel/Lawa/internal/runstore"
 	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
 )
 
 // statusCommand строит read-only снимок без coordinator.lock. Поэтому команда
@@ -38,44 +40,13 @@ func statusCommand(args []string, out io.Writer, deps dependencies) error {
 		runstore.SafeTerminalText(runtime), runstore.SafeTerminalText(snapshot.Meta.CWD)); err != nil {
 		return err
 	}
+	if snapshot.Meta.Version == 4 {
+		return writeAgentStatus(out, snapshot, summaries)
+	}
 	for _, step := range snapshot.Meta.Steps {
 		summary := summaries[step.ID]
-		threadID, turnID := step.CodexThreadID, step.TurnID
-		if turnID == "" {
-			turnID = summary.TurnID
-		}
-		if threadID == "" {
-			threadID = "-"
-		}
-		if turnID == "" {
-			turnID = "-"
-		}
-		activity, process := "-", "-"
-		if !summary.LastActivity.IsZero() {
-			activity = summary.LastActivity.Local().Format(time.RFC3339)
-		}
-		if summary.PID != 0 {
-			process = fmt.Sprintf("pid %d", summary.PID)
-		} else if summary.ExitCode != nil {
-			process = fmt.Sprintf("завершён, exit %d", *summary.ExitCode)
-		} else if summary.Signal != "" {
-			process = "завершён, signal " + summary.Signal
-		}
-		if _, err = fmt.Fprintf(out, "\n%s: %s\n  thread: %s\n  turn: %s\n  процесс: %s\n  активность: %s\n",
-			runstore.SafeTerminalText(step.ID), runstore.SafeTerminalText(string(step.State)),
-			runstore.SafeTerminalText(threadID), runstore.SafeTerminalText(turnID),
-			runstore.SafeTerminalText(process), runstore.SafeTerminalText(activity)); err != nil {
+		if err = writeStatusEntry(out, step.ID, step.State, step.CodexThreadID, step.TurnID, summary); err != nil {
 			return err
-		}
-		if summary.Message != "" {
-			if _, err = fmt.Fprintf(out, "  сообщение: %s\n", runstore.SafeTerminalText(summary.Message)); err != nil {
-				return err
-			}
-		}
-		if len(summary.ActiveItemTypes) != 0 {
-			if _, err = fmt.Fprintf(out, "  действие: %s\n", runstore.SafeTerminalText(strings.Join(summary.ActiveItemTypes, ", "))); err != nil {
-				return err
-			}
 		}
 	}
 	if snapshot.HistoricalAppNative {
@@ -84,27 +55,195 @@ func statusCommand(args []string, out io.Writer, deps dependencies) error {
 	return err
 }
 
+// writeAgentStatus показывает append-only историю v4, не сворачивая повторные
+// посещения одного StepID. Статический workflow нужен только для разрешённых
+// routes и лимитов; фактический выбор и skipped берутся из durable metadata.
+func writeAgentStatus(out io.Writer, snapshot runstore.Snapshot, summaries map[string]runstore.EventSummary) error {
+	if _, err := fmt.Fprintf(out, "runState: %s\n", runstore.SafeTerminalText(string(snapshot.Meta.RunState))); err != nil {
+		return err
+	}
+	if snapshot.Meta.StopVisitID != "" {
+		if _, err := fmt.Fprintf(out, "stopVisit: %s\n", runstore.SafeTerminalText(snapshot.Meta.StopVisitID)); err != nil {
+			return err
+		}
+	}
+	if snapshot.Meta.StopLimitStepID != "" {
+		trigger := ""
+		if snapshot.Meta.StopLimitTrigger != nil {
+			trigger = statusTriggerText(*snapshot.Meta.StopLimitTrigger)
+		}
+		if _, err := fmt.Fprintf(out, "limit: step=%s, iteration=%d, trigger=%s\n",
+			runstore.SafeTerminalText(snapshot.Meta.StopLimitStepID), snapshot.Meta.StopLimitIteration,
+			runstore.SafeTerminalText(trigger)); err != nil {
+			return err
+		}
+	}
+	if snapshot.Meta.StopReason != "" {
+		if _, err := fmt.Fprintf(out, "причина: %s\n", runstore.SafeTerminalText(snapshot.Meta.StopReason)); err != nil {
+			return err
+		}
+	}
+	steps := make(map[string]workflow.Step, len(snapshot.Workflow.Steps))
+	for _, step := range snapshot.Workflow.Steps {
+		steps[step.ID] = step
+	}
+	for _, visit := range snapshot.Meta.Visits {
+		label := fmt.Sprintf("%s#%d [%s]", visit.StepID, visit.Visit, visit.VisitID)
+		if err := writeStatusEntry(out, label, visit.State, visit.CodexThreadID, visit.TurnID, summaries[visit.VisitID]); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(out, "  iteration: %d\n  attempt: %d\n  trigger: %s\n",
+			visit.Iteration, visit.Attempt, runstore.SafeTerminalText(statusTriggerText(visit.Trigger))); err != nil {
+			return err
+		}
+		step := steps[visit.StepID]
+		if step.MaxVisits != nil {
+			limit := fmt.Sprintf("maxVisits=%d, onLimit=failed (по умолчанию)", *step.MaxVisits)
+			if step.OnLimit != nil {
+				limit = fmt.Sprintf("maxVisits=%d, onLimit=%s", *step.MaxVisits, *step.OnLimit)
+			}
+			if _, err := fmt.Fprintf(out, "  limit: %s\n", runstore.SafeTerminalText(limit)); err != nil {
+				return err
+			}
+		}
+		if routes := statusRoutesText(step); routes != "" {
+			if _, err := fmt.Fprintf(out, "  routes: %s\n", runstore.SafeTerminalText(routes)); err != nil {
+				return err
+			}
+		}
+		if visit.TechnicalError != "" {
+			if _, err := fmt.Fprintf(out, "  техническая ошибка: %s\n", runstore.SafeTerminalText(visit.TechnicalError)); err != nil {
+				return err
+			}
+		}
+		if visit.Decision != nil {
+			decision := visit.Decision
+			if _, err := fmt.Fprintf(out, "  решение: %s, applied=%t\n",
+				runstore.SafeTerminalText(decision.Key), decision.Applied); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(out, "  переход: %s\n", runstore.SafeTerminalText(statusDecisionDestination(*decision))); err != nil {
+				return err
+			}
+			if decision.Explanation != "" {
+				if _, err := fmt.Fprintf(out, "  объяснение: %s\n", runstore.SafeTerminalText(decision.Explanation)); err != nil {
+					return err
+				}
+			}
+			if len(decision.Skipped) != 0 {
+				if _, err := fmt.Fprintf(out, "  skipped: %s\n", runstore.SafeTerminalText(strings.Join(decision.Skipped, ", "))); err != nil {
+					return err
+				}
+			}
+			if decision.Error != "" {
+				if _, err := fmt.Fprintf(out, "  ошибка решения: %s\n", runstore.SafeTerminalText(decision.Error)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// writeStatusEntry сохраняет прежний блок runtime-диагностики legacy и даёт v4
+// ту же сводку, ключеванную VisitID. Пустые внешние ID показаны явно через "-".
+func writeStatusEntry(out io.Writer, label string, state scheduler.State, threadID, turnID string, summary runstore.EventSummary) error {
+	if turnID == "" {
+		turnID = summary.TurnID
+	}
+	if threadID == "" {
+		threadID = "-"
+	}
+	if turnID == "" {
+		turnID = "-"
+	}
+	activity, process := "-", "-"
+	if !summary.LastActivity.IsZero() {
+		activity = summary.LastActivity.Local().Format(time.RFC3339)
+	}
+	if summary.PID != 0 {
+		process = fmt.Sprintf("pid %d", summary.PID)
+	} else if summary.ExitCode != nil {
+		process = fmt.Sprintf("завершён, exit %d", *summary.ExitCode)
+	} else if summary.Signal != "" {
+		process = "завершён, signal " + summary.Signal
+	}
+	if _, err := fmt.Fprintf(out, "\n%s: %s\n  thread: %s\n  turn: %s\n  процесс: %s\n  активность: %s\n",
+		runstore.SafeTerminalText(label), runstore.SafeTerminalText(string(state)),
+		runstore.SafeTerminalText(threadID), runstore.SafeTerminalText(turnID),
+		runstore.SafeTerminalText(process), runstore.SafeTerminalText(activity)); err != nil {
+		return err
+	}
+	if summary.Message != "" {
+		if _, err := fmt.Fprintf(out, "  сообщение: %s\n", runstore.SafeTerminalText(summary.Message)); err != nil {
+			return err
+		}
+	}
+	if len(summary.ActiveItemTypes) != 0 {
+		if _, err := fmt.Fprintf(out, "  действие: %s\n", runstore.SafeTerminalText(strings.Join(summary.ActiveItemTypes, ", "))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// statusTriggerText сохраняет порядок causal sourceVisitIds и выбранный ключ.
+func statusTriggerText(trigger runstore.VisitTrigger) string {
+	result := string(trigger.Kind)
+	if trigger.DecisionKey != "" {
+		result += ":" + trigger.DecisionKey
+	}
+	if len(trigger.SourceVisitIDs) != 0 {
+		result += " <- " + strings.Join(trigger.SourceVisitIDs, ", ")
+	}
+	return result
+}
+
+// statusRoutesText сортирует decision keys, но не меняет пользовательский
+// порядок route.to. Невыбранные routes остаются описанием, а не состояниями.
+func statusRoutesText(step workflow.Step) string {
+	keys := make([]string, 0, len(step.Decisions))
+	for key := range step.Decisions {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	routes := make([]string, 0, len(keys))
+	for _, key := range keys {
+		route := step.Decisions[key]
+		destination := strings.Join(route.To, ", ")
+		if route.Finish != nil {
+			destination = "finish:" + string(*route.Finish)
+		}
+		routes = append(routes, key+" → "+destination)
+	}
+	return strings.Join(routes, "; ")
+}
+
+// statusDecisionDestination выводит именно сохранённый выбранный переход. Это
+// отличает результат visit от полного статического перечня разрешённых routes.
+func statusDecisionDestination(decision runstore.DecisionRecord) string {
+	if decision.Finish != nil {
+		return "finish:" + string(*decision.Finish)
+	}
+	return strings.Join(decision.To, ", ")
+}
+
 // logsCommand печатает только нормализованные события Lawa. `--follow` читает
 // новые полные строки с сохранённой byte-позиции и не открывает App Server.
 // Терминальный meta.json сам по себе недостаточен для выхода: coordinator пишет
-// его раньше финального step_state, который иначе мог бы потеряться для оператора.
+// его раньше финального step_state/visit_state, который иначе мог бы потеряться
+// для оператора.
 func logsCommand(ctx context.Context, args []string, out io.Writer, deps dependencies) error {
-	runID, stepID, root, follow, err := parseLogsArguments(args, deps)
+	parsed, err := parseLogsArguments(args, deps)
 	if err != nil {
 		return err
 	}
-	if stepID != "" {
-		snapshot, loadErr := runstore.LoadForDashboard(root, runID)
-		if loadErr != nil {
-			return fmt.Errorf("прочитать run %q: %w", runID, loadErr)
-		}
-		known := false
-		for _, step := range snapshot.Meta.Steps {
-			known = known || step.ID == stepID
-		}
-		if !known {
-			return fmt.Errorf("run %q не содержит шаг %q", runID, stepID)
-		}
+	snapshot, err := runstore.LoadForDashboard(parsed.root, parsed.runID)
+	if err != nil {
+		return fmt.Errorf("прочитать run %q: %w", parsed.runID, err)
+	}
+	if err = validateLogsFilter(snapshot, parsed); err != nil {
+		return fmt.Errorf("run %q: %w", parsed.runID, err)
 	}
 	offset := int64(0)
 	finalStates := make(map[string]eventState)
@@ -115,31 +254,32 @@ func logsCommand(ctx context.Context, args []string, out io.Writer, deps depende
 	for {
 		var events []runstore.RuntimeEvent
 		var readErr error
-		if follow {
-			events, offset, readErr = runstore.ReadEventsAfter(root, runID, offset)
+		if parsed.follow {
+			events, offset, readErr = runstore.ReadEventsAfter(parsed.root, parsed.runID, offset)
 		} else {
-			events, readErr = runstore.ReadEvents(root, runID)
+			events, readErr = runstore.ReadEvents(parsed.root, parsed.runID)
 		}
 		if readErr != nil {
-			return fmt.Errorf("прочитать события run %q: %w", runID, readErr)
+			return fmt.Errorf("прочитать события run %q: %w", parsed.runID, readErr)
 		}
 		for _, event := range events {
-			if event.Kind == "step_state" || event.Kind == "thread_reconciled" {
-				finalStates[event.StepID] = eventState{State: event.State, TurnID: event.TurnID}
+			if stateKey := terminalEventKey(snapshot, event); stateKey != "" {
+				finalStates[stateKey] = eventState{State: event.State, TurnID: event.TurnID}
 			}
-			if stepID != "" && event.StepID != stepID {
+			if parsed.stepID != "" && event.StepID != parsed.stepID ||
+				parsed.visitID != "" && event.VisitID != parsed.visitID {
 				continue
 			}
 			if _, err = fmt.Fprintln(out, runstore.FormatEvent(event)); err != nil {
 				return err
 			}
 		}
-		if !follow {
+		if !parsed.follow {
 			return nil
 		}
-		snapshot, loadErr := runstore.LoadForDashboard(root, runID)
+		snapshot, loadErr := runstore.LoadForDashboard(parsed.root, parsed.runID)
 		if loadErr != nil {
-			return fmt.Errorf("прочитать run %q: %w", runID, loadErr)
+			return fmt.Errorf("прочитать run %q: %w", parsed.runID, loadErr)
 		}
 		if snapshot.HistoricalAppNative || runTerminal(snapshot) && terminalEventsRecorded(snapshot, finalStates) {
 			return nil
@@ -161,6 +301,21 @@ func logsCommand(ctx context.Context, args []string, out io.Writer, deps depende
 
 type eventState struct{ State, TurnID string }
 
+// terminalEventKey отделяет адреса двух форматов. У v4 stepId намеренно не
+// подходит: два прохода цикла имеют один логический шаг, но разные финалы.
+func terminalEventKey(snapshot runstore.Snapshot, event runstore.RuntimeEvent) string {
+	if snapshot.Meta.Version == 4 {
+		if (event.Kind == "visit_state" || event.Kind == "thread_reconciled") && event.VisitID != "" {
+			return event.VisitID
+		}
+		return ""
+	}
+	if event.Kind == "step_state" || event.Kind == "thread_reconciled" {
+		return event.StepID
+	}
+	return ""
+}
+
 // terminalEventsRecorded подтверждает, что журнал дошёл до состояния и turn из
 // meta.json каждого кубика. Сравнение turn не даёт старому succeeded-событию
 // преждевременно завершить follow после ручного продолжения того же thread.
@@ -168,6 +323,22 @@ func terminalEventsRecorded(snapshot runstore.Snapshot, states map[string]eventS
 	// В старых форматах обязательного events.jsonl ещё не было. Их сохранённый
 	// терминал остаётся читаемым и не превращает `--follow` в вечное ожидание.
 	if snapshot.Meta.Version < 3 {
+		return true
+	}
+	if snapshot.Meta.Version == 4 {
+		for _, visit := range snapshot.Meta.Visits {
+			// Explicit finish и onLimit могут оставить ещё не запущенные ветки.
+			// Для Pending нет и не должно быть visit_state. Starting появляется
+			// при durable reserve до любого thread/turn и также не обещает
+			// отдельного state-события: после crash его уже некому дописать.
+			if visit.State == scheduler.Pending || visit.State == scheduler.Starting {
+				continue
+			}
+			event, ok := states[visit.VisitID]
+			if !ok || event.State != string(visit.State) || event.TurnID != visit.TurnID {
+				return false
+			}
+		}
 		return true
 	}
 	for _, step := range snapshot.Meta.Steps {
@@ -191,36 +362,89 @@ func parseReadRunArguments(command string, args []string, deps dependencies) (st
 	return positionals[0], root, err
 }
 
-func parseLogsArguments(args []string, deps dependencies) (runID, stepID, root string, follow bool, err error) {
+type logsArguments struct {
+	runID, stepID, visitID, root string
+	follow                       bool
+}
+
+func parseLogsArguments(args []string, deps dependencies) (logsArguments, error) {
+	var parsed logsArguments
 	filtered := make([]string, 0, len(args))
 	for _, argument := range args {
 		if argument == "--follow" {
-			if follow {
-				return "", "", "", false, errors.New("параметр --follow повторён")
+			if parsed.follow {
+				return logsArguments{}, errors.New("параметр --follow повторён")
 			}
-			follow = true
+			parsed.follow = true
 			continue
 		}
 		filtered = append(filtered, argument)
 	}
-	positionals, values, err := parseOptions(filtered, map[string]bool{"root": true})
+	positionals, values, err := parseOptions(filtered, map[string]bool{"root": true, "visit": true})
 	if err != nil || len(positionals) < 1 || len(positionals) > 2 || strings.TrimSpace(positionals[0]) == "" {
 		if err != nil {
-			return "", "", "", false, err
+			return logsArguments{}, err
 		}
-		return "", "", "", false, errors.New("использование: lawa logs <run-id> [step-id] [--root <путь>] [--follow]")
+		return logsArguments{}, errors.New("использование: lawa logs <run-id> [step-id] [--visit <visit-id>] [--root <путь>] [--follow]")
 	}
+	parsed.runID = positionals[0]
 	if len(positionals) == 2 {
-		stepID = positionals[1]
-		if strings.TrimSpace(stepID) == "" {
-			return "", "", "", false, errors.New("step-id должен быть непустым")
+		parsed.stepID = positionals[1]
+		if strings.TrimSpace(parsed.stepID) == "" {
+			return logsArguments{}, errors.New("step-id должен быть непустым")
 		}
 	}
-	root, err = resolveRoot(values["root"], deps.userHomeDir)
-	return positionals[0], stepID, root, follow, err
+	if visitID, exists := values["visit"]; exists {
+		if strings.TrimSpace(visitID) == "" {
+			return logsArguments{}, errors.New("visit-id должен быть непустым")
+		}
+		parsed.visitID = visitID
+	}
+	if parsed.stepID != "" && parsed.visitID != "" {
+		return logsArguments{}, errors.New("step-id и --visit взаимоисключающие")
+	}
+	parsed.root, err = resolveRoot(values["root"], deps.userHomeDir)
+	return parsed, err
+}
+
+// validateLogsFilter проверяет фильтр по неизменяемому workflow/append-only
+// history до чтения журнала. StepID v2 может быть известен ещё до первого visit;
+// VisitID, напротив, обязан уже существовать в durable metadata.
+func validateLogsFilter(snapshot runstore.Snapshot, parsed logsArguments) error {
+	if parsed.visitID != "" {
+		if snapshot.Meta.Version != 4 {
+			return errors.New("--visit поддерживается только для workflow version=2")
+		}
+		for _, visit := range snapshot.Meta.Visits {
+			if visit.VisitID == parsed.visitID {
+				return nil
+			}
+		}
+		return fmt.Errorf("не содержит посещение %q", parsed.visitID)
+	}
+	if parsed.stepID == "" {
+		return nil
+	}
+	if snapshot.Meta.Version == 4 {
+		for _, step := range snapshot.Workflow.Steps {
+			if step.ID == parsed.stepID {
+				return nil
+			}
+		}
+	} else {
+		for _, step := range snapshot.Meta.Steps {
+			if step.ID == parsed.stepID {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("не содержит шаг %q", parsed.stepID)
 }
 
 func runTerminal(snapshot runstore.Snapshot) bool {
+	if snapshot.Meta.Version == 4 {
+		return snapshot.Meta.RunState != runstore.RunRunning
+	}
 	for _, step := range snapshot.Meta.Steps {
 		switch step.State {
 		case scheduler.Pending, scheduler.Starting, scheduler.Running, scheduler.Unknown, scheduler.WaitingForApproval:

--- a/cmd/lawa/observability_agent_test.go
+++ b/cmd/lawa/observability_agent_test.go
@@ -1,0 +1,273 @@
+//go:build darwin || linux
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stray-live-pixel/Lawa/internal/runstore"
+	"github.com/stray-live-pixel/Lawa/internal/scheduler"
+)
+
+// agentObservabilityRun создаёт два законченных прохода self-loop и достигает
+// maxVisits при третьей активации. Второй стартовый шаг остаётся Pending: это
+// штатная история terminal outcome, а не незаписанное событие исполнителя.
+func agentObservabilityRun(t *testing.T) (string, runstore.Snapshot, runstore.Visit, runstore.Visit) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "runs")
+	snapshot, err := runstore.CreateAgentGraph(root, runstore.Input{
+		WorkflowJSON: []byte(`{
+  "version": 2,
+  "id": "observe-agent-graph",
+  "start": ["loop", "unused"],
+  "steps": [
+    {"id":"loop","type":"agent","prompt":"Проверь","after":[],"maxVisits":2,"onLimit":"failed","decisions":{
+      "again":{"to":["loop"]},"done":{"finish":"succeeded"}}},
+    {"id":"unused","type":"agent","prompt":"Не запускать","after":[]}
+  ]
+}`),
+		Task: "Проверить наблюдаемость agent graph", CWD: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runstore.OpenLocked(root, snapshot.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if closeErr := run.Close(); closeErr != nil {
+			t.Error(closeErr)
+		}
+	}()
+	first := snapshot.Meta.Visits[0]
+	finishAgentObservabilityVisit(t, run, first, "первый проход")
+	advanced, err := run.AdvanceAgentGraph()
+	if err != nil || len(advanced.CreatedVisits) != 1 {
+		t.Fatalf("не создан второй проход: %+v, %v", advanced, err)
+	}
+	second := advanced.CreatedVisits[0]
+	finishAgentObservabilityVisit(t, run, second, "второй проход")
+	terminal, err := run.AdvanceAgentGraph()
+	if err != nil || terminal.Snapshot.Meta.RunState != runstore.RunFailed {
+		t.Fatalf("maxVisits не завершил run: %+v, %v", terminal, err)
+	}
+	return root, terminal.Snapshot, first, second
+}
+
+// finishAgentObservabilityVisit повторяет durable-порядок coordinator: reserve,
+// связь с чатом, turn, решение, terminal metadata и только затем событие. Такой
+// порядок важен для отдельной проверки, что logs --follow дожидается JSONL.
+func finishAgentObservabilityVisit(t *testing.T, run *runstore.LockedRun, visit runstore.Visit, message string) {
+	t.Helper()
+	threadID, turnID := "thread-"+visit.VisitID, "turn-"+visit.VisitID
+	if err := run.ReserveVisits([]string{visit.VisitID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(visit.VisitID, scheduler.Unknown, threadID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.SetVisitTurn(visit.VisitID, turnID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run.CommitDecision(visit.VisitID, threadID, turnID, "again", "Нужна ещё проверка", "call-"+visit.VisitID); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.UpdateVisit(visit.VisitID, scheduler.Succeeded, threadID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := run.AppendEvent(runstore.RuntimeEvent{
+		VisitID: visit.VisitID, StepID: visit.StepID, ThreadID: threadID, TurnID: turnID,
+		Kind: "visit_state", State: string(scheduler.Succeeded), Message: message,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAgentStatusShowsVisitsRoutesAndLimit проверяет операторский снимок v4:
+// повторные проходы не схлопываются, а причина остановки и непройденные routes
+// читаются из durable истории, а не реконструируются из финального текста агента.
+func TestAgentStatusShowsVisitsRoutesAndLimit(t *testing.T) {
+	root, snapshot, first, second := agentObservabilityRun(t)
+	var output bytes.Buffer
+	if err := statusCommand([]string{snapshot.Meta.RunID, "--root", root}, &output, dependencies{}); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	for _, fragment := range []string{
+		"runState: failed",
+		"stopVisit: " + second.VisitID,
+		"limit: step=loop, iteration=3, trigger=decision:again <- " + second.VisitID,
+		"причина: ",
+		"loop#1 [" + first.VisitID + "]: succeeded",
+		"loop#2 [" + second.VisitID + "]: succeeded",
+		"iteration: 1",
+		"iteration: 2",
+		"limit: maxVisits=2, onLimit=failed",
+		"routes: again → loop; done → finish:succeeded",
+		"решение: again, applied=true",
+		"решение: again, applied=false",
+		"переход: loop",
+		"объяснение: Нужна ещё проверка",
+		"skipped: done",
+		"сообщение: первый проход",
+		"unused#1 [",
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Errorf("status не содержит %q:\n%s", fragment, text)
+		}
+	}
+}
+
+// TestAgentLogsFilterByStepAndVisit фиксирует две разные адресации: step-id
+// собирает всю историю логического шага, а --visit оставляет ровно один проход.
+// Известный, но ещё не посещённый шаг является корректным пустым фильтром.
+func TestAgentLogsFilterByStepAndVisit(t *testing.T) {
+	root, snapshot, first, second := agentObservabilityRun(t)
+	deps := dependencies{}
+
+	var byStep bytes.Buffer
+	if err := logsCommand(t.Context(), []string{snapshot.Meta.RunID, "loop", "--root", root}, &byStep, deps); err != nil {
+		t.Fatal(err)
+	}
+	if text := byStep.String(); !strings.Contains(text, "visit="+first.VisitID) || !strings.Contains(text, "visit="+second.VisitID) {
+		t.Fatalf("фильтр шага потерял проход: %q", text)
+	}
+
+	var byVisit bytes.Buffer
+	if err := logsCommand(t.Context(), []string{snapshot.Meta.RunID, "--visit", second.VisitID, "--root", root}, &byVisit, deps); err != nil {
+		t.Fatal(err)
+	}
+	if text := byVisit.String(); strings.Contains(text, "visit="+first.VisitID) || !strings.Contains(text, "visit="+second.VisitID) {
+		t.Fatalf("точный фильтр visit смешал проходы: %q", text)
+	}
+
+	var unvisited bytes.Buffer
+	if err := logsCommand(t.Context(), []string{snapshot.Meta.RunID, "unused", "--root", root}, &unvisited, deps); err != nil || unvisited.Len() != 0 {
+		t.Fatalf("известный шаг без событий не стал пустым фильтром: %q, %v", unvisited.String(), err)
+	}
+}
+
+// TestAgentLogsRejectInvalidVisitFilters покрывает строгий CLI-контракт. VisitID
+// нельзя угадывать, смешивать со StepID или применять к legacy metadata.
+func TestAgentLogsRejectInvalidVisitFilters(t *testing.T) {
+	root, snapshot, _, visit := agentObservabilityRun(t)
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"неизвестный visit", []string{snapshot.Meta.RunID, "--visit", "missing", "--root", root}, "не содержит посещение"},
+		{"пустой visit", []string{snapshot.Meta.RunID, "--visit=", "--root", root}, "visit-id должен быть непустым"},
+		{"повтор visit", []string{snapshot.Meta.RunID, "--visit", visit.VisitID, "--visit", visit.VisitID, "--root", root}, "параметр --visit повторён"},
+		{"visit и step", []string{snapshot.Meta.RunID, "loop", "--visit", visit.VisitID, "--root", root}, "взаимоисключающие"},
+		{"неизвестный step", []string{snapshot.Meta.RunID, "missing", "--root", root}, "не содержит шаг"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := logsCommand(t.Context(), tc.args, io.Discard, dependencies{})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("получена ошибка %v, ожидался фрагмент %q", err, tc.want)
+			}
+		})
+	}
+
+	legacyRoot := filepath.Join(t.TempDir(), "legacy")
+	legacy, err := runstore.Create(legacyRoot, runstore.Input{
+		WorkflowJSON: []byte(`{"id":"legacy","steps":[{"id":"step","type":"agent","prompt":"Работай","dependsOn":[]}]}`),
+		Task:         "Legacy", CWD: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = logsCommand(t.Context(), []string{legacy.Meta.RunID, "--visit", visit.VisitID, "--root", legacyRoot}, io.Discard, dependencies{})
+	if err == nil || !strings.Contains(err.Error(), "только для workflow version=2") {
+		t.Fatalf("legacy run принял --visit: %v", err)
+	}
+}
+
+// TestAgentLogsFollowDrainsVisitEventAndIgnoresUnstarted проверяет три границы
+// завершения: terminal RunState не опережает финальный JSONL, но Pending и
+// зарезервированный Starting без thread/turn не требуют несуществующих событий.
+func TestAgentLogsFollowDrainsVisitEventAndIgnoresUnstarted(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "runs")
+	snapshot, err := runstore.CreateAgentGraph(root, runstore.Input{
+		WorkflowJSON: []byte(`{
+  "version":2,"id":"follow-v2","start":["finish","pending","ambiguous"],"steps":[
+    {"id":"finish","type":"agent","prompt":"Заверши","after":[],"decisions":{"done":{"finish":"succeeded"}}},
+    {"id":"pending","type":"agent","prompt":"Не запускать","after":[]},
+    {"id":"ambiguous","type":"agent","prompt":"Только зарезервировать","after":[]}
+  ]}`),
+		Task: "Проверить follow v2", CWD: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runstore.OpenLocked(root, snapshot.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+	visit := snapshot.Meta.Visits[0]
+	threadID, turnID := "thread-finish", "turn-finish"
+	if err = run.ReserveVisits([]string{visit.VisitID, snapshot.Meta.Visits[2].VisitID}); err == nil {
+		err = run.UpdateVisit(visit.VisitID, scheduler.Unknown, threadID, "")
+	}
+	if err == nil {
+		err = run.SetVisitTurn(visit.VisitID, turnID)
+	}
+	if err == nil {
+		err = run.AppendEvent(runstore.RuntimeEvent{
+			VisitID: visit.VisitID, StepID: visit.StepID, ThreadID: threadID, TurnID: turnID, Kind: "turn_bound",
+		})
+	}
+	if err == nil {
+		_, err = run.CommitDecision(visit.VisitID, threadID, turnID, "done", "Работа завершена", "call-finish")
+	}
+	if err == nil {
+		err = run.UpdateVisit(visit.VisitID, scheduler.Succeeded, threadID, "")
+	}
+	if err == nil {
+		_, err = run.AdvanceAgentGraph()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var output bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- logsCommand(ctx, []string{snapshot.Meta.RunID, "--root", root, "--follow"}, &output, dependencies{logsPollInterval: time.Millisecond})
+	}()
+	select {
+	case followErr := <-done:
+		t.Fatalf("follow завершился до visit_state: %v", followErr)
+	case <-time.After(20 * time.Millisecond):
+	}
+	if err = run.AppendEvent(runstore.RuntimeEvent{
+		VisitID: visit.VisitID, StepID: visit.StepID, ThreadID: threadID, TurnID: turnID,
+		Kind: "visit_state", State: string(scheduler.Succeeded),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case followErr := <-done:
+		if followErr != nil {
+			t.Fatal(followErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("follow не завершился после финального visit_state")
+	}
+	text := output.String()
+	if strings.Count(text, "turn_bound") != 1 || strings.Count(text, "visit_state") != 1 {
+		t.Fatalf("follow повторил старое или потерял финальное событие: %q", text)
+	}
+}

--- a/internal/runstore/events.go
+++ b/internal/runstore/events.go
@@ -479,16 +479,16 @@ func FormatEvent(event RuntimeEvent) string {
 	return SafeTerminalText(line)
 }
 
-// SafeTerminalText сохраняет читаемые Unicode-символы, а управляющие C0/C1
-// показывает как обычный текст. В частности, ESC больше не может начать ANSI
-// или OSC-команду, которая очистит экран, изменит заголовок либо подменит
-// видимую диагностику. Экранирование выполняется только при выводе: точные ID и
-// сообщения остаются в хранилище пригодными для протокола и расследования.
+// SafeTerminalText сохраняет читаемые Unicode-символы, а управляющие C0/C1 и
+// разделители строк/абзацев Zl/Zp показывает как обычный текст. В частности,
+// ESC больше не может начать ANSI/OSC-команду, а U+2028/U+2029 — визуально
+// разорвать одну запись на несколько. Экранирование выполняется только при
+// выводе: точные ID и сообщения остаются в хранилище для расследования.
 func SafeTerminalText(value string) string {
 	var result strings.Builder
 	result.Grow(len(value))
 	for _, character := range value {
-		if unicode.IsControl(character) {
+		if unicode.IsControl(character) || unicode.Is(unicode.Zl, character) || unicode.Is(unicode.Zp, character) {
 			fmt.Fprintf(&result, `\u%04X`, character)
 			continue
 		}

--- a/internal/runstore/events_test.go
+++ b/internal/runstore/events_test.go
@@ -317,16 +317,16 @@ func TestLegacyRuntimeEventRejectsVisitID(t *testing.T) {
 func TestFormatEventEscapesTerminalControls(t *testing.T) {
 	event := RuntimeEvent{
 		Time: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC), Kind: "error\x1b[2J",
-		StepID: "step\x07", ThreadID: "thread\u009b", Message: "первая\nвторая",
+		StepID: "step\x07", ThreadID: "thread\u009b", Message: "первая\nвторая\u2028третья\u2029четвёртая",
 		Usage: map[string]int64{"tokens\x1b]52;c;secret\x07": 1},
 	}
 	formatted := FormatEvent(event)
-	for _, forbidden := range []string{"\x1b", "\x07", "\u009b", "\n"} {
+	for _, forbidden := range []string{"\x1b", "\x07", "\u009b", "\n", "\u2028", "\u2029"} {
 		if strings.Contains(formatted, forbidden) {
 			t.Fatalf("FormatEvent оставил управляющий символ %q: %q", forbidden, formatted)
 		}
 	}
-	for _, visible := range []string{`\u001B[2J`, `step\u0007`, `thread\u009B`, `первая\u000Aвторая`, `\u001B]52;c;secret\u0007`} {
+	for _, visible := range []string{`\u001B[2J`, `step\u0007`, `thread\u009B`, `первая\u000Aвторая\u2028третья\u2029четвёртая`, `\u001B]52;c;secret\u0007`} {
 		if !strings.Contains(formatted, visible) {
 			t.Fatalf("FormatEvent потерял видимое экранирование %q: %q", visible, formatted)
 		}


### PR DESCRIPTION
## Что сделано

- `lawa status` показывает append-only visits, итерации, попытки, причины запуска, решения, выбранные переходы, skipped routes и maxVisits/onLimit
- `lawa logs` поддерживает логический фильтр по step-id и точный `--visit <visit-id>` для workflow v2
- `logs --follow` использует runState v4, ждёт финальные visit-события и не зависает на незапущенных Pending/Starting visits
- terminal-вывод дополнительно экранирует Unicode-разделители строк U+2028/U+2029
- legacy status/logs сохранены без изменения контракта

## Проверки

- `go test ./...`
- `go test -race ./cmd/lawa ./internal/runstore`
- 20 повторов CLI-регрессий фильтрации и follow
- независимое ревью: APPROVE

## Размер

657 изменённых строк (578 добавлено, 79 удалено). Это выше ориентира 500 строк, но ниже блокирующего предела 1200; объём остаётся одной законченной CLI-доработкой и включает регрессионные тесты.

Stacked on #81. Часть #50.