### PR TITLE
Persist causal skipped visits in agent runs

### DIFF
--- a/internal/runstore/visits.go
+++ b/internal/runstore/visits.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -29,9 +30,10 @@ const (
 type TriggerKind string
 
 const (
-	TriggerStart    TriggerKind = "start"
-	TriggerAfter    TriggerKind = "after"
-	TriggerDecision TriggerKind = "decision"
+	TriggerStart           TriggerKind = "start"
+	TriggerAfter           TriggerKind = "after"
+	TriggerDecision        TriggerKind = "decision"
+	TriggerDecisionSkipped TriggerKind = "decision_skipped"
 )
 
 // VisitTrigger хранит неизменяемую причину активации. SourceVisitIDs упорядочены:
@@ -106,8 +108,17 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 		steps[step.ID] = step
 	}
 	seen, chats := make(map[string]Visit), make(map[string]bool)
-	numbers, active := make(map[string]int), make(map[string]bool)
+	// numbers нумерует все durable branch instances, включая Skipped. Квота же
+	// ограничивает только исполнения, способные создать Codex turn: причинная
+	// запись об отсутствии запуска не должна отнимать разрешённое посещение.
+	numbers, runnableNumbers := make(map[string]int), make(map[string]int)
+	lastRunnable, active := make(map[string]Visit), make(map[string]bool)
 	afterUses, decisionUses := make(map[afterCause]bool), make(map[decisionCause]bool)
+	// skipWaves выводится только из проверенных sourceVisitIds. Один и тот же
+	// набор корневых решений может пройти каждый decision-target лишь однажды:
+	// это делает synthetic-обход безопасным даже для разрешённых route-циклов.
+	skipWaves := make(map[string][]string)
+	skipReached := make(map[skipReach]bool)
 	advanced := make(map[string]bool)
 	for index, visit := range m.Visits {
 		step, exists := steps[visit.StepID]
@@ -121,20 +132,35 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 		if visit.Visit != numbers[visit.StepID] || visit.Iteration < 1 || visit.Attempt < 0 {
 			return fmt.Errorf("посещение %q: нарушена нумерация visit/iteration/attempt", visit.VisitID)
 		}
-		if step.MaxVisits != nil && visit.Visit > *step.MaxVisits {
+		if visit.State != scheduler.Skipped {
+			runnableNumbers[visit.StepID]++
+			lastRunnable[visit.StepID] = visit
+		}
+		if step.MaxVisits != nil && runnableNumbers[visit.StepID] > *step.MaxVisits {
 			return fmt.Errorf("посещение %q превышает maxVisits=%d шага %q", visit.VisitID, *step.MaxVisits, visit.StepID)
 		}
 		if err := validateVisitState(visit, chats); err != nil {
 			return fmt.Errorf("посещение %q: %w", visit.VisitID, err)
 		}
-		if active[visit.StepID] {
+		// Skipped не занимает executor, поэтому отдельная причинная ветка может
+		// быть записана рядом с реальным активным visit общего target. No-overlap
+		// остаётся строгим для любых двух действительно запускаемых посещений.
+		if active[visit.StepID] && visit.State != scheduler.Skipped {
 			return fmt.Errorf("предыдущее посещение шага %q ещё не завершено", visit.StepID)
 		}
 		if !visitTerminal(visit.State) {
 			active[visit.StepID] = true
 		}
-		if err := validateTrigger(index, visit, step, s.Workflow.Start, m.Visits[:index], seen, afterUses, decisionUses); err != nil {
+		roots, err := validateTriggerWithSkipWaves(
+			index, visit, step, s.Workflow.Start, m.Visits[:index], seen, steps,
+			afterUses, decisionUses, skipWaves, skipReached,
+		)
+		if err != nil {
 			return fmt.Errorf("посещение %q: %w", visit.VisitID, err)
+		}
+		if len(roots) != 0 {
+			skipWaves[visit.VisitID] = roots
+			skipReached[skipReach{waveKey: skipWaveKey(roots), targetStepID: visit.StepID}] = true
 		}
 		if err := validateDecision(visit, step); err != nil {
 			return fmt.Errorf("посещение %q: %w", visit.VisitID, err)
@@ -184,7 +210,9 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 		if !exists || limitedStep.MaxVisits == nil {
 			return fmt.Errorf("stopLimitStepId не ссылается на шаг с maxVisits")
 		}
-		if !hasStopVisit || stopVisit.StepID != limitedStep.ID || stopVisit.Visit != *limitedStep.MaxVisits || numbers[limitedStep.ID] != *limitedStep.MaxVisits {
+		lastAllowed, hasLastAllowed := lastRunnable[limitedStep.ID]
+		if !hasStopVisit || stopVisit.StepID != limitedStep.ID || !hasLastAllowed || lastAllowed.VisitID != stopVisit.VisitID ||
+			runnableNumbers[limitedStep.ID] != *limitedStep.MaxVisits {
 			return fmt.Errorf("остановка по maxVisits требует последний разрешённый visit ограниченного шага")
 		}
 		outcome, expected := workflow.OutcomeFailed, RunFailed
@@ -211,7 +239,7 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 		// открыть более ранний маршрут, не меняя уже опубликованный исход.
 		if err := validateLimitTrigger(
 			limitedStep, *m.StopLimitTrigger, m.StopLimitIteration, m.Visits,
-			seen, steps, numbers, active, afterUses, decisionUses,
+			seen, steps, runnableNumbers, active, afterUses, decisionUses,
 		); err != nil {
 			return fmt.Errorf("остановка по maxVisits не подтверждена trigger: %w", err)
 		}
@@ -307,7 +335,7 @@ func validateLimitTrigger(
 	switch trigger.Kind {
 	case TriggerAfter:
 		proof := Visit{VisitID: "limit-proof", StepID: step.ID, Iteration: iteration, Trigger: trigger}
-		return validateTrigger(len(history), proof, step, nil, history, seen, afterUses, decisionUses)
+		return validateTrigger(len(history), proof, step, nil, history, seen, steps, afterUses, decisionUses)
 	case TriggerDecision:
 		if len(trigger.SourceVisitIDs) != 1 || trigger.DecisionKey == "" {
 			return fmt.Errorf("decision-limit требует один источник и ключ")
@@ -368,6 +396,10 @@ func agentVisitViews(visits []Visit) []scheduler.AgentVisitView {
 type afterCause struct{ targetStepID, dependencyStepID, sourceVisitID string }
 type decisionCause struct{ targetStepID, sourceVisitID string }
 
+// skipReach адресует decision-target внутри одной причинной волны. After имеет
+// собственную FIFO-причину и потому не дедуплицируется этим ключом.
+type skipReach struct{ waveKey, targetStepID string }
+
 // filepathIsSafeAbsolute повторяет общую границу cwd без принятия NUL.
 func filepathIsSafeAbsolute(path string) bool {
 	return filepath.IsAbs(path) && validText(path) && !strings.ContainsRune(path, 0)
@@ -380,6 +412,10 @@ func validateVisitState(visit Visit, chats map[string]bool) error {
 	case scheduler.Pending:
 		if visit.CodexThreadID != "" || visit.TurnID != "" || visit.Attempt != 0 || visit.TechnicalError != "" || visit.Decision != nil {
 			return fmt.Errorf("Pending не может содержать результаты запуска")
+		}
+	case scheduler.Skipped:
+		if visit.CodexThreadID != "" || visit.TurnID != "" || visit.Attempt != 0 || visit.TechnicalError != "" || visit.Decision != nil {
+			return fmt.Errorf("Skipped не может содержать результаты запуска")
 		}
 	case scheduler.Starting:
 		if visit.TurnID != "" || visit.Attempt != 0 || visit.TechnicalError != "" || visit.Decision != nil {
@@ -410,66 +446,211 @@ func validateVisitState(visit Visit, chats map[string]bool) error {
 	return nil
 }
 
-func validateTrigger(index int, visit Visit, step workflow.Step, start []string, history []Visit, seen map[string]Visit, afterUses map[afterCause]bool, decisionUses map[decisionCause]bool) error {
+func validateTrigger(
+	index int,
+	visit Visit,
+	step workflow.Step,
+	start []string,
+	history []Visit,
+	seen map[string]Visit,
+	steps map[string]workflow.Step,
+	afterUses map[afterCause]bool,
+	decisionUses map[decisionCause]bool,
+) error {
+	_, err := validateTriggerWithSkipWaves(
+		index, visit, step, start, history, seen, steps,
+		afterUses, decisionUses, nil, nil,
+	)
+	return err
+}
+
+// validateTriggerWithSkipWaves проверяет durable trigger и одновременно выводит
+// корни causal skip-wave. Корень — реальный visit решения; вложенный пропущенный
+// decision и полностью пропущенный after наследуют тот же канонический набор.
+func validateTriggerWithSkipWaves(
+	index int,
+	visit Visit,
+	step workflow.Step,
+	start []string,
+	history []Visit,
+	seen map[string]Visit,
+	steps map[string]workflow.Step,
+	afterUses map[afterCause]bool,
+	decisionUses map[decisionCause]bool,
+	skipWaves map[string][]string,
+	skipReached map[skipReach]bool,
+) ([]string, error) {
 	if index < len(start) {
 		if visit.StepID != start[index] || visit.Trigger.Kind != TriggerStart || visit.Visit != 1 || visit.Iteration != 1 {
-			return fmt.Errorf("начальные посещения должны совпадать с порядком workflow.start")
+			return nil, fmt.Errorf("начальные посещения должны совпадать с порядком workflow.start")
 		}
 	}
 	switch visit.Trigger.Kind {
 	case TriggerStart:
 		if index >= len(start) || len(visit.Trigger.SourceVisitIDs) != 0 || visit.Trigger.DecisionKey != "" {
-			return fmt.Errorf("start допустим только в начальном префиксе без источников")
+			return nil, fmt.Errorf("start допустим только в начальном префиксе без источников")
+		}
+		if visit.State == scheduler.Skipped {
+			return nil, fmt.Errorf("start не может быть synthetic Skipped")
 		}
 	case TriggerAfter:
 		if len(step.After) == 0 || len(visit.Trigger.SourceVisitIDs) != len(step.After) || visit.Trigger.DecisionKey != "" {
-			return fmt.Errorf("after должен содержать источник для каждого Step.After")
+			return nil, fmt.Errorf("after должен содержать источник для каждого Step.After")
 		}
 		maxIteration := 0
+		allSkipped := true
+		var roots []string
 		for i, sourceID := range visit.Trigger.SourceVisitIDs {
 			source, exists := seen[sourceID]
 			if !exists || !visitTerminal(source.State) || source.StepID != step.After[i] {
-				return fmt.Errorf("after-источник %q не является нужным завершённым посещением", sourceID)
+				return nil, fmt.Errorf("after-источник %q не является нужным завершённым посещением", sourceID)
 			}
 			cause := afterCause{visit.StepID, step.After[i], sourceID}
 			expected := ""
 			for _, candidate := range history {
 				candidateCause := afterCause{visit.StepID, step.After[i], candidate.VisitID}
-				if candidate.StepID == step.After[i] && visitTerminal(candidate.State) && !afterUses[candidateCause] {
+				// FIFO учитывает и незавершённый instance. Иначе более поздний
+				// synthetic Skipped смог бы обойти ранний Running того же шага.
+				if candidate.StepID == step.After[i] && !afterUses[candidateCause] {
 					expected = candidate.VisitID
 					break
 				}
 			}
 			if sourceID != expected || afterUses[cause] {
-				return fmt.Errorf("after должен потреблять самый ранний неиспользованный источник")
+				return nil, fmt.Errorf("after должен потреблять самый ранний неиспользованный источник")
 			}
 			afterUses[cause] = true
 			maxIteration = max(maxIteration, source.Iteration)
+			allSkipped = allSkipped && source.State == scheduler.Skipped
+			roots = append(roots, skipWaves[sourceID]...)
 		}
 		if visit.Iteration != maxIteration {
-			return fmt.Errorf("after должен наследовать максимальную iteration источников")
+			return nil, fmt.Errorf("after должен наследовать максимальную iteration источников")
+		}
+		if (visit.State == scheduler.Skipped) != allSkipped {
+			return nil, fmt.Errorf("Skipped after должен иметь только Skipped-источники")
+		}
+		if allSkipped {
+			roots = canonicalSkipRoots(roots)
+			if len(roots) == 0 {
+				return nil, fmt.Errorf("Skipped after потерял причинную волну")
+			}
+			return roots, nil
 		}
 	case TriggerDecision:
+		if visit.State == scheduler.Skipped {
+			return nil, fmt.Errorf("выбранный decision-target не может быть Skipped")
+		}
 		if len(visit.Trigger.SourceVisitIDs) != 1 || visit.Trigger.DecisionKey == "" {
-			return fmt.Errorf("decision требует один источник и ключ")
+			return nil, fmt.Errorf("decision требует один источник и ключ")
 		}
 		source, exists := seen[visit.Trigger.SourceVisitIDs[0]]
 		if !exists || source.State != scheduler.Succeeded || source.Decision == nil || !source.Decision.Applied ||
 			source.Decision.Key != visit.Trigger.DecisionKey || !slices.Contains(source.Decision.To, visit.StepID) {
-			return fmt.Errorf("decision-источник не применял этот маршрут к шагу")
+			return nil, fmt.Errorf("decision-источник не применял этот маршрут к шагу")
 		}
 		cause := decisionCause{visit.StepID, source.VisitID}
 		if decisionUses[cause] {
-			return fmt.Errorf("decision-источник уже материализовал этот target")
+			return nil, fmt.Errorf("decision-источник уже материализовал этот target")
 		}
 		decisionUses[cause] = true
 		if visit.Iteration != source.Iteration+1 {
-			return fmt.Errorf("decision-target должен увеличить iteration источника")
+			return nil, fmt.Errorf("decision-target должен увеличить iteration источника")
 		}
+	case TriggerDecisionSkipped:
+		if visit.State != scheduler.Skipped || len(visit.Trigger.SourceVisitIDs) != 1 || visit.Trigger.DecisionKey == "" {
+			return nil, fmt.Errorf("decision_skipped требует Skipped-target, один источник и ключ")
+		}
+		source, exists := seen[visit.Trigger.SourceVisitIDs[0]]
+		if !exists {
+			return nil, fmt.Errorf("decision_skipped ссылается на неизвестный источник")
+		}
+		selectedKey, key := "", ""
+		var roots []string
+		switch source.State {
+		case scheduler.Succeeded:
+			if source.Decision == nil || !source.Decision.Applied || source.Decision.Error != "" {
+				return nil, fmt.Errorf("decision_skipped ссылается не на применённое решение")
+			}
+			selectedKey = source.Decision.Key
+			roots = []string{source.VisitID}
+		case scheduler.Skipped:
+			if len(steps[source.StepID].Decisions) == 0 || len(skipWaves[source.VisitID]) == 0 {
+				return nil, fmt.Errorf("decision_skipped ссылается не на causal decision-источник")
+			}
+			roots = slices.Clone(skipWaves[source.VisitID])
+		default:
+			return nil, fmt.Errorf("decision_skipped ссылается не на terminal decision-источник")
+		}
+		key, exists = canonicalSkippedTargetKey(steps[source.StepID], selectedKey, visit.StepID)
+		if !exists || visit.Trigger.DecisionKey != key {
+			return nil, fmt.Errorf("decision_skipped не совпадает с пропущенным target решения")
+		}
+		cause := decisionCause{visit.StepID, source.VisitID}
+		if decisionUses[cause] {
+			return nil, fmt.Errorf("decision-источник уже материализовал этот target")
+		}
+		if visit.Iteration != source.Iteration+1 {
+			return nil, fmt.Errorf("decision_skipped-target должен увеличить iteration источника")
+		}
+		waveReach := skipReach{waveKey: skipWaveKey(roots), targetStepID: visit.StepID}
+		if skipReached != nil && skipReached[waveReach] {
+			return nil, fmt.Errorf("волна пропуска уже достигла target %q", visit.StepID)
+		}
+		decisionUses[cause] = true
+		return roots, nil
 	default:
-		return fmt.Errorf("неизвестный trigger %q", visit.Trigger.Kind)
+		return nil, fmt.Errorf("неизвестный trigger %q", visit.Trigger.Kind)
 	}
-	return nil
+	return nil, nil
+}
+
+// canonicalSkippedTargetKey выбирает стабильную причину synthetic Skipped.
+// Для реального решения рассматриваются только невыбранные ключи; для уже
+// пропущенного decision — все routes. Общий target выбранного route не пропускается.
+func canonicalSkippedTargetKey(step workflow.Step, selectedKey, target string) (string, bool) {
+	if selectedKey != "" && slices.Contains(step.Decisions[selectedKey].To, target) {
+		return "", false
+	}
+	keys := make([]string, 0, len(step.Decisions))
+	for key := range step.Decisions {
+		if key != selectedKey {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if slices.Contains(step.Decisions[key].To, target) {
+			return key, true
+		}
+	}
+	return "", false
+}
+
+// canonicalSkipRoots превращает объединение корней join в детерминированное
+// множество. Одинаковая причинная волна не зависит от порядка Step.After.
+func canonicalSkipRoots(values []string) []string {
+	unique := make(map[string]bool, len(values))
+	for _, value := range values {
+		unique[value] = true
+	}
+	result := make([]string, 0, len(unique))
+	for value := range unique {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// skipWaveKey кодирует множество visitId без неоднозначного разделителя.
+func skipWaveKey(roots []string) string {
+	var result strings.Builder
+	for _, root := range roots {
+		result.WriteString(strconv.Itoa(len(root)))
+		result.WriteByte(':')
+		result.WriteString(root)
+	}
+	return result.String()
 }
 
 func validateDecision(visit Visit, step workflow.Step) error {
@@ -500,7 +681,7 @@ func validateDecision(visit Visit, step workflow.Step) error {
 }
 
 func visitTerminal(state scheduler.State) bool {
-	return state == scheduler.Failed || state == scheduler.Succeeded
+	return state == scheduler.Failed || state == scheduler.Skipped || state == scheduler.Succeeded
 }
 
 func sameOutcome(left, right *workflow.TerminalOutcome) bool {

--- a/internal/runstore/visits_locked.go
+++ b/internal/runstore/visits_locked.go
@@ -88,6 +88,12 @@ func (r *LockedRun) UpdateVisit(visitID string, state scheduler.State, codexThre
 
 // updateVisit принимает Sync для регрессионных тестов атомарной публикации.
 func (r *LockedRun) updateVisit(visitID string, state scheduler.State, chat, diagnostic string, syncFile func(*os.File) error) error {
+	// Skipped является результатом планирования графа, а не внешним статусом
+	// Codex. Только атомарная materialization-процедура вправе создать такую
+	// запись вместе с причинным trigger.
+	if state == scheduler.Skipped {
+		return fmt.Errorf("посещение %q: Skipped может сохранить только планировщик", visitID)
+	}
 	return r.mutateVisits(syncFile, func(s *Snapshot) (bool, error) {
 		index, err := findVisit(s.Meta.Visits, visitID)
 		if err != nil {

--- a/internal/runstore/visits_locked_test.go
+++ b/internal/runstore/visits_locked_test.go
@@ -17,6 +17,9 @@ import (
 func TestVisitLifecycle(t *testing.T) {
 	root, initial, run := testAgentGraphRun(t)
 	first, second := initial.Meta.Visits[0].VisitID, initial.Meta.Visits[1].VisitID
+	if err := run.UpdateVisit(first, scheduler.Skipped, "", ""); err == nil {
+		t.Fatal("публичный UpdateVisit создал synthetic Skipped без причинного trigger")
+	}
 	if err := run.Reserve([]string{"choice"}); err == nil {
 		t.Fatal("legacy Reserve неожиданно управляет v4")
 	}

--- a/internal/runstore/visits_test.go
+++ b/internal/runstore/visits_test.go
@@ -354,6 +354,186 @@ func TestAgentGraphMetadataValidation(t *testing.T) {
 	}
 }
 
+// skippedJournalSnapshot собирает журнал, в котором выбранная ветка решения
+// сосуществует с причинной волной пропущенных альтернатив. Вложенный decision
+// распространяет ту же волну дальше, а after различает полностью пропущенный и
+// смешанный набор источников. Fixture не использует runtime-планировщик: этот
+// срез проверяет только durable-формат, который тот будет атомарно записывать.
+func skippedJournalSnapshot(t *testing.T) Snapshot {
+	t.Helper()
+	snapshot, err := Create(t.TempDir(), Input{
+		WorkflowJSON: []byte(`{
+  "version": 2,
+  "id": "skipped-journal",
+  "start": ["choice", "real"],
+  "steps": [
+    {"id":"choice","type":"agent","prompt":"Выбери ветку","after":[],"decisions":{
+      "main":{"to":["selected"]},"alpha":{"to":["inner"]},"zeta":{"to":["inner"]}}},
+    {"id":"real","type":"agent","prompt":"Выполни реальную ветку","after":[]},
+    {"id":"selected","type":"agent","prompt":"Выполни выбранную ветку","after":[]},
+    {"id":"inner","type":"agent","prompt":"Вложенное решение","after":[],"maxVisits":2,"decisions":{
+      "a":{"to":["leaf","inner"]},"b":{"to":["leaf"]}}},
+    {"id":"leaf","type":"agent","prompt":"Вложенный лист","after":[]},
+    {"id":"all-skipped","type":"agent","prompt":"Полностью пропущенный join","after":["inner","leaf"]},
+    {"id":"mixed","type":"agent","prompt":"Смешанный join","after":["real","inner"]}
+  ]
+}`),
+		Task: "Проверить журнал пропусков", CWD: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	choice, real := &snapshot.Meta.Visits[0], &snapshot.Meta.Visits[1]
+	choice.State, choice.CodexThreadID, choice.TurnID, choice.Attempt = scheduler.Succeeded, "chat-choice", "turn-choice", 1
+	choice.Decision = &DecisionRecord{
+		Key: "main", TurnID: "turn-choice", CallID: "call-choice", To: []string{"selected"},
+		Skipped: []string{"alpha", "zeta"}, Applied: true,
+	}
+	real.State, real.CodexThreadID, real.TurnID, real.Attempt = scheduler.Succeeded, "chat-real", "turn-real", 1
+	selectedID, innerID, leafID := newID(), newID(), newID()
+	snapshot.Meta.Visits = append(snapshot.Meta.Visits,
+		Visit{
+			VisitID: selectedID, StepID: "selected", Visit: 1, Iteration: 2,
+			Trigger: VisitTrigger{Kind: TriggerDecision, SourceVisitIDs: []string{choice.VisitID}, DecisionKey: "main"},
+			State:   scheduler.Succeeded, CodexThreadID: "chat-selected", TurnID: "turn-selected", Attempt: 1,
+		},
+		Visit{
+			VisitID: innerID, StepID: "inner", Visit: 1, Iteration: 2,
+			Trigger: VisitTrigger{Kind: TriggerDecisionSkipped, SourceVisitIDs: []string{choice.VisitID}, DecisionKey: "alpha"},
+			State:   scheduler.Skipped,
+		},
+		Visit{
+			VisitID: leafID, StepID: "leaf", Visit: 1, Iteration: 3,
+			Trigger: VisitTrigger{Kind: TriggerDecisionSkipped, SourceVisitIDs: []string{innerID}, DecisionKey: "a"},
+			State:   scheduler.Skipped,
+		},
+		Visit{
+			VisitID: newID(), StepID: "all-skipped", Visit: 1, Iteration: 3,
+			Trigger: VisitTrigger{Kind: TriggerAfter, SourceVisitIDs: []string{innerID, leafID}}, State: scheduler.Skipped,
+		},
+		Visit{
+			VisitID: newID(), StepID: "mixed", Visit: 1, Iteration: 2,
+			Trigger: VisitTrigger{Kind: TriggerAfter, SourceVisitIDs: []string{real.VisitID, innerID}}, State: scheduler.Pending,
+		},
+	)
+	if err := snapshot.validate(snapshot.Meta.RunID); err != nil {
+		t.Fatalf("допустимый skipped-журнал не прошёл проверку: %v", err)
+	}
+	return snapshot
+}
+
+// TestAgentGraphSkippedJournalValidation закрепляет причинность synthetic
+// Skipped. Ключ alternative каноничен, вложенная волна конечна даже на route-
+// цикле, а состояние after выводится только из фактических состояний источников.
+func TestAgentGraphSkippedJournalValidation(t *testing.T) {
+	valid := skippedJournalSnapshot(t)
+	clone := func() Snapshot { return cloneSnapshotMetadata(t, valid) }
+	for name, mutate := range map[string]func(*Snapshot){
+		"skipped с данными запуска": func(s *Snapshot) {
+			s.Meta.Visits[3].CodexThreadID = "forged-chat"
+		},
+		"неканоничный ключ общей альтернативы": func(s *Snapshot) {
+			s.Meta.Visits[3].Trigger.DecisionKey = "zeta"
+		},
+		"decision_skipped не является skipped": func(s *Snapshot) {
+			s.Meta.Visits[3].State = scheduler.Pending
+		},
+		"all-skipped after запущен": func(s *Snapshot) {
+			s.Meta.Visits[5].State = scheduler.Pending
+		},
+		"mixed after пропущен": func(s *Snapshot) {
+			s.Meta.Visits[6].State = scheduler.Skipped
+		},
+		"route-цикл повторно достигнут той же волной": func(s *Snapshot) {
+			s.Meta.Visits = append(s.Meta.Visits, Visit{
+				VisitID: newID(), StepID: "inner", Visit: 2, Iteration: 3,
+				Trigger: VisitTrigger{Kind: TriggerDecisionSkipped, SourceVisitIDs: []string{s.Meta.Visits[3].VisitID}, DecisionKey: "a"},
+				State:   scheduler.Skipped,
+			})
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			damaged := clone()
+			mutate(&damaged)
+			if err := damaged.validate(damaged.Meta.RunID); err == nil {
+				t.Fatal("повреждённый skipped-журнал принят")
+			}
+		})
+	}
+}
+
+// TestAgentGraphSkippedDoesNotConsumeMaxVisits проверяет общий target двух
+// решений. Synthetic-запись сохраняет собственный ordinal visit, но не занимает
+// квоту и не мешает выбранной ветке создать единственный реальный запуск.
+func TestAgentGraphSkippedDoesNotConsumeMaxVisits(t *testing.T) {
+	snapshot, err := Create(t.TempDir(), Input{
+		WorkflowJSON: []byte(`{
+  "version": 2,
+  "id": "skipped-quota",
+  "start": ["skip", "run"],
+  "steps": [
+    {"id":"skip","type":"agent","prompt":"Пропусти target","after":[],"decisions":{
+      "main":{"to":["other"]},"unused":{"to":["target"]}}},
+    {"id":"run","type":"agent","prompt":"Выбери target","after":[],"decisions":{"go":{"to":["target"]}}},
+    {"id":"other","type":"agent","prompt":"Другая ветка","after":[]},
+    {"id":"target","type":"agent","prompt":"Общий target","after":[],"maxVisits":1}
+  ]
+}`),
+		Task: "Проверить квоту пропуска", CWD: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	skip, run := &snapshot.Meta.Visits[0], &snapshot.Meta.Visits[1]
+	skip.State, skip.CodexThreadID, skip.TurnID, skip.Attempt = scheduler.Succeeded, "chat-skip", "turn-skip", 1
+	skip.Decision = &DecisionRecord{Key: "main", TurnID: "turn-skip", CallID: "call-skip", To: []string{"other"}, Skipped: []string{"unused"}, Applied: true}
+	run.State, run.CodexThreadID, run.TurnID, run.Attempt = scheduler.Succeeded, "chat-run", "turn-run", 1
+	run.Decision = &DecisionRecord{Key: "go", TurnID: "turn-run", CallID: "call-run", To: []string{"target"}, Applied: true}
+	snapshot.Meta.Visits = append(snapshot.Meta.Visits,
+		Visit{
+			VisitID: newID(), StepID: "other", Visit: 1, Iteration: 2,
+			Trigger: VisitTrigger{Kind: TriggerDecision, SourceVisitIDs: []string{skip.VisitID}, DecisionKey: "main"}, State: scheduler.Pending,
+		},
+		Visit{
+			VisitID: newID(), StepID: "target", Visit: 1, Iteration: 2,
+			Trigger: VisitTrigger{Kind: TriggerDecisionSkipped, SourceVisitIDs: []string{skip.VisitID}, DecisionKey: "unused"}, State: scheduler.Skipped,
+		},
+		Visit{
+			VisitID: newID(), StepID: "target", Visit: 2, Iteration: 2,
+			Trigger: VisitTrigger{Kind: TriggerDecision, SourceVisitIDs: []string{run.VisitID}, DecisionKey: "go"}, State: scheduler.Pending,
+		},
+	)
+	if err := snapshot.validate(snapshot.Meta.RunID); err != nil {
+		t.Fatalf("Skipped ошибочно занял maxVisits общего target: %v", err)
+	}
+	overLimit := cloneSnapshotMetadata(t, snapshot)
+	overLimit.Meta.Visits[4].State = scheduler.Succeeded
+	overLimit.Meta.Visits[4].CodexThreadID, overLimit.Meta.Visits[4].TurnID, overLimit.Meta.Visits[4].Attempt = "chat-target", "turn-target", 1
+	overLimit.Meta.Visits = append(overLimit.Meta.Visits, Visit{
+		VisitID: newID(), StepID: "target", Visit: 3, Iteration: 3,
+		Trigger: VisitTrigger{Kind: TriggerDecision, SourceVisitIDs: []string{run.VisitID}, DecisionKey: "go"}, State: scheduler.Pending,
+	})
+	if err := overLimit.validate(overLimit.Meta.RunID); err == nil || !strings.Contains(err.Error(), "maxVisits") {
+		t.Fatalf("второй реальный запуск общего target обошёл квоту: %v", err)
+	}
+}
+
+// TestCanonicalSkippedTargetKey не позволяет пропустить target, который есть у
+// выбранного route, даже если на него указывает и невыбранная альтернатива.
+func TestCanonicalSkippedTargetKey(t *testing.T) {
+	step := workflow.Step{Decisions: map[string]workflow.Route{
+		"main":  {To: []string{"shared"}},
+		"alpha": {To: []string{"shared", "only-skipped"}},
+		"zeta":  {To: []string{"only-skipped"}},
+	}}
+	if key, ok := canonicalSkippedTargetKey(step, "main", "shared"); ok || key != "" {
+		t.Fatalf("выбранный общий target помечен как Skipped ключом %q", key)
+	}
+	if key, ok := canonicalSkippedTargetKey(step, "main", "only-skipped"); !ok || key != "alpha" {
+		t.Fatalf("не выбран канонический ключ общей альтернативы: %q, %v", key, ok)
+	}
+}
+
 // TestAfterTriggerFIFO не позволяет переставить причинность уже завершённых
 // посещений: каждый after-barrier обязан потреблять их в durable-порядке Visits.
 func TestAfterTriggerFIFO(t *testing.T) {
@@ -365,7 +545,7 @@ func TestAfterTriggerFIFO(t *testing.T) {
 	trigger := func(source Visit) error {
 		return validateTrigger(2, Visit{StepID: "check", Iteration: source.Iteration,
 			Trigger: VisitTrigger{Kind: TriggerAfter, SourceVisitIDs: []string{source.VisitID}}},
-			workflow.Step{ID: "check", After: []string{"work"}}, nil, history, seen, uses, map[decisionCause]bool{})
+			workflow.Step{ID: "check", After: []string{"work"}}, nil, history, seen, nil, uses, map[decisionCause]bool{})
 	}
 	if err := trigger(second); err == nil {
 		t.Fatal("after принял более поздний источник раньше первого")
@@ -375,6 +555,21 @@ func TestAfterTriggerFIFO(t *testing.T) {
 	}
 	if err := trigger(second); err != nil {
 		t.Fatalf("after не перешёл к следующему источнику: %v", err)
+	}
+
+	// Незавершённый ранний instance остаётся первым в FIFO. Более поздний
+	// synthetic Skipped нельзя использовать как обход блокирующего Running.
+	running := Visit{VisitID: newID(), StepID: "work", State: scheduler.Running, Iteration: 1, CodexThreadID: "chat", TurnID: "turn", Attempt: 1}
+	skipped := Visit{VisitID: newID(), StepID: "work", State: scheduler.Skipped, Iteration: 2}
+	history = []Visit{running, skipped}
+	seen = map[string]Visit{running.VisitID: running, skipped.VisitID: skipped}
+	_, err := validateTriggerWithSkipWaves(2, Visit{
+		StepID: "check", Iteration: 2, State: scheduler.Skipped,
+		Trigger: VisitTrigger{Kind: TriggerAfter, SourceVisitIDs: []string{skipped.VisitID}},
+	}, workflow.Step{ID: "check", After: []string{"work"}}, nil, history, seen, nil,
+		map[afterCause]bool{}, map[decisionCause]bool{}, map[string][]string{skipped.VisitID: {newID()}}, map[skipReach]bool{})
+	if err == nil {
+		t.Fatal("after обошёл ранний Running через более поздний Skipped")
 	}
 }
 


### PR DESCRIPTION
## Результат

- добавлен durable trigger `decision_skipped`;
- сохранённые `skipped`-посещения проверяются как причинные terminal-записи без Codex thread/turn;
- `skipped` не расходует `maxVisits` и не блокирует выполняемый visit общего target;
- причинные волны дедуплицируются для shared targets и циклов;
- внешний `UpdateVisit` не может подделать состояние `skipped`.

## Проверки

- `go test -count=1 ./internal/runstore`
- `go test -count=1 ./...`
- `git diff --check`

## Размер

411 добавлений, 26 удалений — 437 изменённых строк.

## Зависимость

Stacked поверх #86. Runtime-производитель skipped-посещений будет подключён отдельным PR.

Part of #50.