### PR TITLE
Materialize skipped branches atomically

### DIFF
--- a/cmd/lawa/observability.go
+++ b/cmd/lawa/observability.go
@@ -131,7 +131,7 @@ func writeAgentStatus(out io.Writer, snapshot runstore.Snapshot, summaries map[s
 				}
 			}
 			if len(decision.Skipped) != 0 {
-				if _, err := fmt.Fprintf(out, "  skipped: %s\n", runstore.SafeTerminalText(strings.Join(decision.Skipped, ", "))); err != nil {
+				if _, err := fmt.Fprintf(out, "  skipped keys: %s\n", runstore.SafeTerminalText(strings.Join(decision.Skipped, ", "))); err != nil {
 					return err
 				}
 			}
@@ -200,7 +200,8 @@ func statusTriggerText(trigger runstore.VisitTrigger) string {
 }
 
 // statusRoutesText сортирует decision keys, но не меняет пользовательский
-// порядок route.to. Невыбранные routes остаются описанием, а не состояниями.
+// порядок route.to. Список описывает весь статический контракт решения; фактические
+// skipped-visits выводятся отдельно из durable metadata вместе с их состояниями.
 func statusRoutesText(step workflow.Step) string {
 	keys := make([]string, 0, len(step.Decisions))
 	for key := range step.Decisions {
@@ -327,11 +328,11 @@ func terminalEventsRecorded(snapshot runstore.Snapshot, states map[string]eventS
 	}
 	if snapshot.Meta.Version == 4 {
 		for _, visit := range snapshot.Meta.Visits {
-			// Explicit finish и onLimit могут оставить ещё не запущенные ветки.
-			// Для Pending нет и не должно быть visit_state. Starting появляется
-			// при durable reserve до любого thread/turn и также не обещает
-			// отдельного state-события: после crash его уже некому дописать.
-			if visit.State == scheduler.Pending || visit.State == scheduler.Starting {
+			// Для Pending и Starting нет обязательного terminal-события исполнителя:
+			// первый ещё не запускался, второй мог остаться после crash до thread/turn.
+			// Skipped никогда не запускает Codex и атомарно появляется в meta.json как
+			// результат планирования, поэтому ожидать для него visit_state нельзя.
+			if visit.State == scheduler.Pending || visit.State == scheduler.Starting || visit.State == scheduler.Skipped {
 				continue
 			}
 			event, ok := states[visit.VisitID]

--- a/cmd/lawa/observability_agent_test.go
+++ b/cmd/lawa/observability_agent_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 // agentObservabilityRun создаёт два законченных прохода self-loop и достигает
-// maxVisits при третьей активации. Второй стартовый шаг остаётся Pending: это
-// штатная история terminal outcome, а не незаписанное событие исполнителя.
+// maxVisits при третьей активации. Второй стартовый шаг становится Skipped:
+// terminal outcome не оставляет видимость будущего запуска Codex.
 func agentObservabilityRun(t *testing.T) (string, runstore.Snapshot, runstore.Visit, runstore.Visit) {
 	t.Helper()
 	root := filepath.Join(t.TempDir(), "runs")
@@ -57,6 +57,9 @@ func agentObservabilityRun(t *testing.T) (string, runstore.Snapshot, runstore.Vi
 	terminal, err := run.AdvanceAgentGraph()
 	if err != nil || terminal.Snapshot.Meta.RunState != runstore.RunFailed {
 		t.Fatalf("maxVisits не завершил run: %+v, %v", terminal, err)
+	}
+	if terminal.Snapshot.Meta.Visits[1].State != scheduler.Skipped {
+		t.Fatalf("не запущенная ветка не получила terminal skipped: %+v", terminal.Snapshot.Meta.Visits)
 	}
 	return root, terminal.Snapshot, first, second
 }
@@ -115,9 +118,9 @@ func TestAgentStatusShowsVisitsRoutesAndLimit(t *testing.T) {
 		"решение: again, applied=false",
 		"переход: loop",
 		"объяснение: Нужна ещё проверка",
-		"skipped: done",
+		"skipped keys: done",
 		"сообщение: первый проход",
-		"unused#1 [",
+		"unused#1 [" + snapshot.Meta.Visits[1].VisitID + "]: skipped",
 	} {
 		if !strings.Contains(text, fragment) {
 			t.Errorf("status не содержит %q:\n%s", fragment, text)
@@ -193,8 +196,8 @@ func TestAgentLogsRejectInvalidVisitFilters(t *testing.T) {
 }
 
 // TestAgentLogsFollowDrainsVisitEventAndIgnoresUnstarted проверяет три границы
-// завершения: terminal RunState не опережает финальный JSONL, но Pending и
-// зарезервированный Starting без thread/turn не требуют несуществующих событий.
+// завершения: terminal RunState не опережает финальный JSONL, но Skipped без
+// запуска Codex и зарезервированный Starting без thread/turn не требуют событий.
 func TestAgentLogsFollowDrainsVisitEventAndIgnoresUnstarted(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "runs")
 	snapshot, err := runstore.Create(root, runstore.Input{
@@ -238,6 +241,13 @@ func TestAgentLogsFollowDrainsVisitEventAndIgnoresUnstarted(t *testing.T) {
 	}
 	if err != nil {
 		t.Fatal(err)
+	}
+	terminal, err := run.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if terminal.Meta.Visits[1].State != scheduler.Skipped {
+		t.Fatalf("terminal finish оставил не запущенную ветку в %s", terminal.Meta.Visits[1].State)
 	}
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/internal/dashboard/agent_test.go
+++ b/internal/dashboard/agent_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 // createAgentDashboardRun строит историю с двумя проходами self-loop и
-// terminal maxVisits. Независимый стартовый visit остаётся Pending, чтобы
-// dashboard показывал фактическую историю, а не выдумывал skipped-состояние.
+// terminal maxVisits. Независимый стартовый visit становится Skipped, чтобы
+// dashboard показывал terminal-ветку без ложного запуска Codex.
 func createAgentDashboardRun(t *testing.T) (string, runstore.Snapshot) {
 	t.Helper()
 	root := filepath.Join(t.TempDir(), "runs")
@@ -100,10 +100,10 @@ func finishDashboardVisit(t *testing.T, run *runstore.LockedRun, visit runstore.
 
 // TestAgentDashboardShowsDurableVisitHistory проверяет карточки, уникальные
 // inspector-ключи и ссылки. Все объяснения берутся из metadata v4; dashboard не
-// создаёт ложных листов для невыбранных routes и не смешивает проходы цикла.
+// показывает durable skipped-лист для невыбранной ветки и не смешивает проходы цикла.
 func TestAgentDashboardShowsDurableVisitHistory(t *testing.T) {
 	root, snapshot := createAgentDashboardRun(t)
-	first, pending, second := snapshot.Meta.Visits[0], snapshot.Meta.Visits[1], snapshot.Meta.Visits[2]
+	first, skipped, second := snapshot.Meta.Visits[0], snapshot.Meta.Visits[1], snapshot.Meta.Visits[2]
 	recorder := httptest.NewRecorder()
 	Handler(root).ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/?period=all&view=all", nil))
 	if recorder.Code != http.StatusOK {
@@ -111,8 +111,9 @@ func TestAgentDashboardShowsDurableVisitHistory(t *testing.T) {
 	}
 	html := recorder.Body.String()
 	for _, fragment := range []string{
-		"dashboard-v2", "Workflow · failed", "Посещения", "2 из 3 завершено",
+		"dashboard-v2", "Workflow · failed", "Посещения", "3 из 3 завершено",
 		"loop#1", "loop#2", "unused#1", "Причина остановки", "Достигнут лимит",
+		"Посещение · skipped", "tone-skipped",
 		"loop · iteration=3 · decision:again ← " + second.VisitID,
 		"Причина запуска", "decision:again ← " + first.VisitID,
 		"Решение", "again · applied=true", "again · applied=false",
@@ -129,8 +130,8 @@ func TestAgentDashboardShowsDurableVisitHistory(t *testing.T) {
 		}
 	}
 	if strings.Contains(html, `step:`+snapshot.Meta.RunID+`:loop"`) ||
-		!strings.Contains(html, `data-inspector-select="step:`+snapshot.Meta.RunID+`:`+pending.VisitID+`"`) {
-		t.Fatal("повторы получили общий inspector key или фактический Pending visit потерян")
+		!strings.Contains(html, `data-inspector-select="step:`+snapshot.Meta.RunID+`:`+skipped.VisitID+`"`) {
+		t.Fatal("повторы получили общий inspector key или durable Skipped visit потерян")
 	}
 
 	node := makeRunNode(root, snapshot)
@@ -143,6 +144,9 @@ func TestAgentDashboardShowsDurableVisitHistory(t *testing.T) {
 	}
 	if byKey[first.VisitID].Message != "первый итог" || byKey[second.VisitID].Message != "второй итог" {
 		t.Fatalf("сводки visits смешаны: first=%+v second=%+v", byKey[first.VisitID], byKey[second.VisitID])
+	}
+	if item := byKey[skipped.VisitID]; item.State != string(scheduler.Skipped) || item.Tone != "skipped" || item.Active {
+		t.Fatalf("пропущенная ветка выглядит активной или аварийной: %+v", item)
 	}
 }
 
@@ -260,6 +264,7 @@ func TestFailedTreeKeepsAgentVisitsOnlyForOwnFailure(t *testing.T) {
 		ID: "parent", State: "running", AgentGraph: true,
 		Steps: []stepNode{
 			{Key: "visit-done", ID: "work#1", State: "succeeded"},
+			{Key: "visit-skipped", ID: "unused#1", State: "skipped"},
 			{Key: "visit-active", ID: "check#1", State: "running", Active: true},
 		},
 	}

--- a/internal/runstore/advance.go
+++ b/internal/runstore/advance.go
@@ -16,10 +16,11 @@ import (
 	"github.com/stray-live-pixel/Lawa/internal/workflow"
 )
 
-// AgentAdvance — результат одной атомарной материализации pure-плана. Snapshot
-// уже содержит новые visits и Applied-флаги; CreatedVisits связывает ordered
-// activations планировщика с созданными visitId для следующего шага coordinator.
-// Changed=false означает, что durable snapshot уже полностью применён.
+// AgentAdvance — результат одной атомарной материализации pure-плана. Plan
+// хранит исходный business-переход scheduler, а Snapshot — его полный результат.
+// CreatedVisits перечисляет в durable-порядке и основные activations, и все
+// автоматически достроенные слои skipped-замыкания; их точные причины уже есть
+// в Trigger. Changed=false означает, что durable snapshot полностью применён.
 type AgentAdvance struct {
 	Snapshot      Snapshot
 	Plan          scheduler.AgentPlan
@@ -60,19 +61,67 @@ func (r *LockedRun) advanceAgentGraph(syncFile func(*os.File) error) (AgentAdvan
 	if err != nil {
 		return AgentAdvance{}, err
 	}
-	if plan.Terminal != nil && (len(plan.DecisionActivations) != 0 || len(plan.AfterActivations) != 0) {
-		return AgentAdvance{}, fmt.Errorf("планировщик смешал terminal outcome и новые activations")
+	if len(plan.MarkSkippedVisitIDs) != 0 && plan.Terminal == nil {
+		return AgentAdvance{}, fmt.Errorf("планировщик пометил существующие visits как skipped без terminal outcome")
 	}
-	changed := len(plan.ApplyDecisionVisitIDs) != 0 || len(plan.DecisionActivations) != 0 || len(plan.AfterActivations) != 0 || plan.Terminal != nil
-	if !changed {
-		return AgentAdvance{Snapshot: snapshot, Plan: plan}, nil
+	if plan.Terminal != nil && agentPlanHasRunnableActivations(plan) {
+		return AgentAdvance{}, fmt.Errorf("планировщик смешал terminal outcome и запускаемые activations")
 	}
+	changed := len(plan.ApplyDecisionVisitIDs) != 0 || len(plan.MarkSkippedVisitIDs) != 0 ||
+		len(plan.DecisionActivations) != 0 || len(plan.AfterActivations) != 0 || plan.Terminal != nil
 
 	if err = applyAgentDecisionFlags(&snapshot, plan.ApplyDecisionVisitIDs); err != nil {
 		return AgentAdvance{}, err
 	}
+	if err = applyAgentSkippedFlags(&snapshot, plan.MarkSkippedVisitIDs); err != nil {
+		return AgentAdvance{}, err
+	}
 	created := materializeAgentVisits(snapshot.Meta.Visits, plan.DecisionActivations, plan.AfterActivations)
 	snapshot.Meta.Visits = append(snapshot.Meta.Visits, created...)
+	limitStepID := ""
+	limitTrigger := scheduler.AgentTriggerView{}
+	if plan.Terminal != nil {
+		limitStepID = plan.Terminal.LimitStepID
+		limitTrigger = plan.Terminal.LimitTrigger
+	}
+
+	// Synthetic Skipped образуют причинное замыкание: пропущенный decision
+	// распространяет отсутствие по всем своим routes, а полностью пропущенный
+	// after — дальше по статическому DAG. Следующей волне нужны реальные visitId
+	// предыдущей, поэтому runstore присваивает ID в памяти и повторяет pure planner
+	// до неподвижной точки. Ни один промежуточный снимок не публикуется. Это особенно
+	// важно для finish: после terminal meta обычный Advance уже запрещён, поэтому
+	// вся недостижимая вложенная ветка обязана попасть в тот же атомарный commit.
+	for {
+		closure, closureErr := scheduler.PlanAgentSkippedClosure(
+			snapshot.Workflow, agentVisitViews(snapshot.Meta.Visits), plan.Terminal != nil, limitStepID, limitTrigger,
+		)
+		if closureErr != nil {
+			return AgentAdvance{}, fmt.Errorf("достроить skipped-ветки: %w", closureErr)
+		}
+		if len(closure.ApplyDecisionVisitIDs) != 0 || len(closure.MarkSkippedVisitIDs) != 0 || closure.Terminal != nil {
+			return AgentAdvance{}, fmt.Errorf("планировщик skipped-замыкания вернул недопустимый переход")
+		}
+		if agentPlanHasRunnableActivations(closure) {
+			return AgentAdvance{}, fmt.Errorf("планировщик skipped-замыкания попытался запустить agent visit")
+		}
+		if len(closure.DecisionActivations) == 0 && len(closure.AfterActivations) == 0 {
+			break
+		}
+		layer := materializeAgentVisits(snapshot.Meta.Visits, closure.DecisionActivations, closure.AfterActivations)
+		if len(layer) == 0 {
+			return AgentAdvance{}, fmt.Errorf("непустое skipped-замыкание не материализовало visits")
+		}
+		snapshot.Meta.Visits = append(snapshot.Meta.Visits, layer...)
+		created = append(created, layer...)
+	}
+	// Skip-only repair не обязан ждать чужую незавершённую decision-wave: он не
+	// запускает работу и не конкурирует с business terminal. Поэтому closure
+	// проверяется даже при пустом основном плане. Если и он пуст, durable-снимок
+	// действительно не изменился и лишний Rename не нужен.
+	if !changed && len(created) == 0 {
+		return AgentAdvance{Snapshot: snapshot, Plan: plan}, nil
+	}
 	if plan.Terminal != nil {
 		switch plan.Terminal.Outcome {
 		case workflow.OutcomeSucceeded:
@@ -113,6 +162,28 @@ func (r *LockedRun) advanceAgentGraph(syncFile func(*os.File) error) (AgentAdvan
 		return AgentAdvance{}, r.recordVisitSaveFailure(err)
 	}
 	return AgentAdvance{Snapshot: snapshot, Plan: plan, CreatedVisits: slices.Clone(created), Changed: true}, nil
+}
+
+// agentActivationState сохраняет обратную совместимость с планами, созданными
+// до появления InitialState: нулевое значение по-прежнему означает запускаемый
+// Pending visit. Явный Skipped создаёт только причинный terminal token без Codex.
+func agentActivationState(activation scheduler.AgentActivation) scheduler.State {
+	if activation.InitialState == "" {
+		return scheduler.Pending
+	}
+	return activation.InitialState
+}
+
+// agentPlanHasRunnableActivations разрешает terminal commit дополнять историю
+// только synthetic Skipped. Pending вместе с итогом был бы опубликован уже после
+// запрета новых turn и навсегда оставил бы ложную готовую работу.
+func agentPlanHasRunnableActivations(plan scheduler.AgentPlan) bool {
+	for _, activation := range append(slices.Clone(plan.DecisionActivations), plan.AfterActivations...) {
+		if agentActivationState(activation) != scheduler.Skipped {
+			return true
+		}
+	}
+	return false
 }
 
 // compactAgentStopReason превращает диагностический текст pure planner в
@@ -167,6 +238,29 @@ func applyAgentDecisionFlags(snapshot *Snapshot, visitIDs []string) error {
 	return nil
 }
 
+// applyAgentSkippedFlags переводит лишь ещё не запущенные durable visits. Их
+// исходный trigger сохраняется: по нему видно, какая выбранная либо стартовая
+// ветка была остановлена общим terminal outcome. Synthetic пропуски сразу
+// создаются как Skipped и поэтому сюда не передаются.
+func applyAgentSkippedFlags(snapshot *Snapshot, visitIDs []string) error {
+	indices := visitIndices(snapshot.Meta.Visits)
+	seen := make(map[string]bool, len(visitIDs))
+	for _, visitID := range visitIDs {
+		index, exists := indices[visitID]
+		if !exists || seen[visitID] {
+			return fmt.Errorf("планировщик указал неизвестное или повторное skipped-посещение %q", visitID)
+		}
+		seen[visitID] = true
+		visit := &snapshot.Meta.Visits[index]
+		if visit.State != scheduler.Pending || visit.CodexThreadID != "" || visit.TurnID != "" || visit.Attempt != 0 ||
+			visit.TechnicalError != "" || visit.Decision != nil {
+			return fmt.Errorf("посещение %q нельзя пометить как skipped", visitID)
+		}
+		visit.State = scheduler.Skipped
+	}
+	return nil
+}
+
 // materializeAgentVisits сохраняет порядок planner: сначала выбранные decision
 // targets в порядке Visits/route.to, затем after-barriers в порядке Steps. Номер
 // Visit считается по уже durable истории и возрастает отдельно для StepID.
@@ -183,7 +277,7 @@ func materializeAgentVisits(history []Visit, decision, after []scheduler.AgentAc
 		numbers[activation.StepID]++
 		created = append(created, Visit{
 			VisitID: newID(), StepID: activation.StepID, Visit: numbers[activation.StepID],
-			Iteration: activation.Iteration, State: scheduler.Pending,
+			Iteration: activation.Iteration, State: agentActivationState(activation),
 			Trigger: VisitTrigger{
 				Kind: TriggerKind(activation.Trigger.Kind), SourceVisitIDs: slices.Clone(activation.Trigger.SourceVisitIDs),
 				DecisionKey: activation.Trigger.DecisionKey,

--- a/internal/runstore/advance_test.go
+++ b/internal/runstore/advance_test.go
@@ -38,6 +38,20 @@ func advanceInput(t *testing.T) Input {
 }`), Task: "Продвинуть граф", Comment: "Тест persistence bridge", CWD: t.TempDir()}
 }
 
+// skippedJoinInput воспроизводит if/else с общим after-join.
+func skippedJoinInput(t *testing.T) Input {
+	t.Helper()
+	return Input{WorkflowJSON: []byte(`{
+  "version":2,"id":"skipped-join","start":["choice"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
+      "left":{"to":["left"]},"right":{"to":["right"]}}},
+    {"id":"left","type":"agent","prompt":"Левая ветка","after":[]},
+    {"id":"right","type":"agent","prompt":"Правая ветка","after":[]},
+    {"id":"join","type":"agent","prompt":"Объедини","after":["left","right"]}
+  ]
+}`), Task: "Проверить пропущенную ветку", CWD: t.TempDir()}
+}
+
 // boundedLoopInput оставляет параллельный Pending visit, чтобы остановка по
 // квоте доказывала семантику всего run, а не только естественную quiescence.
 func boundedLoopInput(t *testing.T, successfulLimit bool) Input {
@@ -266,6 +280,51 @@ func TestAdvanceAgentGraphRouteAndAfter(t *testing.T) {
 	}
 }
 
+// TestAdvanceAgentGraphPersistsSkippedBranchAndUnblocksJoin проверяет всю
+// persistence-цепочку if/else: невыбранная ветка не запускается, но остаётся
+// terminal-причиной для общего join.
+func TestAdvanceAgentGraphPersistsSkippedBranchAndUnblocksJoin(t *testing.T) {
+	root := t.TempDir()
+	initial, err := Create(root, skippedJoinInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+
+	choiceID := initial.Meta.Visits[0].VisitID
+	finishDecisionVisit(t, run, choiceID, "left")
+	advanced, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !advanced.Changed || len(advanced.CreatedVisits) != 2 || !advanced.Snapshot.Meta.Visits[0].Decision.Applied {
+		t.Fatalf("выбор и branch-записи не опубликованы одним переходом: %+v", advanced)
+	}
+	left, right := advanced.CreatedVisits[0], advanced.CreatedVisits[1]
+	if left.StepID != "left" || left.State != scheduler.Pending ||
+		right.StepID != "right" || right.State != scheduler.Skipped || right.Trigger.Kind != TriggerDecisionSkipped {
+		t.Fatalf("ветки получили неверные состояния: left=%+v right=%+v", left, right)
+	}
+	if info, statErr := os.Stat(filepath.Join(root, initial.Meta.RunID, "memory", right.VisitID+".md")); statErr != nil || info.Size() != 0 {
+		t.Fatalf("Skipped visit не получил пустую durable-память: info=%v err=%v", info, statErr)
+	}
+
+	finishPlainVisit(t, run, left.VisitID)
+	joined, err := run.AdvanceAgentGraph()
+	if err != nil || len(joined.CreatedVisits) != 1 {
+		t.Fatalf("смешанный barrier не создал join: %+v, %v", joined, err)
+	}
+	join := joined.CreatedVisits[0]
+	if join.StepID != "join" || join.State != scheduler.Pending ||
+		!slices.Equal(join.Trigger.SourceVisitIDs, []string{left.VisitID, right.VisitID}) {
+		t.Fatalf("join потерял выполненную или пропущенную причину: %+v", join)
+	}
+}
+
 // TestAdvanceAgentGraphFinishWithActiveVisit фиксирует приоритет explicit finish:
 // он атомарно связывается с Applied decision и останавливает планирование, не
 // переписывая состояние уже работающего параллельного visit.
@@ -294,8 +353,13 @@ func TestAdvanceAgentGraphFinishWithActiveVisit(t *testing.T) {
 	}
 	if !result.Changed || result.Plan.Terminal == nil || result.Snapshot.Meta.RunState != RunSucceeded ||
 		result.Snapshot.Meta.StopReason == "" || result.Snapshot.Meta.StopVisitID != decisionID ||
-		!result.Snapshot.Meta.Visits[0].Decision.Applied || result.Snapshot.Meta.Visits[1].State != scheduler.Running || len(result.CreatedVisits) != 0 {
+		!result.Snapshot.Meta.Visits[0].Decision.Applied || result.Snapshot.Meta.Visits[1].State != scheduler.Running || len(result.CreatedVisits) != 3 {
 		t.Fatalf("finish опубликован неатомарно: %+v", result)
+	}
+	for _, visit := range result.CreatedVisits {
+		if visit.State != scheduler.Skipped {
+			t.Fatalf("finish не сохранил пропущенную ветку: %+v", visit)
+		}
 	}
 	if _, err := run.AdvanceAgentGraph(); err == nil {
 		t.Fatal("terminal run принят для повторного планирования")
@@ -467,6 +531,8 @@ func TestAdvanceAgentGraphBoundedLoop(t *testing.T) {
 				s.Workflow.Steps = slices.Clone(s.Workflow.Steps)
 				outcome := workflow.OutcomeSucceeded
 				s.Workflow.Steps[1].Decisions = map[string]workflow.Route{"done": {Finish: &outcome}}
+				s.Meta.Visits[1].State, s.Meta.Visits[1].CodexThreadID = scheduler.Running, "chat-open-wave"
+				s.Meta.Visits[1].TurnID, s.Meta.Visits[1].Attempt = "turn-open-wave", 1
 			},
 			"no pending activation": func(s *Snapshot) {
 				s.Meta.Visits[2].State, s.Meta.Visits[2].Decision = scheduler.Failed, nil
@@ -495,7 +561,7 @@ func TestAdvanceAgentGraphBoundedLoop(t *testing.T) {
 		if err != nil || result.Snapshot.Meta.RunState != RunSucceeded || result.Snapshot.Meta.StopVisitID != second.VisitID ||
 			result.Snapshot.Meta.StopLimitStepID != "loop" || result.Snapshot.Meta.StopLimitTrigger == nil ||
 			result.Snapshot.Meta.StopLimitIteration != 3 || result.Plan.Terminal == nil ||
-			result.Plan.Terminal.Outcome != workflow.OutcomeSucceeded || result.Snapshot.Meta.Visits[1].State != scheduler.Pending {
+			result.Plan.Terminal.Outcome != workflow.OutcomeSucceeded || result.Snapshot.Meta.Visits[1].State != scheduler.Skipped {
 			t.Fatalf("onLimit не завершил run при активной параллельной ветке: %+v, %v", result, err)
 		}
 	})

--- a/internal/runstore/visits.go
+++ b/internal/runstore/visits.go
@@ -97,6 +97,11 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 		return fmt.Errorf("workflow v4: %w", err)
 	}
 	hasLimitProof := m.StopLimitStepID != "" || m.StopLimitTrigger != nil || m.StopLimitIteration != 0
+	limitDecisionSourceID := ""
+	if m.RunState != RunRunning && m.StopLimitTrigger != nil && m.StopLimitTrigger.Kind == TriggerDecision &&
+		len(m.StopLimitTrigger.SourceVisitIDs) == 1 {
+		limitDecisionSourceID = m.StopLimitTrigger.SourceVisitIDs[0]
+	}
 	if m.RunState != RunRunning && m.RunState != RunSucceeded && m.RunState != RunFailed ||
 		m.RunState == RunRunning && (m.StopReason != "" || m.StopVisitID != "" || hasLimitProof) ||
 		m.RunState != RunRunning && !safeStoredText(m.StopReason, true) {
@@ -153,7 +158,7 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 		}
 		roots, err := validateTriggerWithSkipWaves(
 			index, visit, step, s.Workflow.Start, m.Visits[:index], seen, steps,
-			afterUses, decisionUses, skipWaves, skipReached,
+			afterUses, decisionUses, skipWaves, skipReached, m.RunState != RunRunning, limitDecisionSourceID,
 		)
 		if err != nil {
 			return fmt.Errorf("посещение %q: %w", visit.VisitID, err)
@@ -161,6 +166,9 @@ func (s Snapshot) validateAgentGraph(runID string) error {
 		if len(roots) != 0 {
 			skipWaves[visit.VisitID] = roots
 			skipReached[skipReach{waveKey: skipWaveKey(roots), targetStepID: visit.StepID}] = true
+		}
+		if err := validateSkippedVisit(m.RunState, visit, seen); err != nil {
+			return fmt.Errorf("посещение %q: %w", visit.VisitID, err)
 		}
 		if err := validateDecision(visit, step); err != nil {
 			return fmt.Errorf("посещение %q: %w", visit.VisitID, err)
@@ -459,7 +467,7 @@ func validateTrigger(
 ) error {
 	_, err := validateTriggerWithSkipWaves(
 		index, visit, step, start, history, seen, steps,
-		afterUses, decisionUses, nil, nil,
+		afterUses, decisionUses, nil, nil, false, "",
 	)
 	return err
 }
@@ -479,6 +487,8 @@ func validateTriggerWithSkipWaves(
 	decisionUses map[decisionCause]bool,
 	skipWaves map[string][]string,
 	skipReached map[skipReach]bool,
+	terminalRun bool,
+	limitDecisionSourceID string,
 ) ([]string, error) {
 	if index < len(start) {
 		if visit.StepID != start[index] || visit.Trigger.Kind != TriggerStart || visit.Visit != 1 || visit.Iteration != 1 {
@@ -490,15 +500,13 @@ func validateTriggerWithSkipWaves(
 		if index >= len(start) || len(visit.Trigger.SourceVisitIDs) != 0 || visit.Trigger.DecisionKey != "" {
 			return nil, fmt.Errorf("start допустим только в начальном префиксе без источников")
 		}
-		if visit.State == scheduler.Skipped {
-			return nil, fmt.Errorf("start не может быть synthetic Skipped")
-		}
 	case TriggerAfter:
 		if len(step.After) == 0 || len(visit.Trigger.SourceVisitIDs) != len(step.After) || visit.Trigger.DecisionKey != "" {
 			return nil, fmt.Errorf("after должен содержать источник для каждого Step.After")
 		}
 		maxIteration := 0
 		allSkipped := true
+		causalSkip := false
 		var roots []string
 		for i, sourceID := range visit.Trigger.SourceVisitIDs {
 			source, exists := seen[sourceID]
@@ -507,40 +515,45 @@ func validateTriggerWithSkipWaves(
 			}
 			cause := afterCause{visit.StepID, step.After[i], sourceID}
 			expected := ""
+			foundSource := false
+			bypassRealSources := terminalRun && visit.State == scheduler.Skipped && source.State == scheduler.Skipped
 			for _, candidate := range history {
 				candidateCause := afterCause{visit.StepID, step.After[i], candidate.VisitID}
-				// FIFO учитывает и незавершённый instance. Иначе более поздний
-				// synthetic Skipped смог бы обойти ранний Running того же шага.
-				if candidate.StepID == step.After[i] && !afterUses[candidateCause] {
+				if candidate.StepID != step.After[i] || afterUses[candidateCause] {
+					continue
+				}
+				if expected == "" {
 					expected = candidate.VisitID
+				}
+				if candidate.VisitID == sourceID {
+					foundSource = true
 					break
 				}
+				if candidate.State == scheduler.Skipped {
+					bypassRealSources = false
+				}
 			}
-			if sourceID != expected || afterUses[cause] {
+			if !foundSource || sourceID != expected && !bypassRealSources || afterUses[cause] {
 				return nil, fmt.Errorf("after должен потреблять самый ранний неиспользованный источник")
 			}
 			afterUses[cause] = true
 			maxIteration = max(maxIteration, source.Iteration)
 			allSkipped = allSkipped && source.State == scheduler.Skipped
-			roots = append(roots, skipWaves[sourceID]...)
+			if sourceRoots, causal := skipWaves[sourceID]; causal {
+				causalSkip = true
+				roots = append(roots, sourceRoots...)
+			}
 		}
 		if visit.Iteration != maxIteration {
 			return nil, fmt.Errorf("after должен наследовать максимальную iteration источников")
 		}
-		if (visit.State == scheduler.Skipped) != allSkipped {
-			return nil, fmt.Errorf("Skipped after должен иметь только Skipped-источники")
+		if visit.State != scheduler.Skipped && allSkipped {
+			return nil, fmt.Errorf("after с полностью Skipped-источниками сам должен быть Skipped")
 		}
-		if allSkipped {
-			roots = canonicalSkipRoots(roots)
-			if len(roots) == 0 {
-				return nil, fmt.Errorf("Skipped after потерял причинную волну")
-			}
-			return roots, nil
+		if visit.State == scheduler.Skipped && allSkipped && causalSkip {
+			return canonicalSkipRoots(roots), nil
 		}
 	case TriggerDecision:
-		if visit.State == scheduler.Skipped {
-			return nil, fmt.Errorf("выбранный decision-target не может быть Skipped")
-		}
 		if len(visit.Trigger.SourceVisitIDs) != 1 || visit.Trigger.DecisionKey == "" {
 			return nil, fmt.Errorf("decision требует один источник и ключ")
 		}
@@ -569,7 +582,8 @@ func validateTriggerWithSkipWaves(
 		var roots []string
 		switch source.State {
 		case scheduler.Succeeded:
-			if source.Decision == nil || !source.Decision.Applied || source.Decision.Error != "" {
+			if source.Decision == nil || source.Decision.Error != "" ||
+				!source.Decision.Applied && source.VisitID != limitDecisionSourceID {
 				return nil, fmt.Errorf("decision_skipped ссылается не на применённое решение")
 			}
 			selectedKey = source.Decision.Key
@@ -651,6 +665,29 @@ func skipWaveKey(roots []string) string {
 		result.WriteString(root)
 	}
 	return result.String()
+}
+
+// validateSkippedVisit отличает synthetic skip работающего графа от Pending,
+// который terminal-переход всего run закрыл без запуска Codex.
+func validateSkippedVisit(runState RunState, visit Visit, seen map[string]Visit) error {
+	if runState != RunRunning || visit.Trigger.Kind == TriggerDecisionSkipped {
+		return nil
+	}
+	if visit.Trigger.Kind != TriggerAfter {
+		if visit.State == scheduler.Skipped {
+			return fmt.Errorf("работающий run допускает Skipped только из невыбранного route или полностью пропущенного after")
+		}
+		return nil
+	}
+	allSkipped := len(visit.Trigger.SourceVisitIDs) != 0
+	for _, sourceID := range visit.Trigger.SourceVisitIDs {
+		source, exists := seen[sourceID]
+		allSkipped = allSkipped && exists && source.State == scheduler.Skipped
+	}
+	if (visit.State == scheduler.Skipped) != allSkipped {
+		return fmt.Errorf("Skipped after должен иметь только Skipped-источники")
+	}
+	return nil
 }
 
 func validateDecision(visit Visit, step workflow.Step) error {

--- a/internal/runstore/visits_test.go
+++ b/internal/runstore/visits_test.go
@@ -567,7 +567,7 @@ func TestAfterTriggerFIFO(t *testing.T) {
 		StepID: "check", Iteration: 2, State: scheduler.Skipped,
 		Trigger: VisitTrigger{Kind: TriggerAfter, SourceVisitIDs: []string{skipped.VisitID}},
 	}, workflow.Step{ID: "check", After: []string{"work"}}, nil, history, seen, nil,
-		map[afterCause]bool{}, map[decisionCause]bool{}, map[string][]string{skipped.VisitID: {newID()}}, map[skipReach]bool{})
+		map[afterCause]bool{}, map[decisionCause]bool{}, map[string][]string{skipped.VisitID: {newID()}}, map[skipReach]bool{}, false, "")
 	if err == nil {
 		t.Fatal("after обошёл ранний Running через более поздний Skipped")
 	}

--- a/internal/scheduler/agent.go
+++ b/internal/scheduler/agent.go
@@ -85,7 +85,10 @@ type AgentPlan struct {
 	ApplyDecisionVisitIDs []string
 	DecisionActivations   []AgentActivation
 	AfterActivations      []AgentActivation
-	Terminal              *AgentTerminal
+	// MarkSkippedVisitIDs закрывает ещё не запущенные Pending-visits вместе с
+	// terminal outcome. Выполняющиеся visits сюда не попадают.
+	MarkSkippedVisitIDs []string
+	Terminal            *AgentTerminal
 }
 
 // PlanAgentGraph вычисляет следующий переход version=2 без I/O и не изменяет
@@ -108,17 +111,17 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 	if w.EffectiveVersion() != workflow.VersionAgentGraph {
 		return AgentPlan{}, fmt.Errorf("visit-aware планировщик требует workflow version=2")
 	}
-	context, err := validateAgentVisitViews(w, visits)
+	context, err := validateAgentSkippedViews(w, visits, false, "")
 	if err != nil {
 		return AgentPlan{}, fmt.Errorf("visit-aware планировщик: %w", err)
 	}
 	if terminal, exists := firstDecisionFatal(context.steps, visits); exists {
-		return terminal, nil
+		return markPendingVisitsSkipped(terminal, visits), nil
 	}
 	decisionWaveComplete := agentDecisionWaveComplete(context.steps, visits)
 	if decisionWaveComplete {
-		if terminal, exists := firstDecisionTerminal(context.steps, visits); exists {
-			return terminal, nil
+		if terminal, exists := firstDecisionTerminal(context, visits); exists {
+			return markPendingVisitsSkipped(terminal, visits), nil
 		}
 	}
 
@@ -127,6 +130,7 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 	for stepID := range context.active {
 		projectedActive[stepID] = true
 	}
+	projectedSkipped := cloneAgentSkipReached(context.skipReached)
 
 	// Один decision fanout является неделимой операцией. Если хотя бы одна цель
 	// занята, нельзя применить только свободную часть: повтор после crash иначе не
@@ -137,7 +141,7 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 		}
 		step := context.steps[visit.StepID]
 		decision := visit.Decision
-		if len(step.Decisions) == 0 || visit.State != Succeeded || decision == nil || decision.Applied || decision.Error != "" {
+		if len(step.Decisions) == 0 || visit.State != Succeeded || decision == nil || decision.Error != "" {
 			continue
 		}
 		route, exists := step.Decisions[decision.Key]
@@ -145,6 +149,15 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 			// Unknown и finish уже обработаны firstDecisionTerminal. Условие
 			// оставлено защитным, чтобы дальнейшее расширение функции не могло
 			// превратить terminal route в обычную активацию.
+			continue
+		}
+		skipped := missingDecisionSkippedActivations(
+			step, visit, decision.Key, []string{visit.VisitID}, projectedSkipped,
+		)
+		if decision.Applied {
+			// Старые running snapshots могли применить выбранный route до появления
+			// durable skipped-записей. Дополняем только отсутствующие альтернативы.
+			plan.DecisionActivations = append(plan.DecisionActivations, skipped...)
 			continue
 		}
 		blocked := false
@@ -163,7 +176,11 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 		for _, target := range route.To {
 			trigger := AgentTriggerView{Kind: AgentTriggerDecision, SourceVisitIDs: []string{visit.VisitID}, DecisionKey: decision.Key}
 			if terminal, reached := agentVisitLimitTerminal(context.steps[target], visit.Iteration+1, trigger, context); reached {
-				return AgentPlan{Terminal: terminal}, nil
+				limitPlan := AgentPlan{Terminal: terminal}
+				if len(skipped) != 0 {
+					limitPlan.DecisionActivations = skipped
+				}
+				return markPendingVisitsSkipped(limitPlan, visits), nil
 			}
 		}
 		plan.ApplyDecisionVisitIDs = append(plan.ApplyDecisionVisitIDs, visit.VisitID)
@@ -174,6 +191,7 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 			})
 			projectedActive[target] = true
 		}
+		plan.DecisionActivations = append(plan.DecisionActivations, skipped...)
 	}
 	// After также ждёт decision-wave. Иначе параллельный Running decision мог бы
 	// завершиться между сохранением limit-terminal и drain: повторная проверка
@@ -186,24 +204,32 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 	// один step в одном снимке, явный route получает его первым, а FIFO-источники
 	// after остаются непотреблёнными до следующего вызова.
 	for _, step := range w.Steps {
-		if len(step.After) == 0 || projectedActive[step.ID] {
+		if len(step.After) == 0 {
 			continue
 		}
-		sources, iteration, ready := nextAfterSources(step, context)
+		sources, iteration, allSkipped, ready := nextSkippedAfterSources(step, context)
 		if !ready {
 			continue
 		}
+		if projectedActive[step.ID] && !allSkipped {
+			continue
+		}
 		trigger := AgentTriggerView{Kind: AgentTriggerAfter, SourceVisitIDs: sources}
-		if terminal, reached := agentVisitLimitTerminal(step, iteration, trigger, context); reached {
+		if terminal, reached := agentVisitLimitTerminal(step, iteration, trigger, context); !allSkipped && reached {
 			// Terminal нельзя смешивать с routes/after, уже накопленными выше:
 			// runstore публикует либо весь обычный переход, либо один итог.
-			return AgentPlan{Terminal: terminal}, nil
+			return markPendingVisitsSkipped(AgentPlan{Terminal: terminal}, visits), nil
 		}
-		plan.AfterActivations = append(plan.AfterActivations, AgentActivation{
+		activation := AgentActivation{
 			StepID: step.ID, Iteration: iteration,
 			Trigger: AgentTriggerView{Kind: AgentTriggerAfter, SourceVisitIDs: sources},
-		})
-		projectedActive[step.ID] = true
+		}
+		if allSkipped {
+			activation.InitialState = Skipped
+		} else {
+			projectedActive[step.ID] = true
+		}
+		plan.AfterActivations = append(plan.AfterActivations, activation)
 	}
 
 	if len(plan.ApplyDecisionVisitIDs) != 0 || len(plan.DecisionActivations) != 0 || len(plan.AfterActivations) != 0 {
@@ -215,17 +241,17 @@ func PlanAgentGraph(w workflow.Workflow, visits []AgentVisitView) (AgentPlan, er
 
 	for _, visit := range visits {
 		if visit.State == Failed && !context.advanced[visit.VisitID] {
-			return AgentPlan{Terminal: &AgentTerminal{
+			return markPendingVisitsSkipped(AgentPlan{Terminal: &AgentTerminal{
 				Outcome:      workflow.OutcomeFailed,
 				Reason:       fmt.Sprintf("terminal-посещение %q шага %q завершилось с ошибкой", visit.VisitID, visit.StepID),
 				CauseVisitID: visit.VisitID,
-			}}, nil
+			}}, visits), nil
 		}
 	}
-	return AgentPlan{Terminal: &AgentTerminal{
+	return markPendingVisitsSkipped(AgentPlan{Terminal: &AgentTerminal{
 		Outcome: workflow.OutcomeSucceeded,
 		Reason:  "workflow достиг естественного завершения",
-	}}, nil
+	}}, visits), nil
 }
 
 // agentPlanningContext — проверенные индексы одного снимка. terminalByStep
@@ -456,9 +482,10 @@ func agentDecisionWaveComplete(steps map[string]workflow.Step, visits []AgentVis
 // возвращает её первый terminal-переход в порядке Visits. Обычные routes здесь
 // не материализуются: если visit требует завершения, накопление активаций даже
 // более раннего route безопасно не начинается.
-func firstDecisionTerminal(steps map[string]workflow.Step, visits []AgentVisitView) (AgentPlan, bool) {
+func firstDecisionTerminal(context agentSkippedContext, visits []AgentVisitView) (AgentPlan, bool) {
+	projectedSkipped := cloneAgentSkipReached(context.skipReached)
 	for _, visit := range visits {
-		step := steps[visit.StepID]
+		step := context.steps[visit.StepID]
 		if len(step.Decisions) == 0 {
 			continue
 		}
@@ -471,6 +498,9 @@ func firstDecisionTerminal(steps map[string]workflow.Step, visits []AgentVisitVi
 			outcome := *route.Finish
 			return AgentPlan{
 				ApplyDecisionVisitIDs: []string{visit.VisitID},
+				DecisionActivations: missingDecisionSkippedActivations(
+					step, visit, decision.Key, []string{visit.VisitID}, projectedSkipped,
+				),
 				Terminal: &AgentTerminal{
 					Outcome:      outcome,
 					Reason:       fmt.Sprintf("решение %q шага %q выбрало finish %q", decision.Key, visit.StepID, outcome),
@@ -480,6 +510,18 @@ func firstDecisionTerminal(steps map[string]workflow.Step, visits []AgentVisitVi
 		}
 	}
 	return AgentPlan{}, false
+}
+
+// markPendingVisitsSkipped убирает обещание будущего запуска после глобального
+// terminal outcome. Уже начатые visits завершает coordinator, а Pending можно
+// безопасно закрыть тем же атомарным commit.
+func markPendingVisitsSkipped(plan AgentPlan, visits []AgentVisitView) AgentPlan {
+	for _, visit := range visits {
+		if visit.State == Pending {
+			plan.MarkSkippedVisitIDs = append(plan.MarkSkippedVisitIDs, visit.VisitID)
+		}
+	}
+	return plan
 }
 
 func fatalDecisionPlan(visit AgentVisitView, detail string) AgentPlan {
@@ -519,17 +561,17 @@ func nextAfterSources(step workflow.Step, context agentPlanningContext) ([]strin
 // очередного посещения step и после проверки no-overlap. Поэтому count==limit
 // означает отказ именно от N+1, а CauseVisitID всегда указывает на последний
 // разрешённый visit N. Положительность лимита уже доказана Workflow.Validate.
-func agentVisitLimitTerminal(step workflow.Step, nextIteration int, trigger AgentTriggerView, context agentPlanningContext) (*AgentTerminal, bool) {
+func agentVisitLimitTerminal(step workflow.Step, nextIteration int, trigger AgentTriggerView, context agentSkippedContext) (*AgentTerminal, bool) {
 	if step.MaxVisits == nil || context.visitCount[step.ID] < *step.MaxVisits {
 		return nil, false
 	}
 	last := context.lastVisit[step.ID]
 	outcome := workflow.OutcomeFailed
-	reason := fmt.Sprintf("шаг %q достиг maxVisits=%d; посещение %d с iteration=%d не создано; onLimit не задан, workflow завершён как %q",
+	reason := fmt.Sprintf("шаг %q достиг maxVisits=%d; исполнение №%d с iteration=%d не создано; onLimit не задан, workflow завершён как %q",
 		step.ID, *step.MaxVisits, context.visitCount[step.ID]+1, nextIteration, outcome)
 	if step.OnLimit != nil {
 		outcome = *step.OnLimit
-		reason = fmt.Sprintf("шаг %q достиг maxVisits=%d; посещение %d с iteration=%d не создано; применён onLimit %q",
+		reason = fmt.Sprintf("шаг %q достиг maxVisits=%d; исполнение №%d с iteration=%d не создано; применён onLimit %q",
 			step.ID, *step.MaxVisits, context.visitCount[step.ID]+1, nextIteration, outcome)
 	}
 	trigger.SourceVisitIDs = slices.Clone(trigger.SourceVisitIDs)
@@ -541,7 +583,7 @@ func agentVisitLimitTerminal(step workflow.Step, nextIteration int, trigger Agen
 
 func knownAgentState(state State) bool {
 	switch state {
-	case Pending, Starting, Unknown, Running, WaitingForApproval, Failed, Cancelled, Succeeded:
+	case Pending, Starting, Unknown, Running, WaitingForApproval, Failed, Cancelled, Skipped, Succeeded:
 		return true
 	default:
 		return false
@@ -549,5 +591,5 @@ func knownAgentState(state State) bool {
 }
 
 func agentVisitTerminal(state State) bool {
-	return state == Failed || state == Succeeded
+	return state == Failed || state == Skipped || state == Succeeded
 }

--- a/internal/scheduler/agent_skipped.go
+++ b/internal/scheduler/agent_skipped.go
@@ -100,11 +100,13 @@ type agentSkippedContext struct {
 	steps        map[string]workflow.Step
 	active       map[string]bool
 	visitCount   map[string]int
+	lastVisit    map[string]AgentVisitView
 	visitsByStep map[string][]AgentVisitView
 	usedAfter    map[agentAfterCause]bool
 	decisionUses map[agentDecisionCause]bool
 	skipRoots    map[string][]string
 	skipReached  map[agentSkipCause]bool
+	advanced     map[string]bool
 }
 
 // agentSkipCause ограничивает decision-fanout одной причинной волны. Одинаковый
@@ -123,9 +125,11 @@ func validateAgentSkippedViews(
 ) (agentSkippedContext, error) {
 	context := agentSkippedContext{
 		steps: make(map[string]workflow.Step, len(w.Steps)), active: make(map[string]bool),
-		visitCount: make(map[string]int), visitsByStep: make(map[string][]AgentVisitView),
-		usedAfter: make(map[agentAfterCause]bool), decisionUses: make(map[agentDecisionCause]bool),
+		visitCount: make(map[string]int), lastVisit: make(map[string]AgentVisitView),
+		visitsByStep: make(map[string][]AgentVisitView),
+		usedAfter:    make(map[agentAfterCause]bool), decisionUses: make(map[agentDecisionCause]bool),
 		skipRoots: make(map[string][]string), skipReached: make(map[agentSkipCause]bool),
+		advanced: make(map[string]bool),
 	}
 	for _, step := range w.Steps {
 		context.steps[step.ID] = step
@@ -150,6 +154,7 @@ func validateAgentSkippedViews(
 		// может сосуществовать с выполняющимся visit того же шага.
 		if visit.State != Skipped {
 			context.visitCount[visit.StepID]++
+			context.lastVisit[visit.StepID] = visit
 			if step.MaxVisits != nil && context.visitCount[visit.StepID] > *step.MaxVisits {
 				return agentSkippedContext{}, fmt.Errorf("посещение %q превышает maxVisits=%d шага %q", visit.VisitID, *step.MaxVisits, visit.StepID)
 			}
@@ -215,6 +220,9 @@ func validateAgentSkippedViews(
 		}
 		seen[visit.VisitID] = visit
 		context.visitsByStep[visit.StepID] = append(context.visitsByStep[visit.StepID], visit)
+		for _, sourceID := range visit.Trigger.SourceVisitIDs {
+			context.advanced[sourceID] = true
+		}
 	}
 
 	// Applied — durable-обещание полного перехода. Выбранные runnable targets

--- a/internal/scheduler/agent_skipped_test.go
+++ b/internal/scheduler/agent_skipped_test.go
@@ -251,10 +251,9 @@ func TestPlanAgentSkippedClosureRejectsForgery(t *testing.T) {
 	})
 }
 
-// TestPlanAgentGraphDoesNotProduceSkipped сохраняет границу этого PR: основному
-// producer ещё не поручено материализовывать альтернативы. Новый pure API можно
-// интегрировать отдельно, не меняя поведение уже работающего планировщика.
-func TestPlanAgentGraphDoesNotProduceSkipped(t *testing.T) {
+// TestPlanAgentGraphProducesSkipped проверяет подключение pure-замыкания к
+// обычному producer: выбранный target запускается, а альтернатива не запускается.
+func TestPlanAgentGraphProducesSkipped(t *testing.T) {
 	w := agentWorkflow([]string{"choice"},
 		agentStep("choice", nil, map[string]workflow.Route{
 			"run": {To: []string{"live"}}, "unused": {To: []string{"unused"}},
@@ -264,9 +263,11 @@ func TestPlanAgentGraphDoesNotProduceSkipped(t *testing.T) {
 	plan, err := PlanAgentGraph(w, []AgentVisitView{
 		agentStartVisit("choice-1", "choice", Succeeded, 1, &AgentDecisionView{Key: "run"}),
 	})
-	if err != nil || len(plan.DecisionActivations) != 1 || plan.DecisionActivations[0].StepID != "live" ||
-		plan.DecisionActivations[0].InitialState != "" || plan.DecisionActivations[0].Trigger.Kind != AgentTriggerDecision {
-		t.Fatalf("основной producer неожиданно изменил поведение: %#v, %v", plan, err)
+	if err != nil || len(plan.DecisionActivations) != 2 || plan.DecisionActivations[0].StepID != "live" ||
+		plan.DecisionActivations[0].InitialState != "" || plan.DecisionActivations[0].Trigger.Kind != AgentTriggerDecision ||
+		plan.DecisionActivations[1].StepID != "unused" || plan.DecisionActivations[1].InitialState != Skipped ||
+		plan.DecisionActivations[1].Trigger.Kind != AgentTriggerDecisionSkipped {
+		t.Fatalf("основной producer не разделил выбранную и пропущенную ветки: %#v, %v", plan, err)
 	}
 }
 

--- a/internal/scheduler/agent_test.go
+++ b/internal/scheduler/agent_test.go
@@ -358,8 +358,8 @@ func TestPlanAgentGraphCancelledWaits(t *testing.T) {
 }
 
 // TestPlanAgentGraphNaturalQuiescence проверяет фактический causal frontier, а не
-// все исторические ошибки. Не выбранная половина статического join не блокирует
-// естественный успех, но необработанный Failed-лист завершает run ошибкой.
+// все исторические ошибки. Невыбранная половина сначала получает durable Skipped;
+// необработанный Failed-лист завершает run ошибкой.
 func TestPlanAgentGraphNaturalQuiescence(t *testing.T) {
 	t.Run("stranded join succeeds", func(t *testing.T) {
 		w := agentWorkflow([]string{"choice"},
@@ -375,8 +375,9 @@ func TestPlanAgentGraphNaturalQuiescence(t *testing.T) {
 			agentDecisionVisit("left-1", "left", Succeeded, 2, "choice-1", "left", nil),
 		}
 		got, err := PlanAgentGraph(w, visits)
-		if err != nil || got.Terminal == nil || got.Terminal.Outcome != workflow.OutcomeSucceeded || got.Terminal.CauseVisitID != "" {
-			t.Fatalf("невыбранная ветка заблокировала natural completion: %#v, %v", got, err)
+		if err != nil || got.Terminal != nil || len(got.DecisionActivations) != 1 ||
+			got.DecisionActivations[0].StepID != "right" || got.DecisionActivations[0].InitialState != Skipped {
+			t.Fatalf("невыбранная ветка не получила durable Skipped: %#v, %v", got, err)
 		}
 	})
 
@@ -415,7 +416,7 @@ func TestPlanAgentGraphBoundedSelfLoop(t *testing.T) {
 		got.Terminal.LimitTrigger.Kind != AgentTriggerDecision ||
 		!slices.Equal(got.Terminal.LimitTrigger.SourceVisitIDs, []string{"loop-2"}) ||
 		got.Terminal.LimitTrigger.DecisionKey != "again" || got.Terminal.LimitIteration != 3 ||
-		len(got.ApplyDecisionVisitIDs) != 0 || len(got.DecisionActivations) != 0 || !strings.Contains(got.Terminal.Reason, "посещение 3") {
+		len(got.ApplyDecisionVisitIDs) != 0 || len(got.DecisionActivations) != 0 || !strings.Contains(got.Terminal.Reason, "исполнение №3") {
 		t.Fatalf("граница self-loop не дала атомарный failed: %#v, %v", got, err)
 	}
 


### PR DESCRIPTION
## Результат

- выбранные routes запускаются как раньше, а невыбранные получают durable `skipped`;
- вложенные пропуски и полностью пропущенные `after` замыкаются до одного атомарного сохранения;
- terminal outcome закрывает ещё не запущенные visits без запуска Codex;
- `skipped` не расходует `maxVisits`;
- пустая память каждого synthetic visit создаётся до публикации metadata;
- CLI follow и dashboard корректно учитывают отсутствие executor-события у `skipped`.

## Проверки

- `go test -count=1 ./...`
- `git diff --check`

## Размер

359 добавлений, 94 удаления — 453 изменённые строки.

## Зависимость

Stacked поверх #88.

Part of #50.