### PR TITLE
Plan transitive skipped branch closure

### DIFF
--- a/internal/scheduler/agent.go
+++ b/internal/scheduler/agent.go
@@ -13,9 +13,10 @@ import (
 type AgentTriggerKind string
 
 const (
-	AgentTriggerStart    AgentTriggerKind = "start"
-	AgentTriggerAfter    AgentTriggerKind = "after"
-	AgentTriggerDecision AgentTriggerKind = "decision"
+	AgentTriggerStart           AgentTriggerKind = "start"
+	AgentTriggerAfter           AgentTriggerKind = "after"
+	AgentTriggerDecision        AgentTriggerKind = "decision"
+	AgentTriggerDecisionSkipped AgentTriggerKind = "decision_skipped"
 )
 
 // AgentTriggerView — минимальная проекция durable trigger, необходимая чистому
@@ -48,13 +49,15 @@ type AgentVisitView struct {
 	Decision  *AgentDecisionView
 }
 
-// AgentActivation полностью описывает новое Pending-посещение, кроме его
-// случайного VisitID. Persistence-слой генерирует ID, создаёт файл памяти и одним
-// атомарным commit сохраняет все активации вместе с применёнными решениями.
+// AgentActivation полностью описывает новое посещение, кроме его случайного
+// VisitID. Нулевой InitialState означает прежний Pending; Skipped позволяет
+// отдельному pure-плану сохранить недостижимую ветку без запуска агента.
+// Persistence-слой генерирует ID и атомарно сохраняет активации с решениями.
 type AgentActivation struct {
-	StepID    string
-	Iteration int
-	Trigger   AgentTriggerView
+	StepID       string
+	Iteration    int
+	Trigger      AgentTriggerView
+	InitialState State
 }
 
 // AgentTerminal — итог всего run. CauseVisitID связывает failed frontier, fatal

--- a/internal/scheduler/agent_skipped.go
+++ b/internal/scheduler/agent_skipped.go
@@ -1,0 +1,593 @@
+package scheduler
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
+)
+
+// PlanAgentSkippedClosure строит один слой только terminal Skipped-посещений.
+// Вызывающая сторона назначает им VisitID, добавляет к переданному append-only
+// журналу и повторяет вызов до пустого плана. Благодаря этому вложенные решения
+// и after-барьеры замыкаются без временных ссылок между ещё не созданными visits.
+//
+// terminal разрешает промежуточный снимок атомарной остановки: применённый
+// finish, rootless cleanup Skipped и точный не применённый источник maxVisits.
+// limitStepID с limitTrigger описывают активацию N+1, которую terminal outcome
+// заменил целиком. Функция никогда не планирует исполняемую работу и не меняет
+// обычный PlanAgentGraph: все возвращённые активации имеют InitialState=Skipped,
+// а ApplyDecisionVisitIDs и Terminal остаются пустыми.
+func PlanAgentSkippedClosure(
+	w workflow.Workflow,
+	visits []AgentVisitView,
+	terminal bool,
+	limitStepID string,
+	limitTrigger AgentTriggerView,
+) (AgentPlan, error) {
+	if err := w.Validate(); err != nil {
+		return AgentPlan{}, fmt.Errorf("замыкание skipped: %w", err)
+	}
+	if w.EffectiveVersion() != workflow.VersionAgentGraph {
+		return AgentPlan{}, fmt.Errorf("замыкание skipped требует workflow version=2")
+	}
+
+	limitDecisionSourceID := ""
+	if limitStepID != "" && limitTrigger.Kind == AgentTriggerDecision && len(limitTrigger.SourceVisitIDs) == 1 {
+		limitDecisionSourceID = limitTrigger.SourceVisitIDs[0]
+	}
+	context, err := validateAgentSkippedViews(w, visits, terminal, limitDecisionSourceID)
+	if err != nil {
+		return AgentPlan{}, fmt.Errorf("замыкание skipped: %w", err)
+	}
+	if err := reserveAgentSkippedLimit(context, visits, terminal, limitStepID, limitTrigger); err != nil {
+		return AgentPlan{}, fmt.Errorf("замыкание skipped: %w", err)
+	}
+
+	plan := AgentPlan{}
+	projectedReached := cloneAgentSkipReached(context.skipReached)
+	for _, visit := range visits {
+		step := context.steps[visit.StepID]
+		if len(step.Decisions) == 0 {
+			continue
+		}
+		switch visit.State {
+		case Succeeded:
+			if visit.Decision == nil || visit.Decision.Error != "" ||
+				!visit.Decision.Applied && visit.VisitID != limitDecisionSourceID {
+				continue
+			}
+			plan.DecisionActivations = append(plan.DecisionActivations,
+				missingDecisionSkippedActivations(
+					step, visit, visit.Decision.Key, []string{visit.VisitID}, projectedReached,
+				)...)
+		case Skipped:
+			if roots, causal := context.skipRoots[visit.VisitID]; causal {
+				plan.DecisionActivations = append(plan.DecisionActivations,
+					missingDecisionSkippedActivations(step, visit, "", roots, projectedReached)...)
+			}
+		}
+	}
+
+	// After не дедуплицируется по wave/target: каждый visit является durable-
+	// квитанцией конкретного FIFO-набора. Статический after-граф ацикличен, поэтому
+	// такие квитанции конечны, а decision-циклы отдельно ограничивает skipReached.
+	for _, step := range w.Steps {
+		if len(step.After) == 0 {
+			continue
+		}
+		sources, iteration, allSkipped, ready := nextSkippedAfterSources(step, context)
+		if terminal {
+			sources, iteration, allSkipped, ready = nextTerminalSkippedAfterSources(step, context)
+		}
+		if !ready || !allSkipped {
+			continue
+		}
+		plan.AfterActivations = append(plan.AfterActivations, AgentActivation{
+			StepID: step.ID, Iteration: iteration, InitialState: Skipped,
+			Trigger: AgentTriggerView{Kind: AgentTriggerAfter, SourceVisitIDs: sources},
+		})
+	}
+	return plan, nil
+}
+
+// agentSkippedContext содержит только индексы, необходимые skip-only API.
+// visitsByStep включает активные и terminal instances в durable-порядке: в
+// работающем run поздний Skipped не вправе обойти более ранний активный source.
+type agentSkippedContext struct {
+	steps        map[string]workflow.Step
+	active       map[string]bool
+	visitCount   map[string]int
+	visitsByStep map[string][]AgentVisitView
+	usedAfter    map[agentAfterCause]bool
+	decisionUses map[agentDecisionCause]bool
+	skipRoots    map[string][]string
+	skipReached  map[agentSkipCause]bool
+}
+
+// agentSkipCause ограничивает decision-fanout одной причинной волны. Одинаковый
+// набор корневых реальных решений может достичь target лишь однажды, что
+// схлопывает shared targets и гарантированно останавливает self-loop и SCC.
+type agentSkipCause struct {
+	waveKey      string
+	targetStepID string
+}
+
+func validateAgentSkippedViews(
+	w workflow.Workflow,
+	visits []AgentVisitView,
+	terminal bool,
+	limitDecisionSourceID string,
+) (agentSkippedContext, error) {
+	context := agentSkippedContext{
+		steps: make(map[string]workflow.Step, len(w.Steps)), active: make(map[string]bool),
+		visitCount: make(map[string]int), visitsByStep: make(map[string][]AgentVisitView),
+		usedAfter: make(map[agentAfterCause]bool), decisionUses: make(map[agentDecisionCause]bool),
+		skipRoots: make(map[string][]string), skipReached: make(map[agentSkipCause]bool),
+	}
+	for _, step := range w.Steps {
+		context.steps[step.ID] = step
+	}
+	if len(visits) < len(w.Start) {
+		return agentSkippedContext{}, fmt.Errorf("история не содержит весь начальный префикс workflow.start")
+	}
+
+	seen := make(map[string]AgentVisitView, len(visits))
+	for index, visit := range visits {
+		step, exists := context.steps[visit.StepID]
+		if !exists || visit.VisitID == "" || visit.Iteration < 1 {
+			return agentSkippedContext{}, fmt.Errorf("visits[%d]: неверный visitId, stepId или iteration", index)
+		}
+		if _, duplicate := seen[visit.VisitID]; duplicate {
+			return agentSkippedContext{}, fmt.Errorf("visits[%d]: повторный visitId %q", index, visit.VisitID)
+		}
+		if !knownAgentSkippedState(visit.State) {
+			return agentSkippedContext{}, fmt.Errorf("посещение %q: неизвестное состояние %q", visit.VisitID, visit.State)
+		}
+		// Skipped подтверждает отсутствие запуска, поэтому не расходует maxVisits и
+		// может сосуществовать с выполняющимся visit того же шага.
+		if visit.State != Skipped {
+			context.visitCount[visit.StepID]++
+			if step.MaxVisits != nil && context.visitCount[visit.StepID] > *step.MaxVisits {
+				return agentSkippedContext{}, fmt.Errorf("посещение %q превышает maxVisits=%d шага %q", visit.VisitID, *step.MaxVisits, visit.StepID)
+			}
+		}
+		if context.active[visit.StepID] && visit.State != Skipped {
+			return agentSkippedContext{}, fmt.Errorf("посещение %q появилось до завершения предыдущего visit шага %q", visit.VisitID, visit.StepID)
+		}
+		if !agentSkippedVisitTerminal(visit.State) {
+			context.active[visit.StepID] = true
+		}
+		if visit.Decision != nil && (len(step.Decisions) == 0 ||
+			visit.Decision.Applied && (visit.State != Succeeded || visit.Decision.Error != "")) {
+			return agentSkippedContext{}, fmt.Errorf("посещение %q содержит решение в несовместимом состоянии", visit.VisitID)
+		}
+
+		if index < len(w.Start) &&
+			(visit.StepID != w.Start[index] || visit.Trigger.Kind != AgentTriggerStart || visit.Iteration != 1) {
+			return agentSkippedContext{}, fmt.Errorf("visits[%d] не совпадает с начальным префиксом workflow.start", index)
+		}
+		switch visit.Trigger.Kind {
+		case AgentTriggerStart:
+			if index >= len(w.Start) || len(visit.Trigger.SourceVisitIDs) != 0 || visit.Trigger.DecisionKey != "" {
+				return agentSkippedContext{}, fmt.Errorf("посещение %q: start допустим только в начальном префиксе", visit.VisitID)
+			}
+			if visit.State == Skipped && !terminal {
+				return agentSkippedContext{}, fmt.Errorf("посещение %q: running run не может пропустить start без terminal-причины", visit.VisitID)
+			}
+		case AgentTriggerAfter:
+			allSkipped, err := validateAgentSkippedAfter(
+				visit, step, seen, context.visitsByStep, context.usedAfter, terminal,
+			)
+			if err != nil {
+				return agentSkippedContext{}, err
+			}
+			if visit.State == Skipped && allSkipped {
+				roots, causal := agentAfterSkipRoots(visit.Trigger.SourceVisitIDs, context.skipRoots)
+				if !causal && !terminal {
+					return agentSkippedContext{}, fmt.Errorf("посещение %q: skipped after потерял причинную волну", visit.VisitID)
+				}
+				if causal {
+					context.skipRoots[visit.VisitID] = roots
+					context.skipReached[agentSkipCause{waveKey: agentSkipWaveKey(roots), targetStepID: visit.StepID}] = true
+				}
+			}
+		case AgentTriggerDecision:
+			if visit.State == Skipped && !terminal {
+				return agentSkippedContext{}, fmt.Errorf("посещение %q: выбранный decision-target может стать skipped только при terminal run", visit.VisitID)
+			}
+			if err := validateAgentDecisionTrigger(visit, seen, context.decisionUses, context.steps); err != nil {
+				return agentSkippedContext{}, err
+			}
+		case AgentTriggerDecisionSkipped:
+			roots, err := validateAgentDecisionSkippedTrigger(
+				visit, seen, context.decisionUses, context.steps, context.skipRoots,
+				context.skipReached, terminal, limitDecisionSourceID,
+			)
+			if err != nil {
+				return agentSkippedContext{}, err
+			}
+			context.skipRoots[visit.VisitID] = roots
+		default:
+			return agentSkippedContext{}, fmt.Errorf("посещение %q: неизвестный trigger %q", visit.VisitID, visit.Trigger.Kind)
+		}
+		seen[visit.VisitID] = visit
+		context.visitsByStep[visit.StepID] = append(context.visitsByStep[visit.StepID], visit)
+	}
+
+	// Applied — durable-обещание полного перехода. Выбранные runnable targets
+	// проверяются после всего прохода, потому что законно расположены позже source.
+	for _, visit := range visits {
+		if visit.Decision == nil || !visit.Decision.Applied {
+			continue
+		}
+		route, exists := context.steps[visit.StepID].Decisions[visit.Decision.Key]
+		if !exists {
+			return agentSkippedContext{}, fmt.Errorf("посещение %q: применено неизвестное решение %q", visit.VisitID, visit.Decision.Key)
+		}
+		if route.Finish != nil && !terminal {
+			return agentSkippedContext{}, fmt.Errorf("посещение %q: применённый finish требует уже terminal run", visit.VisitID)
+		}
+		if route.Finish != nil {
+			continue
+		}
+		for _, target := range route.To {
+			if !context.decisionUses[agentDecisionCause{targetStepID: target, sourceVisitID: visit.VisitID}] {
+				return agentSkippedContext{}, fmt.Errorf("посещение %q: применённое решение не материализовало target %q", visit.VisitID, target)
+			}
+		}
+	}
+	return context, nil
+}
+
+func validateAgentSkippedAfter(
+	visit AgentVisitView,
+	step workflow.Step,
+	seen map[string]AgentVisitView,
+	visitsByStep map[string][]AgentVisitView,
+	used map[agentAfterCause]bool,
+	terminal bool,
+) (bool, error) {
+	if len(step.After) == 0 || len(visit.Trigger.SourceVisitIDs) != len(step.After) || visit.Trigger.DecisionKey != "" {
+		return false, fmt.Errorf("посещение %q: неверная форма after-trigger", visit.VisitID)
+	}
+	maxIteration, allSkipped := 0, true
+	for index, dependency := range step.After {
+		sourceID := visit.Trigger.SourceVisitIDs[index]
+		source, exists := seen[sourceID]
+		if !exists || source.StepID != dependency || !agentSkippedVisitTerminal(source.State) {
+			return false, fmt.Errorf("посещение %q: неверный after-источник %q", visit.VisitID, sourceID)
+		}
+		expected, foundSource := "", false
+		bypassReal := terminal && visit.State == Skipped && source.State == Skipped
+		for _, candidate := range visitsByStep[dependency] {
+			cause := agentAfterCause{targetStepID: step.ID, dependencyStepID: dependency, sourceVisitID: candidate.VisitID}
+			if used[cause] {
+				continue
+			}
+			if expected == "" {
+				expected = candidate.VisitID
+			}
+			if candidate.VisitID == sourceID {
+				foundSource = true
+				break
+			}
+			// Terminal closure может обойти только реальные sources. Более ранний
+			// Skipped всё равно обязан сначала оставить свою after-квитанцию.
+			if candidate.State == Skipped {
+				bypassReal = false
+			}
+		}
+		cause := agentAfterCause{targetStepID: step.ID, dependencyStepID: dependency, sourceVisitID: sourceID}
+		if !foundSource || sourceID != expected && !bypassReal || used[cause] {
+			return false, fmt.Errorf("посещение %q: after нарушает FIFO зависимости %q", visit.VisitID, dependency)
+		}
+		used[cause] = true
+		maxIteration = max(maxIteration, source.Iteration)
+		allSkipped = allSkipped && source.State == Skipped
+	}
+	if visit.Iteration != maxIteration {
+		return false, fmt.Errorf("посещение %q: after должен наследовать максимальную iteration источников", visit.VisitID)
+	}
+	if visit.State != Skipped && allSkipped || visit.State == Skipped && !allSkipped && !terminal {
+		return false, fmt.Errorf("посещение %q: skipped after должен иметь только skipped-источники", visit.VisitID)
+	}
+	return allSkipped, nil
+}
+
+func validateAgentDecisionSkippedTrigger(
+	visit AgentVisitView,
+	seen map[string]AgentVisitView,
+	uses map[agentDecisionCause]bool,
+	steps map[string]workflow.Step,
+	skipRoots map[string][]string,
+	skipReached map[agentSkipCause]bool,
+	terminal bool,
+	limitDecisionSourceID string,
+) ([]string, error) {
+	if visit.State != Skipped || len(visit.Trigger.SourceVisitIDs) != 1 || visit.Trigger.DecisionKey == "" {
+		return nil, fmt.Errorf("посещение %q: неверная форма skipped decision-trigger", visit.VisitID)
+	}
+	source, exists := seen[visit.Trigger.SourceVisitIDs[0]]
+	if !exists {
+		return nil, fmt.Errorf("посещение %q: неверный источник skipped decision", visit.VisitID)
+	}
+	selectedKey := ""
+	var roots []string
+	switch source.State {
+	case Succeeded:
+		if source.Decision == nil || source.Decision.Error != "" ||
+			!source.Decision.Applied && (!terminal || source.VisitID != limitDecisionSourceID) {
+			return nil, fmt.Errorf("посещение %q: неверный источник skipped decision", visit.VisitID)
+		}
+		if _, exists := steps[source.StepID].Decisions[source.Decision.Key]; !exists {
+			return nil, fmt.Errorf("посещение %q: источник выбрал неизвестное решение", visit.VisitID)
+		}
+		selectedKey, roots = source.Decision.Key, []string{source.VisitID}
+	case Skipped:
+		if len(steps[source.StepID].Decisions) == 0 {
+			return nil, fmt.Errorf("посещение %q: skipped-источник не является шагом решения", visit.VisitID)
+		}
+		var causal bool
+		roots, causal = skipRoots[source.VisitID]
+		if !causal {
+			return nil, fmt.Errorf("посещение %q: skipped-источник не принадлежит причинной волне", visit.VisitID)
+		}
+	default:
+		return nil, fmt.Errorf("посещение %q: неверный источник skipped decision", visit.VisitID)
+	}
+
+	wantKey := ""
+	for _, candidate := range decisionSkippedTargets(steps[source.StepID], selectedKey) {
+		if candidate.StepID == visit.StepID {
+			wantKey = candidate.DecisionKey
+			break
+		}
+	}
+	if wantKey == "" || visit.Trigger.DecisionKey != wantKey {
+		return nil, fmt.Errorf("посещение %q: skipped decision не соответствует невыбранному target", visit.VisitID)
+	}
+	cause := agentDecisionCause{targetStepID: visit.StepID, sourceVisitID: source.VisitID}
+	if uses[cause] {
+		return nil, fmt.Errorf("посещение %q: decision-target уже материализован", visit.VisitID)
+	}
+	if visit.Iteration != source.Iteration+1 {
+		return nil, fmt.Errorf("посещение %q: skipped decision-target должен увеличить iteration", visit.VisitID)
+	}
+	waveCause := agentSkipCause{waveKey: agentSkipWaveKey(roots), targetStepID: visit.StepID}
+	if skipReached[waveCause] {
+		return nil, fmt.Errorf("посещение %q: target уже достигнут в той же skipped-волне", visit.VisitID)
+	}
+	uses[cause], skipReached[waveCause] = true, true
+	return slices.Clone(roots), nil
+}
+
+func reserveAgentSkippedLimit(
+	context agentSkippedContext,
+	visits []AgentVisitView,
+	terminal bool,
+	limitStepID string,
+	trigger AgentTriggerView,
+) error {
+	if limitStepID == "" {
+		if trigger.Kind != "" || len(trigger.SourceVisitIDs) != 0 || trigger.DecisionKey != "" {
+			return fmt.Errorf("limit-trigger задан без limitStepId")
+		}
+		return nil
+	}
+	if !terminal {
+		return fmt.Errorf("maxVisits-trigger допустим только после terminal outcome")
+	}
+	limited, exists := context.steps[limitStepID]
+	if !exists || limited.MaxVisits == nil {
+		return fmt.Errorf("неизвестный шаг maxVisits %q", limitStepID)
+	}
+	switch trigger.Kind {
+	case AgentTriggerDecision:
+		if len(trigger.SourceVisitIDs) != 1 || trigger.DecisionKey == "" {
+			return fmt.Errorf("неверная форма decision-limit trigger")
+		}
+		var source AgentVisitView
+		for _, visit := range visits {
+			if visit.VisitID == trigger.SourceVisitIDs[0] {
+				source = visit
+				break
+			}
+		}
+		route, routeExists := context.steps[source.StepID].Decisions[trigger.DecisionKey]
+		if source.VisitID == "" || source.State != Succeeded || source.Decision == nil || source.Decision.Applied ||
+			source.Decision.Error != "" || source.Decision.Key != trigger.DecisionKey || !routeExists ||
+			route.Finish != nil || !slices.Contains(route.To, limitStepID) ||
+			context.active[limitStepID] || context.visitCount[limitStepID] < *limited.MaxVisits {
+			return fmt.Errorf("decision-limit trigger не подтверждён историей")
+		}
+	case AgentTriggerAfter:
+		if len(limited.After) == 0 || len(trigger.SourceVisitIDs) != len(limited.After) || trigger.DecisionKey != "" {
+			return fmt.Errorf("неверная форма after-limit trigger")
+		}
+		sources, _, allSkipped, ready := nextSkippedAfterSources(limited, context)
+		if !ready || allSkipped || !slices.Equal(sources, trigger.SourceVisitIDs) ||
+			context.active[limitStepID] || context.visitCount[limitStepID] < *limited.MaxVisits {
+			return fmt.Errorf("after-limit trigger не подтверждён историей")
+		}
+		// Точный FIFO-набор уже был потреблён попыткой создать N+1. Резервируем
+		// его только для limited target, чтобы следующие causal Skipped не застряли.
+		for index, dependency := range limited.After {
+			cause := agentAfterCause{targetStepID: limitStepID, dependencyStepID: dependency, sourceVisitID: trigger.SourceVisitIDs[index]}
+			if context.usedAfter[cause] {
+				return fmt.Errorf("after-limit source уже использован")
+			}
+			context.usedAfter[cause] = true
+		}
+	default:
+		return fmt.Errorf("maxVisits не поддерживает trigger %q", trigger.Kind)
+	}
+	return nil
+}
+
+// decisionSkippedTargets возвращает по одному target всех невыбранных routes.
+// Ключи сортируются, порядок route.to сохраняется, target выбранного route всегда
+// побеждает совпадающую альтернативу, а общий target альтернатив создаётся раз.
+func decisionSkippedTargets(step workflow.Step, selectedKey string) []agentSkippedTarget {
+	selected := make(map[string]bool)
+	if route, exists := step.Decisions[selectedKey]; exists {
+		for _, target := range route.To {
+			selected[target] = true
+		}
+	}
+	keys := make([]string, 0, len(step.Decisions))
+	for key := range step.Decisions {
+		if key != selectedKey {
+			keys = append(keys, key)
+		}
+	}
+	slices.Sort(keys)
+	seen := make(map[string]bool)
+	result := make([]agentSkippedTarget, 0)
+	for _, key := range keys {
+		for _, target := range step.Decisions[key].To {
+			if selected[target] || seen[target] {
+				continue
+			}
+			seen[target] = true
+			result = append(result, agentSkippedTarget{StepID: target, DecisionKey: key})
+		}
+	}
+	return result
+}
+
+type agentSkippedTarget struct {
+	StepID      string
+	DecisionKey string
+}
+
+func missingDecisionSkippedActivations(
+	step workflow.Step,
+	source AgentVisitView,
+	selectedKey string,
+	roots []string,
+	reached map[agentSkipCause]bool,
+) []AgentActivation {
+	result := make([]AgentActivation, 0)
+	waveKey := agentSkipWaveKey(roots)
+	for _, target := range decisionSkippedTargets(step, selectedKey) {
+		cause := agentSkipCause{waveKey: waveKey, targetStepID: target.StepID}
+		if reached[cause] {
+			continue
+		}
+		reached[cause] = true
+		result = append(result, AgentActivation{
+			StepID: target.StepID, Iteration: source.Iteration + 1, InitialState: Skipped,
+			Trigger: AgentTriggerView{
+				Kind: AgentTriggerDecisionSkipped, SourceVisitIDs: []string{source.VisitID}, DecisionKey: target.DecisionKey,
+			},
+		})
+	}
+	return result
+}
+
+func nextSkippedAfterSources(step workflow.Step, context agentSkippedContext) ([]string, int, bool, bool) {
+	sources := make([]string, 0, len(step.After))
+	maxIteration, allSkipped := 0, true
+	for _, dependency := range step.After {
+		found := false
+		for _, candidate := range context.visitsByStep[dependency] {
+			cause := agentAfterCause{targetStepID: step.ID, dependencyStepID: dependency, sourceVisitID: candidate.VisitID}
+			if context.usedAfter[cause] {
+				continue
+			}
+			if !agentSkippedVisitTerminal(candidate.State) {
+				return nil, 0, false, false
+			}
+			sources = append(sources, candidate.VisitID)
+			maxIteration = max(maxIteration, candidate.Iteration)
+			allSkipped = allSkipped && candidate.State == Skipped
+			found = true
+			break
+		}
+		if !found {
+			return nil, 0, false, false
+		}
+	}
+	return sources, maxIteration, allSkipped, true
+}
+
+func nextTerminalSkippedAfterSources(step workflow.Step, context agentSkippedContext) ([]string, int, bool, bool) {
+	sources := make([]string, 0, len(step.After))
+	maxIteration := 0
+	for _, dependency := range step.After {
+		found := false
+		for _, candidate := range context.visitsByStep[dependency] {
+			cause := agentAfterCause{targetStepID: step.ID, dependencyStepID: dependency, sourceVisitID: candidate.VisitID}
+			if context.usedAfter[cause] || candidate.State != Skipped {
+				continue
+			}
+			sources = append(sources, candidate.VisitID)
+			maxIteration = max(maxIteration, candidate.Iteration)
+			found = true
+			break
+		}
+		if !found {
+			return nil, 0, false, false
+		}
+	}
+	return sources, maxIteration, true, true
+}
+
+func agentAfterSkipRoots(sourceIDs []string, rootsByVisit map[string][]string) ([]string, bool) {
+	groups := make([][]string, 0, len(sourceIDs))
+	for _, sourceID := range sourceIDs {
+		if roots, exists := rootsByVisit[sourceID]; exists {
+			groups = append(groups, roots)
+		}
+	}
+	if len(groups) == 0 {
+		return nil, false
+	}
+	return mergeAgentSkipRoots(groups...), true
+}
+
+func mergeAgentSkipRoots(groups ...[]string) []string {
+	seen := make(map[string]bool)
+	result := make([]string, 0)
+	for _, group := range groups {
+		for _, root := range group {
+			if !seen[root] {
+				seen[root] = true
+				result = append(result, root)
+			}
+		}
+	}
+	slices.Sort(result)
+	return result
+}
+
+// agentSkipWaveKey кодирует набор roots однозначно даже для VisitID с любыми
+// разделителями: длина каждого непрозрачного значения входит в ключ.
+func agentSkipWaveKey(roots []string) string {
+	var key strings.Builder
+	for _, root := range roots {
+		key.WriteString(strconv.Itoa(len(root)))
+		key.WriteByte(':')
+		key.WriteString(root)
+	}
+	return key.String()
+}
+
+func cloneAgentSkipReached(source map[agentSkipCause]bool) map[agentSkipCause]bool {
+	result := make(map[agentSkipCause]bool, len(source))
+	for cause := range source {
+		result[cause] = true
+	}
+	return result
+}
+
+func knownAgentSkippedState(state State) bool {
+	return state == Skipped || knownAgentState(state)
+}
+
+func agentSkippedVisitTerminal(state State) bool {
+	return state == Failed || state == Skipped || state == Succeeded
+}

--- a/internal/scheduler/agent_skipped_test.go
+++ b/internal/scheduler/agent_skipped_test.go
@@ -1,0 +1,303 @@
+package scheduler
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stray-live-pixel/Lawa/internal/workflow"
+)
+
+// TestPlanAgentSkippedClosureBuildsNestedLayers воспроизводит полную причинную
+// цепочку issue #50. Невыбранный decision-кубик становится Skipped, раскрывает
+// все свои контрфактические routes, а полностью пропущенный after-барьер получает
+// отдельную durable-квитанцию. Каждый вызов возвращает только готовый слой:
+// вызывающая сторона должна сначала назначить его visits настоящие VisitID.
+func TestPlanAgentSkippedClosureBuildsNestedLayers(t *testing.T) {
+	w := agentWorkflow([]string{"choice"},
+		agentStep("choice", nil, map[string]workflow.Route{
+			"run":    {To: []string{"live"}},
+			"unused": {To: []string{"nested"}},
+		}),
+		agentStep("live", nil, nil),
+		agentStep("nested", nil, map[string]workflow.Route{
+			"alpha": {To: []string{"left"}},
+			"beta":  {To: []string{"right"}},
+		}),
+		agentStep("left", nil, nil),
+		agentStep("right", nil, nil),
+		agentStep("join", []string{"left", "right"}, nil),
+	)
+	visits := []AgentVisitView{
+		agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "run", Applied: true}),
+		agentDecisionVisit("live-1", "live", Succeeded, 2, "choice-1", "run", nil),
+	}
+
+	first := requireSkippedClosure(t, w, visits, false)
+	wantFirst := []AgentActivation{{
+		StepID: "nested", Iteration: 2, InitialState: Skipped,
+		Trigger: AgentTriggerView{
+			Kind: AgentTriggerDecisionSkipped, SourceVisitIDs: []string{"choice-1"}, DecisionKey: "unused",
+		},
+	}}
+	if !reflect.DeepEqual(first.DecisionActivations, wantFirst) {
+		t.Fatalf("первый слой не материализовал внешнюю невыбранную ветку:\n got: %#v\nwant: %#v", first.DecisionActivations, wantFirst)
+	}
+	visits = append(visits, agentSkippedActivation("nested-skip", first.DecisionActivations[0]))
+
+	second := requireSkippedClosure(t, w, visits, false)
+	wantSecond := []AgentActivation{
+		{
+			StepID: "left", Iteration: 3, InitialState: Skipped,
+			Trigger: AgentTriggerView{Kind: AgentTriggerDecisionSkipped, SourceVisitIDs: []string{"nested-skip"}, DecisionKey: "alpha"},
+		},
+		{
+			StepID: "right", Iteration: 3, InitialState: Skipped,
+			Trigger: AgentTriggerView{Kind: AgentTriggerDecisionSkipped, SourceVisitIDs: []string{"nested-skip"}, DecisionKey: "beta"},
+		},
+	}
+	if !reflect.DeepEqual(second.DecisionActivations, wantSecond) {
+		t.Fatalf("nested decision не раскрыл все routes в стабильном порядке:\n got: %#v\nwant: %#v", second.DecisionActivations, wantSecond)
+	}
+	visits = append(visits,
+		agentSkippedActivation("left-skip", second.DecisionActivations[0]),
+		agentSkippedActivation("right-skip", second.DecisionActivations[1]),
+	)
+
+	third := requireSkippedClosure(t, w, visits, false)
+	wantAfter := []AgentActivation{{
+		StepID: "join", Iteration: 3, InitialState: Skipped,
+		Trigger: AgentTriggerView{Kind: AgentTriggerAfter, SourceVisitIDs: []string{"left-skip", "right-skip"}},
+	}}
+	if !reflect.DeepEqual(third.AfterActivations, wantAfter) {
+		t.Fatalf("all-skipped barrier не получил FIFO-квитанцию:\n got: %#v\nwant: %#v", third.AfterActivations, wantAfter)
+	}
+	visits = append(visits, agentSkippedActivation("join-skip", third.AfterActivations[0]))
+	if final := requireSkippedClosure(t, w, visits, false); !reflect.DeepEqual(final, AgentPlan{}) {
+		t.Fatalf("замкнутая история повторно создала skipped-visits: %#v", final)
+	}
+}
+
+// TestPlanAgentSkippedClosureDeduplicatesRoutes проверяет два уровня dedupe.
+// Реально выбранный общий target нельзя одновременно назвать пропущенным, а
+// общий target двух невыбранных ключей получает один канонический trigger.
+// При этом отдельный активный visit того же target не мешает синтетической
+// записи: это разные причинные ветки, и Skipped не запускает второй executor.
+func TestPlanAgentSkippedClosureDeduplicatesRoutes(t *testing.T) {
+	w := agentWorkflow([]string{"choice", "busy"},
+		agentStep("choice", nil, map[string]workflow.Route{
+			"alpha": {To: []string{"shared", "busy"}},
+			"beta":  {To: []string{"busy"}},
+			"run":   {To: []string{"shared"}},
+		}),
+		agentStep("shared", nil, nil),
+		agentStep("busy", nil, nil),
+	)
+	visits := []AgentVisitView{
+		agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "run", Applied: true}),
+		agentStartVisit("busy-1", "busy", Running, 1, nil),
+		agentDecisionVisit("shared-1", "shared", Running, 2, "choice-1", "run", nil),
+	}
+	plan := requireSkippedClosure(t, w, visits, false)
+	want := []AgentActivation{{
+		StepID: "busy", Iteration: 2, InitialState: Skipped,
+		Trigger: AgentTriggerView{Kind: AgentTriggerDecisionSkipped, SourceVisitIDs: []string{"choice-1"}, DecisionKey: "alpha"},
+	}}
+	if !reflect.DeepEqual(plan.DecisionActivations, want) {
+		t.Fatalf("selected/shared target продублирован в skipped-ветке: got %#v, want %#v", plan.DecisionActivations, want)
+	}
+	visits = append(visits, agentSkippedActivation("busy-skip", plan.DecisionActivations[0]))
+	if next := requireSkippedClosure(t, w, visits, false); !reflect.DeepEqual(next, AgentPlan{}) {
+		t.Fatalf("сосуществующие active и skipped visits создали дубль: %#v", next)
+	}
+}
+
+// TestPlanAgentSkippedClosureStopsDecisionSCC доказывает конечность обхода. Одна
+// причинная волна проходит A→B→A, но второй A подавляется; независимые выходы из
+// обоих decisions при этом не теряются. maxVisits=1 не мешает, потому что
+// Skipped не означает фактический запуск агента и не расходует квоту.
+func TestPlanAgentSkippedClosureStopsDecisionSCC(t *testing.T) {
+	limit := 1
+	a := agentStep("a", nil, map[string]workflow.Route{
+		"continue": {To: []string{"b"}}, "leave": {To: []string{"leaf-a"}},
+	})
+	b := agentStep("b", nil, map[string]workflow.Route{
+		"continue": {To: []string{"a"}}, "leave": {To: []string{"leaf-b"}},
+	})
+	a.MaxVisits, b.MaxVisits = &limit, &limit
+	w := agentWorkflow([]string{"choice"},
+		agentStep("choice", nil, map[string]workflow.Route{
+			"run": {To: []string{"live"}}, "unused": {To: []string{"a"}},
+		}),
+		agentStep("live", nil, nil), a, b,
+		agentStep("leaf-a", nil, nil), agentStep("leaf-b", nil, nil),
+	)
+	visits := []AgentVisitView{
+		agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "run", Applied: true}),
+		agentDecisionVisit("live-1", "live", Succeeded, 2, "choice-1", "run", nil),
+	}
+
+	first := requireSkippedClosure(t, w, visits, false)
+	visits = append(visits, agentSkippedActivation("a-skip", first.DecisionActivations[0]))
+	second := requireSkippedClosure(t, w, visits, false)
+	if got := skippedStepIDs(second.DecisionActivations); !reflect.DeepEqual(got, []string{"b", "leaf-a"}) {
+		t.Fatalf("первый узел SCC потерял выходы: %v", got)
+	}
+	visits = append(visits,
+		agentSkippedActivation("b-skip", second.DecisionActivations[0]),
+		agentSkippedActivation("leaf-a-skip", second.DecisionActivations[1]),
+	)
+	third := requireSkippedClosure(t, w, visits, false)
+	if got := skippedStepIDs(third.DecisionActivations); !reflect.DeepEqual(got, []string{"leaf-b"}) {
+		t.Fatalf("обратное ребро SCC повторно создало A или потеряло выход: %v", got)
+	}
+	visits = append(visits, agentSkippedActivation("leaf-b-skip", third.DecisionActivations[0]))
+	if final := requireSkippedClosure(t, w, visits, false); !reflect.DeepEqual(final, AgentPlan{}) {
+		t.Fatalf("decision-SCC не достиг fixpoint: %#v", final)
+	}
+}
+
+// TestPlanAgentSkippedClosureTerminalSources фиксирует две специальные причины
+// terminal closure: применённый finish и не применённый decision, чей runnable
+// target N+1 заменён maxVisits. В обоих случаях альтернативы остаются причинными
+// Skipped; без terminal-доказательства такие snapshots отклоняются.
+func TestPlanAgentSkippedClosureTerminalSources(t *testing.T) {
+	t.Run("finish", func(t *testing.T) {
+		w := agentWorkflow([]string{"choice"},
+			agentStep("choice", nil, map[string]workflow.Route{
+				"finish": {Finish: agentOutcome(workflow.OutcomeSucceeded)},
+				"unused": {To: []string{"unused"}},
+			}),
+			agentStep("unused", nil, nil),
+		)
+		visits := []AgentVisitView{
+			agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "finish", Applied: true}),
+		}
+		if _, err := PlanAgentSkippedClosure(w, visits, false, "", AgentTriggerView{}); err == nil || !strings.Contains(err.Error(), "terminal run") {
+			t.Fatalf("running snapshot принял applied finish: %v", err)
+		}
+		plan := requireSkippedClosure(t, w, visits, true)
+		if got := skippedStepIDs(plan.DecisionActivations); !reflect.DeepEqual(got, []string{"unused"}) {
+			t.Fatalf("finish потерял невыбранную ветку: %v", got)
+		}
+	})
+
+	t.Run("decision limit", func(t *testing.T) {
+		limit := 1
+		limited := agentStep("limited", nil, nil)
+		limited.MaxVisits = &limit
+		w := agentWorkflow([]string{"choice", "limited"},
+			agentStep("choice", nil, map[string]workflow.Route{
+				"retry": {To: []string{"limited"}}, "unused": {To: []string{"unused"}},
+			}),
+			limited, agentStep("unused", nil, nil),
+		)
+		visits := []AgentVisitView{
+			agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "retry"}),
+			agentStartVisit("limited-1", "limited", Succeeded, 1, nil),
+		}
+		trigger := AgentTriggerView{Kind: AgentTriggerDecision, SourceVisitIDs: []string{"choice-1"}, DecisionKey: "retry"}
+		plan, err := PlanAgentSkippedClosure(w, visits, true, "limited", trigger)
+		if err != nil || !reflect.DeepEqual(skippedStepIDs(plan.DecisionActivations), []string{"unused"}) {
+			t.Fatalf("decision-limit не сохранил известную альтернативу: %#v, %v", plan, err)
+		}
+	})
+}
+
+// TestPlanAgentSkippedClosureRejectsForgery проверяет критические инварианты
+// durable view: selected target нельзя подделать как невыбранный, а runnable
+// after нельзя построить целиком из Skipped-источников.
+func TestPlanAgentSkippedClosureRejectsForgery(t *testing.T) {
+	t.Run("selected target", func(t *testing.T) {
+		w := agentWorkflow([]string{"choice"},
+			agentStep("choice", nil, map[string]workflow.Route{
+				"run": {To: []string{"live"}}, "unused": {To: []string{"unused"}},
+			}),
+			agentStep("live", nil, nil), agentStep("unused", nil, nil),
+		)
+		visits := []AgentVisitView{
+			agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "run", Applied: true}),
+			agentDecisionVisit("live-1", "live", Succeeded, 2, "choice-1", "run", nil),
+			{
+				VisitID: "forged", StepID: "live", Iteration: 2, State: Skipped,
+				Trigger: AgentTriggerView{Kind: AgentTriggerDecisionSkipped, SourceVisitIDs: []string{"choice-1"}, DecisionKey: "run"},
+			},
+		}
+		if _, err := PlanAgentSkippedClosure(w, visits, false, "", AgentTriggerView{}); err == nil {
+			t.Fatal("selected target принят как skipped")
+		}
+	})
+
+	t.Run("runnable after from skipped", func(t *testing.T) {
+		w := agentWorkflow([]string{"choice"},
+			agentStep("choice", nil, map[string]workflow.Route{
+				"run": {To: []string{"live"}}, "unused": {To: []string{"left"}},
+			}),
+			agentStep("live", nil, nil), agentStep("left", nil, nil),
+			agentStep("join", []string{"left"}, nil),
+		)
+		visits := []AgentVisitView{
+			agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "run", Applied: true}),
+			agentDecisionVisit("live-1", "live", Succeeded, 2, "choice-1", "run", nil),
+			{
+				VisitID: "left-skip", StepID: "left", Iteration: 2, State: Skipped,
+				Trigger: AgentTriggerView{Kind: AgentTriggerDecisionSkipped, SourceVisitIDs: []string{"choice-1"}, DecisionKey: "unused"},
+			},
+			agentAfterVisit("forged-join", "join", Pending, 2, []string{"left-skip"}, nil),
+		}
+		if _, err := PlanAgentSkippedClosure(w, visits, false, "", AgentTriggerView{}); err == nil || !strings.Contains(err.Error(), "skipped after") {
+			t.Fatalf("runnable after из skipped-источников принят: %v", err)
+		}
+	})
+}
+
+// TestPlanAgentGraphDoesNotProduceSkipped сохраняет границу этого PR: основному
+// producer ещё не поручено материализовывать альтернативы. Новый pure API можно
+// интегрировать отдельно, не меняя поведение уже работающего планировщика.
+func TestPlanAgentGraphDoesNotProduceSkipped(t *testing.T) {
+	w := agentWorkflow([]string{"choice"},
+		agentStep("choice", nil, map[string]workflow.Route{
+			"run": {To: []string{"live"}}, "unused": {To: []string{"unused"}},
+		}),
+		agentStep("live", nil, nil), agentStep("unused", nil, nil),
+	)
+	plan, err := PlanAgentGraph(w, []AgentVisitView{
+		agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "run"}),
+	})
+	if err != nil || len(plan.DecisionActivations) != 1 || plan.DecisionActivations[0].StepID != "live" ||
+		plan.DecisionActivations[0].InitialState != "" || plan.DecisionActivations[0].Trigger.Kind != AgentTriggerDecision {
+		t.Fatalf("основной producer неожиданно изменил поведение: %#v, %v", plan, err)
+	}
+}
+
+func requireSkippedClosure(t *testing.T, w workflow.Workflow, visits []AgentVisitView, terminal bool) AgentPlan {
+	t.Helper()
+	plan, err := PlanAgentSkippedClosure(w, visits, terminal, "", AgentTriggerView{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.ApplyDecisionVisitIDs) != 0 || plan.Terminal != nil {
+		t.Fatalf("skip-only API вернул исполняемое или terminal-действие: %#v", plan)
+	}
+	for _, activation := range append(append([]AgentActivation{}, plan.DecisionActivations...), plan.AfterActivations...) {
+		if activation.InitialState != Skipped {
+			t.Fatalf("skip-only API вернул не-Skipped активацию: %#v", activation)
+		}
+	}
+	return plan
+}
+
+func agentSkippedActivation(visitID string, activation AgentActivation) AgentVisitView {
+	return AgentVisitView{
+		VisitID: visitID, StepID: activation.StepID, Iteration: activation.Iteration,
+		State: Skipped, Trigger: activation.Trigger,
+	}
+}
+
+func skippedStepIDs(activations []AgentActivation) []string {
+	result := make([]string, 0, len(activations))
+	for _, activation := range activations {
+		result = append(result, activation.StepID)
+	}
+	return result
+}


### PR DESCRIPTION
## Результат

- добавлен чистый planner для транзитивного замыкания `skipped`-веток;
- пропуск распространяется через вложенные decision-кубики без фиктивного бизнес-решения;
- полностью пропущенный `after` становится `skipped`, смешанный join остаётся исполняемым;
- shared targets и decision-циклы конечны за счёт дедупликации causal wave;
- planner проверяет форму и причинность переданной durable-истории.

Основной `PlanAgentGraph` и persistence runtime пока не включают producer: подключение будет отдельным PR.

## Проверки

- `go test -count=1 ./internal/scheduler`
- `go test -count=1 ./...`
- `git diff --check`

## Размер

908 добавлений, 9 удалений — 917 изменённых строк. PR крупнее ориентира 500 строк, но ниже блокирующего предела 1200; основную часть занимают изолированная pure-логика и её тесты.

## Зависимость

Stacked поверх #87.

Part of #50.