### PR TITLE
Покрыть skipped-переходы интеграционными тестами

### DIFF
--- a/internal/runstore/advance_test.go
+++ b/internal/runstore/advance_test.go
@@ -38,11 +38,16 @@ func advanceInput(t *testing.T) Input {
 }`), Task: "Продвинуть граф", Comment: "Тест persistence bridge", CWD: t.TempDir()}
 }
 
-// skippedJoinInput воспроизводит if/else с общим after-join.
+// skippedJoinInput воспроизводит обычный if/else с общим after-join. Выбранная
+// ветка должна запустить агента, невыбранная — создать durable Skipped token,
+// чтобы join не потерял одну половину барьера и не завершил run преждевременно.
 func skippedJoinInput(t *testing.T) Input {
 	t.Helper()
 	return Input{WorkflowJSON: []byte(`{
-  "version":2,"id":"skipped-join","start":["choice"],"steps":[
+  "version":2,
+  "id":"skipped-join",
+  "start":["choice"],
+  "steps":[
     {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
       "left":{"to":["left"]},"right":{"to":["right"]}}},
     {"id":"left","type":"agent","prompt":"Левая ветка","after":[]},
@@ -52,35 +57,106 @@ func skippedJoinInput(t *testing.T) Input {
 }`), Task: "Проверить пропущенную ветку", CWD: t.TempDir()}
 }
 
+// nestedSkippedInput воспроизводит вложенную развилку из замечания ревью.
+// Невыбранный outer-route ведёт не прямо к листу, а к ещё одному decision:
+// такой кубик не должен выбирать бизнес-ключ, но обязан распространить ту же
+// причинную волну сразу по объединению всех своих статических routes.
 func nestedSkippedInput(t *testing.T) Input {
 	t.Helper()
 	return Input{WorkflowJSON: []byte(`{
-  "version":2,"id":"nested-skipped","start":["outer"],"steps":[
-    {"id":"outer","type":"agent","prompt":"Выбери","after":[],"decisions":{
+  "version":2,
+  "id":"nested-skipped",
+  "start":["outer"],
+  "steps":[
+    {"id":"outer","type":"agent","prompt":"Выбери внешнюю ветку","after":[],"decisions":{
       "nested":{"to":["inner"]},"right":{"to":["right"]}}},
-    {"id":"inner","type":"agent","prompt":"Уточни","after":[],"decisions":{
+    {"id":"inner","type":"agent","prompt":"Выбери внутреннюю ветку","after":[],"decisions":{
       "a":{"to":["leaf-a"]},"b":{"to":["leaf-b"]}}},
     {"id":"right","type":"agent","prompt":"Правая ветка","after":[]},
     {"id":"leaf-a","type":"agent","prompt":"Лист A","after":[]},
     {"id":"leaf-b","type":"agent","prompt":"Лист B","after":[]},
     {"id":"join","type":"agent","prompt":"Объедини","after":["right","leaf-a","leaf-b"]}
   ]
-}`), Task: "Проверить вложенную ветку", CWD: t.TempDir()}
+}`), Task: "Проверить вложенную пропущенную ветку", CWD: t.TempDir()}
 }
 
+// terminalNestedSkippedInput отделяет критичную границу explicit finish. После
+// публикации terminal run продвигать нельзя, поэтому весь transitive skip-chain
+// должен получить настоящие visitId и попасть в тот же metadata commit.
 func terminalNestedSkippedInput(t *testing.T) Input {
 	t.Helper()
 	return Input{WorkflowJSON: []byte(`{
-  "version":2,"id":"terminal-nested-skipped","start":["choice"],"steps":[
+  "version":2,
+  "id":"terminal-nested-skipped",
+  "start":["choice"],
+  "steps":[
     {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
       "investigate":{"to":["inner"]},"safe":{"finish":"succeeded"}}},
     {"id":"inner","type":"agent","prompt":"Уточни","after":[],"decisions":{
       "a":{"to":["leaf-a"]},"b":{"to":["leaf-b"]}}},
     {"id":"leaf-a","type":"agent","prompt":"Лист A","after":[]},
     {"id":"leaf-b","type":"agent","prompt":"Лист B","after":[]},
-    {"id":"summary","type":"agent","prompt":"Итог","after":["leaf-a","leaf-b"]}
+    {"id":"summary","type":"agent","prompt":"Собери итог","after":["leaf-a","leaf-b"]}
   ]
-}`), Task: "Проверить terminal skipped", CWD: t.TempDir()}
+}`), Task: "Проверить terminal skipped-замыкание", CWD: t.TempDir()}
+}
+
+// activeSkippedTargetInput моделирует общий target с двумя независимыми
+// причинами. Первый shared уже исполняется как start, а невыбранная ветка
+// решения должна сохранить второй, синтетический instance того же stepId.
+func activeSkippedTargetInput(t *testing.T) Input {
+	t.Helper()
+	return Input{WorkflowJSON: []byte(`{
+  "version":2,
+  "id":"active-skipped-target",
+  "start":["choice","shared"],
+  "steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
+      "selected":{"to":["left"]},"other":{"to":["shared"]}}},
+    {"id":"shared","type":"agent","prompt":"Уже выполняется","after":[]},
+    {"id":"left","type":"agent","prompt":"Выбранная ветка","after":[]},
+    {"id":"tail","type":"agent","prompt":"Продолжи shared","after":["shared"]}
+  ]
+}`), Task: "Проверить active и skipped общего target", CWD: t.TempDir()}
+}
+
+// terminalSharedFIFOInput сочетает global finish с двумя instances одного
+// logical step. Более ранний start shared может быть Pending/Running, а
+// невыбранный route создаёт поздний causal Skipped. Terminal closure обязан
+// провести именно причинный instance через tail.after, не запуская tail.
+func terminalSharedFIFOInput(t *testing.T) Input {
+	t.Helper()
+	return Input{WorkflowJSON: []byte(`{
+  "version":2,
+  "id":"terminal-shared-fifo",
+  "start":["choice","shared"],
+  "steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
+      "branch":{"to":["shared"]},"safe":{"finish":"succeeded"}}},
+    {"id":"shared","type":"agent","prompt":"Общий шаг","after":[]},
+    {"id":"tail","type":"agent","prompt":"Хвост","after":["shared"]}
+  ]
+}`), Task: "Проверить terminal FIFO для skipped", CWD: t.TempDir()}
+}
+
+// skippedQuotaInput создаёт один пропущенный и два выбранных instances общего
+// target. maxVisits=1 должен разрешить первый реальный запуск независимо от его
+// порядкового visit=2, а следующую попытку завершить по квоте с причиной в нём.
+func skippedQuotaInput(t *testing.T) Input {
+	t.Helper()
+	return Input{WorkflowJSON: []byte(`{
+  "version":2,
+  "id":"skipped-quota",
+  "start":["first","second","third"],
+  "steps":[
+    {"id":"first","type":"agent","prompt":"Первая развилка","after":[],"decisions":{
+      "other":{"to":["other"]},"shared":{"to":["shared"]}}},
+    {"id":"second","type":"agent","prompt":"Первый запуск","after":[],"decisions":{"go":{"to":["shared"]}}},
+    {"id":"third","type":"agent","prompt":"Лишний запуск","after":[],"decisions":{"go":{"to":["shared"]}}},
+    {"id":"other","type":"agent","prompt":"Другая ветка","after":[]},
+    {"id":"shared","type":"agent","prompt":"Общая ветка","after":[],"maxVisits":1}
+  ]
+}`), Task: "Проверить квоту после skipped", CWD: t.TempDir()}
 }
 
 // boundedLoopInput оставляет параллельный Pending visit, чтобы остановка по
@@ -312,8 +388,9 @@ func TestAdvanceAgentGraphRouteAndAfter(t *testing.T) {
 }
 
 // TestAdvanceAgentGraphPersistsSkippedBranchAndUnblocksJoin проверяет всю
-// persistence-цепочку if/else: невыбранная ветка не запускается, но остаётся
-// terminal-причиной для общего join.
+// persistence-цепочку if/else. Skipped получает собственные ID, trigger и пустую
+// память, но не запускается; смешанный Succeeded/Skipped barrier создаёт обычный
+// Pending join с точными причинными visitId.
 func TestAdvanceAgentGraphPersistsSkippedBranchAndUnblocksJoin(t *testing.T) {
 	root := t.TempDir()
 	initial, err := Create(root, skippedJoinInput(t))
@@ -333,26 +410,359 @@ func TestAdvanceAgentGraphPersistsSkippedBranchAndUnblocksJoin(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !advanced.Changed || len(advanced.CreatedVisits) != 2 || !advanced.Snapshot.Meta.Visits[0].Decision.Applied {
-		t.Fatalf("выбор и branch-записи не опубликованы одним переходом: %+v", advanced)
+		t.Fatalf("выбор и обе branch-записи не опубликованы одним переходом: %+v", advanced)
 	}
 	left, right := advanced.CreatedVisits[0], advanced.CreatedVisits[1]
-	if left.StepID != "left" || left.State != scheduler.Pending ||
-		right.StepID != "right" || right.State != scheduler.Skipped || right.Trigger.Kind != TriggerDecisionSkipped {
-		t.Fatalf("ветки получили неверные состояния: left=%+v right=%+v", left, right)
+	if left.StepID != "left" || left.State != scheduler.Pending || left.Trigger.Kind != TriggerDecision ||
+		right.StepID != "right" || right.State != scheduler.Skipped || right.Trigger.Kind != TriggerDecisionSkipped ||
+		right.Trigger.DecisionKey != "right" || !slices.Equal(right.Trigger.SourceVisitIDs, []string{choiceID}) {
+		t.Fatalf("ветки получили неверные состояния или причины: left=%+v right=%+v", left, right)
 	}
-	if info, statErr := os.Stat(filepath.Join(root, initial.Meta.RunID, "memory", right.VisitID+".md")); statErr != nil || info.Size() != 0 {
+	if info, statErr := os.Stat(filepath.Join(root, initial.Meta.RunID, "memory", right.VisitID+".md")); statErr != nil || !info.Mode().IsRegular() || info.Size() != 0 {
 		t.Fatalf("Skipped visit не получил пустую durable-память: info=%v err=%v", info, statErr)
+	}
+	if err = run.ReserveVisits([]string{right.VisitID}); err == nil {
+		t.Fatal("Skipped visit принят для запуска Codex")
 	}
 
 	finishPlainVisit(t, run, left.VisitID)
 	joined, err := run.AdvanceAgentGraph()
-	if err != nil || len(joined.CreatedVisits) != 1 {
-		t.Fatalf("смешанный barrier не создал join: %+v, %v", joined, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(joined.CreatedVisits) != 1 {
+		t.Fatalf("смешанный barrier не создал ровно один join: %+v", joined)
 	}
 	join := joined.CreatedVisits[0]
-	if join.StepID != "join" || join.State != scheduler.Pending ||
+	if join.StepID != "join" || join.State != scheduler.Pending || join.Trigger.Kind != TriggerAfter ||
 		!slices.Equal(join.Trigger.SourceVisitIDs, []string{left.VisitID, right.VisitID}) {
 		t.Fatalf("join потерял выполненную или пропущенную причину: %+v", join)
+	}
+}
+
+// TestAdvanceAgentGraphPropagatesNestedSkippedBranch проверяет пользовательский
+// сценарий из ревью целиком. После выбора right внутренний decision и оба его
+// возможных листа становятся Skipped без запуска; реальная правая ветка затем
+// вместе с этими причинными tokens открывает обычный смешанный join.
+func TestAdvanceAgentGraphPropagatesNestedSkippedBranch(t *testing.T) {
+	root := t.TempDir()
+	initial, err := Create(root, nestedSkippedInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+
+	outerID := initial.Meta.Visits[0].VisitID
+	finishDecisionVisit(t, run, outerID, "right")
+	first, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := make(map[string]Visit, len(first.CreatedVisits))
+	for _, visit := range first.CreatedVisits {
+		created[visit.StepID] = visit
+	}
+	if len(first.CreatedVisits) != 4 || created["right"].State != scheduler.Pending ||
+		created["inner"].State != scheduler.Skipped || created["leaf-a"].State != scheduler.Skipped ||
+		created["leaf-b"].State != scheduler.Skipped {
+		t.Fatalf("вложенная skipped-ветка материализована не полностью: %+v", first.CreatedVisits)
+	}
+	inner := created["inner"]
+	if inner.Trigger.Kind != TriggerDecisionSkipped || !slices.Equal(inner.Trigger.SourceVisitIDs, []string{outerID}) ||
+		created["leaf-a"].Trigger.Kind != TriggerDecisionSkipped ||
+		!slices.Equal(created["leaf-a"].Trigger.SourceVisitIDs, []string{inner.VisitID}) ||
+		!slices.Equal(created["leaf-b"].Trigger.SourceVisitIDs, []string{inner.VisitID}) {
+		t.Fatalf("вложенная ветка потеряла immediate causal links: %+v", first.CreatedVisits)
+	}
+
+	finishPlainVisit(t, run, created["right"].VisitID)
+	joined, err := run.AdvanceAgentGraph()
+	if err != nil || len(joined.CreatedVisits) != 1 {
+		t.Fatalf("смешанный join не открылся: %+v, %v", joined, err)
+	}
+	join := joined.CreatedVisits[0]
+	if join.StepID != "join" || join.State != scheduler.Pending || join.Trigger.Kind != TriggerAfter ||
+		!slices.Equal(join.Trigger.SourceVisitIDs, []string{
+			created["right"].VisitID, created["leaf-a"].VisitID, created["leaf-b"].VisitID,
+		}) {
+		t.Fatalf("join не сохранил real/skipped sources: %+v", join)
+	}
+	finishPlainVisit(t, run, join.VisitID)
+	finished, err := run.AdvanceAgentGraph()
+	if err != nil || finished.Snapshot.Meta.RunState != RunSucceeded || finished.Plan.Terminal == nil {
+		t.Fatalf("граф не достиг естественного успеха после join: %+v, %v", finished, err)
+	}
+}
+
+// TestAdvanceAgentGraphClosesSkippedBranchBeforeFinish доказывает атомарность
+// terminal boundary. Даже если choice немедленно выбрал finish, runstore сначала
+// выдаёт настоящие visitId всей вложенной skipped-цепочке и лишь потом публикует
+// RunSucceeded; отдельного post-terminal Advance для ремонта не требуется.
+func TestAdvanceAgentGraphClosesSkippedBranchBeforeFinish(t *testing.T) {
+	root := t.TempDir()
+	initial, err := Create(root, terminalNestedSkippedInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+
+	choiceID := initial.Meta.Visits[0].VisitID
+	finishDecisionVisit(t, run, choiceID, "safe")
+	result, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Snapshot.Meta.RunState != RunSucceeded || result.Snapshot.Meta.StopVisitID != choiceID ||
+		result.Plan.Terminal == nil || len(result.CreatedVisits) != 4 {
+		t.Fatalf("finish опубликован до полного skipped-замыкания: %+v", result)
+	}
+	created := make(map[string]Visit, len(result.CreatedVisits))
+	for _, visit := range result.CreatedVisits {
+		created[visit.StepID] = visit
+		if visit.State != scheduler.Skipped || visit.CodexThreadID != "" || visit.TurnID != "" || visit.Attempt != 0 {
+			t.Fatalf("terminal closure попытался выполнить пропущенный visit: %+v", visit)
+		}
+		info, statErr := os.Stat(filepath.Join(root, initial.Meta.RunID, "memory", visit.VisitID+".md"))
+		if statErr != nil || !info.Mode().IsRegular() || info.Size() != 0 {
+			t.Fatalf("пропущенный visit не получил пустую durable-память: %v, %v", info, statErr)
+		}
+	}
+	inner, leafA, leafB, summary := created["inner"], created["leaf-a"], created["leaf-b"], created["summary"]
+	if inner.VisitID == "" || leafA.VisitID == "" || leafB.VisitID == "" || summary.VisitID == "" ||
+		!slices.Equal(inner.Trigger.SourceVisitIDs, []string{choiceID}) ||
+		!slices.Equal(leafA.Trigger.SourceVisitIDs, []string{inner.VisitID}) ||
+		!slices.Equal(leafB.Trigger.SourceVisitIDs, []string{inner.VisitID}) ||
+		summary.Trigger.Kind != TriggerAfter || !slices.Equal(summary.Trigger.SourceVisitIDs, []string{leafA.VisitID, leafB.VisitID}) {
+		t.Fatalf("terminal closure потерял причинную цепочку: %+v", result.CreatedVisits)
+	}
+	if reloaded, loadErr := Load(root, initial.Meta.RunID); loadErr != nil || !reflect.DeepEqual(reloaded.Meta, result.Snapshot.Meta) {
+		t.Fatalf("полное terminal-замыкание не прошло повторную валидацию: %+v, %v", reloaded.Meta, loadErr)
+	}
+}
+
+// TestAdvanceAgentGraphTerminalClosureCrossesSharedFIFO проверяет два способа,
+// которыми ранний instance общего step раньше блокировал causal Skipped навсегда.
+// Pending превращается в rootless cleanup и должен оставить отдельную
+// after-квитанцию; Running нельзя подменить, поэтому terminal closure устойчиво
+// обходит его и связывает tail с поздним causal source. В обоих случаях весь
+// результат публикуется тем же commit, что и finish.
+func TestAdvanceAgentGraphTerminalClosureCrossesSharedFIFO(t *testing.T) {
+	for _, variant := range []struct {
+		name        string
+		runShared   bool
+		wantTailNum int
+	}{
+		{name: "pending cleanup receipt", wantTailNum: 2},
+		{name: "running source is abandoned", runShared: true, wantTailNum: 1},
+	} {
+		t.Run(variant.name, func(t *testing.T) {
+			root := t.TempDir()
+			initial, err := Create(root, terminalSharedFIFOInput(t))
+			if err != nil {
+				t.Fatal(err)
+			}
+			run, err := OpenLocked(root, initial.Meta.RunID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer run.Close()
+
+			choiceID, sharedID := initial.Meta.Visits[0].VisitID, initial.Meta.Visits[1].VisitID
+			sharedChat := ""
+			if variant.runShared {
+				sharedChat = runDecisionlessVisit(t, run, sharedID)
+			}
+			finishDecisionVisit(t, run, choiceID, "safe")
+			result, err := run.AdvanceAgentGraph()
+			if err != nil || result.Snapshot.Meta.RunState != RunSucceeded {
+				t.Fatalf("terminal closure не опубликован: %+v, %v", result, err)
+			}
+
+			var causalShared Visit
+			var tails []Visit
+			for _, visit := range result.CreatedVisits {
+				switch visit.StepID {
+				case "shared":
+					causalShared = visit
+				case "tail":
+					tails = append(tails, visit)
+				}
+				if visit.State != scheduler.Skipped {
+					t.Fatalf("terminal closure попытался запустить visit: %+v", visit)
+				}
+			}
+			if causalShared.Trigger.Kind != TriggerDecisionSkipped ||
+				!slices.Equal(causalShared.Trigger.SourceVisitIDs, []string{choiceID}) || len(tails) != variant.wantTailNum {
+				t.Fatalf("causal shared или tail-получатели потеряны: %+v", result.CreatedVisits)
+			}
+			causalTail := tails[len(tails)-1]
+			if causalTail.Trigger.Kind != TriggerAfter ||
+				!slices.Equal(causalTail.Trigger.SourceVisitIDs, []string{causalShared.VisitID}) {
+				t.Fatalf("последний tail не продолжил causal source: %+v", tails)
+			}
+			if !variant.runShared && !slices.Equal(tails[0].Trigger.SourceVisitIDs, []string{sharedID}) {
+				t.Fatalf("cleanup source не оставил первую FIFO-квитанцию: %+v", tails)
+			}
+			if variant.runShared {
+				if err = run.UpdateVisit(sharedID, scheduler.Cancelled, sharedChat, "run уже завершён"); err != nil {
+					t.Fatalf("terminal drain активного source сломал bypass-инвариант: %v", err)
+				}
+				if _, err = run.Load(); err != nil {
+					t.Fatalf("terminal snapshot не читается после drain: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestAdvanceAgentGraphPersistsSkippedBesideActiveTarget проверяет liveness
+// общей ноды. Синтетический Skipped не запускает executor и потому не обязан
+// ждать завершения уже активного visit того же шага; весь decision transition
+// сохраняется сразу и остаётся валидным после повторного чтения metadata.
+func TestAdvanceAgentGraphPersistsSkippedBesideActiveTarget(t *testing.T) {
+	root := t.TempDir()
+	initial, err := Create(root, activeSkippedTargetInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+
+	choiceID, sharedID := initial.Meta.Visits[0].VisitID, initial.Meta.Visits[1].VisitID
+	sharedChat := runDecisionlessVisit(t, run, sharedID)
+	finishDecisionVisit(t, run, choiceID, "selected")
+	advanced, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !advanced.Changed || !advanced.Snapshot.Meta.Visits[0].Decision.Applied || len(advanced.CreatedVisits) != 2 {
+		t.Fatalf("активный общий target заблокировал decision transition: %+v", advanced)
+	}
+	left, skippedShared := advanced.CreatedVisits[0], advanced.CreatedVisits[1]
+	if left.StepID != "left" || left.State != scheduler.Pending ||
+		skippedShared.StepID != "shared" || skippedShared.Visit != 2 || skippedShared.State != scheduler.Skipped ||
+		skippedShared.Trigger.Kind != TriggerDecisionSkipped || !slices.Equal(skippedShared.Trigger.SourceVisitIDs, []string{choiceID}) {
+		t.Fatalf("selected и skipped instances сохранены неверно: left=%+v shared=%+v", left, skippedShared)
+	}
+	reloaded, err := run.Load()
+	if err != nil || reloaded.Meta.Visits[1].State != scheduler.Running || reloaded.Meta.Visits[3].State != scheduler.Skipped {
+		t.Fatalf("Running и Skipped одного stepId не пережили валидацию: %+v, %v", reloaded.Meta.Visits, err)
+	}
+
+	// Завершение более раннего real visit не должно ретроактивно сломать FIFO.
+	// Первый tail потребляет его, затем skip-only closure тем же commit забирает
+	// следующий Skipped-source. Оба instances упорядочены, а второй не ждёт
+	// исполнения первого, потому что сам не занимает executor.
+	if err = run.UpdateVisit(sharedID, scheduler.Succeeded, sharedChat, ""); err != nil {
+		t.Fatalf("завершение real visit после Skipped повредило историю: %v", err)
+	}
+	firstTail, err := run.AdvanceAgentGraph()
+	if err != nil || len(firstTail.CreatedVisits) != 2 || firstTail.CreatedVisits[0].StepID != "tail" ||
+		firstTail.CreatedVisits[0].State != scheduler.Pending || !slices.Equal(firstTail.CreatedVisits[0].Trigger.SourceVisitIDs, []string{sharedID}) ||
+		firstTail.CreatedVisits[1].StepID != "tail" || firstTail.CreatedVisits[1].State != scheduler.Skipped ||
+		!slices.Equal(firstTail.CreatedVisits[1].Trigger.SourceVisitIDs, []string{skippedShared.VisitID}) {
+		t.Fatalf("FIFO не отдал ранний real visit первым: %+v, %v", firstTail, err)
+	}
+}
+
+// TestAdvanceAgentGraphTerminalMarksPendingAndBranchesSkipped фиксирует один
+// атомарный terminal commit: ещё не запущенный start и цели невыбранного route
+// становятся Skipped, а внешний callback не может изготовить такой статус сам.
+func TestAdvanceAgentGraphTerminalMarksPendingAndBranchesSkipped(t *testing.T) {
+	root, initial, run := testAdvanceRun(t)
+	choiceID, parallelID := initial.Meta.Visits[0].VisitID, initial.Meta.Visits[1].VisitID
+	finishDecisionVisit(t, run, choiceID, "done")
+
+	result, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Snapshot.Meta.RunState != RunSucceeded || result.Snapshot.Meta.Visits[1].State != scheduler.Skipped ||
+		len(result.CreatedVisits) != 3 {
+		t.Fatalf("terminal не закрыл Pending и невыбранный fanout: %+v", result)
+	}
+	for _, visit := range result.Snapshot.Meta.Visits {
+		if visit.State == scheduler.Pending {
+			t.Fatalf("terminal snapshot оставил Pending visit: %+v", visit)
+		}
+	}
+	for _, visit := range result.CreatedVisits {
+		if visit.State != scheduler.Skipped {
+			t.Fatalf("невыбранная ветка не сохранена как synthetic Skipped: %+v", visit)
+		}
+		if visit.StepID == "join" {
+			if visit.Trigger.Kind != TriggerAfter || len(visit.Trigger.SourceVisitIDs) != 2 {
+				t.Fatalf("terminal closure не распространил skipped через join: %+v", visit)
+			}
+		} else if visit.Trigger.Kind != TriggerDecisionSkipped || !slices.Equal(visit.Trigger.SourceVisitIDs, []string{choiceID}) {
+			t.Fatalf("невыбранный route потерял решение-источник: %+v", visit)
+		}
+		if info, statErr := os.Stat(filepath.Join(root, initial.Meta.RunID, "memory", visit.VisitID+".md")); statErr != nil || !info.Mode().IsRegular() {
+			t.Fatalf("нет памяти synthetic Skipped %q: %v", visit.VisitID, statErr)
+		}
+	}
+	if err = run.UpdateVisit(parallelID, scheduler.Skipped, "", ""); err == nil {
+		t.Fatal("UpdateVisit позволил внешнему коду изготовить Skipped")
+	}
+}
+
+// TestAdvanceAgentGraphSkippedDoesNotConsumeMaxVisits связывает два счётчика:
+// Visit остаётся монотонным номером всей истории, а maxVisits учитывает только
+// записи, которые действительно могли создать Codex turn.
+func TestAdvanceAgentGraphSkippedDoesNotConsumeMaxVisits(t *testing.T) {
+	root := t.TempDir()
+	initial, err := Create(root, skippedQuotaInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+
+	finishDecisionVisit(t, run, initial.Meta.Visits[0].VisitID, "other")
+	finishDecisionVisit(t, run, initial.Meta.Visits[1].VisitID, "go")
+	finishDecisionVisit(t, run, initial.Meta.Visits[2].VisitID, "go")
+	first, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var skipped, runnable Visit
+	for _, visit := range first.CreatedVisits {
+		if visit.StepID != "shared" {
+			continue
+		}
+		if visit.State == scheduler.Skipped {
+			skipped = visit
+		} else {
+			runnable = visit
+		}
+	}
+	if skipped.Visit != 1 || runnable.Visit != 2 || runnable.State != scheduler.Pending {
+		t.Fatalf("Skipped съел квоту или нарушил нумерацию: skipped=%+v runnable=%+v", skipped, runnable)
+	}
+	finishPlainVisit(t, run, runnable.VisitID)
+
+	limited, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if limited.Snapshot.Meta.RunState != RunFailed || limited.Snapshot.Meta.StopLimitStepID != "shared" ||
+		limited.Snapshot.Meta.StopVisitID != runnable.VisitID || limited.Snapshot.Meta.StopLimitIteration != 2 ||
+		!strings.Contains(limited.Snapshot.Meta.StopReason, "исполнение №2") {
+		t.Fatalf("limit не сослался на единственный runnable visit: %+v", limited)
 	}
 }
 
@@ -388,8 +798,10 @@ func TestAdvanceAgentGraphFinishWithActiveVisit(t *testing.T) {
 		t.Fatalf("finish опубликован неатомарно: %+v", result)
 	}
 	for _, visit := range result.CreatedVisits {
-		if visit.State != scheduler.Skipped {
-			t.Fatalf("finish не сохранил пропущенную ветку: %+v", visit)
+		if visit.State != scheduler.Skipped ||
+			visit.StepID == "join" && visit.Trigger.Kind != TriggerAfter ||
+			visit.StepID != "join" && visit.Trigger.Kind != TriggerDecisionSkipped {
+			t.Fatalf("finish не сохранил невыбранную ветку: %+v", visit)
 		}
 	}
 	if _, err := run.AdvanceAgentGraph(); err == nil {
@@ -507,6 +919,167 @@ func TestAdvanceAgentGraphMemoryBeforeMetadata(t *testing.T) {
 	}
 }
 
+// TestAdvanceAgentGraphSkippedSurvivesCrashAndReopen проверяет новую часть той
+// же durability-границы: если запись meta оборвалась после пустых файлов памяти,
+// reopen повторно строит ровно один synthetic Skipped с новым ID, а orphan-файл
+// не становится частью причинной истории.
+func TestAdvanceAgentGraphSkippedSurvivesCrashAndReopen(t *testing.T) {
+	root := t.TempDir()
+	initial, err := Create(root, skippedJoinInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finishDecisionVisit(t, run, initial.Meta.Visits[0].VisitID, "left")
+	memoryDir := filepath.Join(root, initial.Meta.RunID, "memory")
+	memoriesReady := false
+	result, err := run.advanceAgentGraph(func(file *os.File) error {
+		info, statErr := file.Stat()
+		if statErr != nil {
+			return statErr
+		}
+		if !info.IsDir() && info.Size() > 0 {
+			entries, readErr := os.ReadDir(memoryDir)
+			memoriesReady = readErr == nil && len(entries) == 3
+			return syscall.EIO
+		}
+		return file.Sync()
+	})
+	if !errors.Is(err, syscall.EIO) || !memoriesReady || !reflect.DeepEqual(result, AgentAdvance{}) {
+		t.Fatalf("не воспроизведена crash-граница skipped: %+v, %v", result, err)
+	}
+	onDisk, err := Load(root, initial.Meta.RunID)
+	if err != nil || len(onDisk.Meta.Visits) != 1 || onDisk.Meta.Visits[0].Decision.Applied {
+		t.Fatalf("отказ частично опубликовал skipped-переход: %+v, %v", onDisk.Meta, err)
+	}
+	if err = run.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	result, err = reopened.AdvanceAgentGraph()
+	if err != nil || len(result.CreatedVisits) != 2 || result.CreatedVisits[1].State != scheduler.Skipped {
+		t.Fatalf("reopen не восстановил selected/skipped пару: %+v, %v", result, err)
+	}
+	entries, err := os.ReadDir(memoryDir)
+	if err != nil || len(entries) != 5 {
+		t.Fatalf("orphan skipped-memory потеряна или стала достижимой: %v, %v", entries, err)
+	}
+}
+
+// TestAdvanceAgentGraphTerminalSkippedClosureSurvivesCrash проверяет новую
+// многоуровневую часть той же durability-границы. Все memory-файлы closure
+// создаются до одного Rename meta; сбой оставляет только недостижимые orphan,
+// а reopen заново строит полную цепочку с новыми ID без частичного terminal.
+func TestAdvanceAgentGraphTerminalSkippedClosureSurvivesCrash(t *testing.T) {
+	root := t.TempDir()
+	initial, err := Create(root, terminalNestedSkippedInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finishDecisionVisit(t, run, initial.Meta.Visits[0].VisitID, "safe")
+	memoryDir := filepath.Join(root, initial.Meta.RunID, "memory")
+	memoriesReady := false
+	result, err := run.advanceAgentGraph(func(file *os.File) error {
+		info, statErr := file.Stat()
+		if statErr != nil {
+			return statErr
+		}
+		if !info.IsDir() && info.Size() > 0 {
+			entries, readErr := os.ReadDir(memoryDir)
+			memoriesReady = readErr == nil && len(entries) == 5
+			return syscall.EIO
+		}
+		return file.Sync()
+	})
+	if !errors.Is(err, syscall.EIO) || !memoriesReady || !reflect.DeepEqual(result, AgentAdvance{}) {
+		t.Fatalf("не воспроизведён crash после skipped-замыкания: %+v, %v", result, err)
+	}
+	onDisk, err := Load(root, initial.Meta.RunID)
+	if err != nil || onDisk.Meta.RunState != RunRunning || onDisk.Meta.Visits[0].Decision.Applied || len(onDisk.Meta.Visits) != 1 {
+		t.Fatalf("сбой частично опубликовал terminal closure: %+v, %v", onDisk.Meta, err)
+	}
+	if err = run.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	result, err = reopened.AdvanceAgentGraph()
+	if err != nil || result.Snapshot.Meta.RunState != RunSucceeded || len(result.CreatedVisits) != 4 || len(result.Snapshot.Meta.Visits) != 5 {
+		t.Fatalf("reopen не пересобрал terminal closure целиком: %+v, %v", result, err)
+	}
+	entries, err := os.ReadDir(memoryDir)
+	if err != nil || len(entries) != 9 {
+		t.Fatalf("orphan closure-memory потеряна или попала в metadata: %v, %v", entries, err)
+	}
+}
+
+// TestAdvanceAgentGraphBackfillsOldAppliedDecision имитирует running v4,
+// сохранённый прежней версией: выбранный target уже материализован и Applied,
+// но synthetic Skipped ещё отсутствует. Новый planner достраивает только
+// безопасный terminal token и не повторяет реальную работу.
+func TestAdvanceAgentGraphBackfillsOldAppliedDecision(t *testing.T) {
+	root := t.TempDir()
+	initial, err := Create(root, skippedJoinInput(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+	choiceID := initial.Meta.Visits[0].VisitID
+	finishDecisionVisit(t, run, choiceID, "left")
+	leftID := newID()
+	if err = os.WriteFile(filepath.Join(root, initial.Meta.RunID, "memory", leftID+".md"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err = run.mutateVisits((*os.File).Sync, func(snapshot *Snapshot) (bool, error) {
+		snapshot.Meta.Visits[0].Decision.Applied = true
+		snapshot.Meta.Visits = append(snapshot.Meta.Visits, Visit{
+			VisitID: leftID, StepID: "left", Visit: 1, Iteration: 2, State: scheduler.Pending,
+			Trigger: VisitTrigger{Kind: TriggerDecision, SourceVisitIDs: []string{choiceID}, DecisionKey: "left"},
+		})
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.CreatedVisits) != 1 || result.CreatedVisits[0].StepID != "right" ||
+		result.CreatedVisits[0].State != scheduler.Skipped || len(result.Snapshot.Meta.Visits) != 3 {
+		t.Fatalf("старое Applied-решение не получило точный backfill: %+v", result)
+	}
+	leftCount := 0
+	for _, visit := range result.Snapshot.Meta.Visits {
+		if visit.StepID == "left" {
+			leftCount++
+		}
+	}
+	if leftCount != 1 {
+		t.Fatalf("backfill повторил выбранную работу: %+v", result.Snapshot.Meta.Visits)
+	}
+}
+
 // TestAdvanceAgentGraphBoundedLoop проверяет durable-границу квоты. Ошибка Sync
 // до Rename не публикует частичный terminal, а reopen детерминированно строит тот
 // же StopVisitID/StopLimitStepID без третьего visit и без Applied у решения.
@@ -596,6 +1169,127 @@ func TestAdvanceAgentGraphBoundedLoop(t *testing.T) {
 			t.Fatalf("onLimit не завершил run при активной параллельной ветке: %+v, %v", result, err)
 		}
 	})
+}
+
+// TestAdvanceAgentGraphLimitKeepsUnselectedSkipped фиксирует связь onLimit с
+// новой семантикой веток. Выбранный target N+1 не создаётся и решение остаётся
+// unapplied, но известная невыбранная альтернатива всё равно обязана получить
+// causal Skipped в том же terminal commit и пройти повторную Load-валидацию.
+func TestAdvanceAgentGraphLimitKeepsUnselectedSkipped(t *testing.T) {
+	root := t.TempDir()
+	initial, err := Create(root, Input{WorkflowJSON: []byte(`{
+  "version":2,
+  "id":"limit-keeps-skipped",
+  "start":["choice","limited"],
+  "steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
+      "go":{"to":["limited"]},"other":{"to":["unused-a","unused-b"]}}},
+    {"id":"limited","type":"agent","prompt":"Лимит","after":[],"maxVisits":1},
+    {"id":"unused-a","type":"agent","prompt":"Не выбран A","after":[]},
+    {"id":"unused-b","type":"agent","prompt":"Не выбран B","after":[]}
+  ]
+}`), Task: "Проверить skipped при maxVisits", CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+
+	choiceID := initial.Meta.Visits[0].VisitID
+	finishPlainVisit(t, run, initial.Meta.Visits[1].VisitID)
+	finishDecisionVisit(t, run, choiceID, "go")
+	result, err := run.AdvanceAgentGraph()
+	if err != nil || result.Snapshot.Meta.RunState != RunFailed || result.Snapshot.Meta.StopLimitStepID != "limited" ||
+		len(result.CreatedVisits) != 2 ||
+		result.Snapshot.Meta.Visits[0].Decision.Applied {
+		t.Fatalf("onLimit потерял невыбранную ветку или применил route: %+v, %v", result, err)
+	}
+	createdTargets := make(map[string]bool, len(result.CreatedVisits))
+	for _, visit := range result.CreatedVisits {
+		createdTargets[visit.StepID] = true
+		if visit.State != scheduler.Skipped || visit.Trigger.Kind != TriggerDecisionSkipped ||
+			!slices.Equal(visit.Trigger.SourceVisitIDs, []string{choiceID}) {
+			t.Fatalf("decision-limit создал неверную skipped-альтернативу: %+v", visit)
+		}
+	}
+	if !createdTargets["unused-a"] || !createdTargets["unused-b"] {
+		t.Fatalf("decision-limit потерял один из skipped targets: %+v", result.CreatedVisits)
+	}
+	if reloaded, loadErr := run.Load(); loadErr != nil || !reflect.DeepEqual(reloaded.Meta, result.Snapshot.Meta) {
+		t.Fatalf("limit snapshot со skipped не прошёл Load: %+v, %v", reloaded.Meta, loadErr)
+	}
+	damaged := cloneSnapshotMetadata(t, result.Snapshot)
+	for index, visit := range damaged.Meta.Visits {
+		if visit.StepID == "unused-b" {
+			damaged.Meta.Visits = slices.Delete(damaged.Meta.Visits, index, index+1)
+			break
+		}
+	}
+	if err := damaged.validate(damaged.Meta.RunID); err == nil || !strings.Contains(err.Error(), "неполное skipped-замыкание") {
+		t.Fatalf("decision-limit terminal принял удалённую skipped-альтернативу: %v", err)
+	}
+}
+
+// TestAdvanceAgentGraphAfterLimitDoesNotReuseFIFO фиксирует атомарность между
+// виртуальной N+1 after-активацией и terminal skipped-замыканием. Источник b
+// уже входит в StopLimitTrigger вместе с ранним real a; более поздний causal a
+// не вправе повторно соединиться с тем же b и создать Skipped-квитанцию
+// ограниченного шага после опубликованного outcome.
+func TestAdvanceAgentGraphAfterLimitDoesNotReuseFIFO(t *testing.T) {
+	root := t.TempDir()
+	initial, err := Create(root, Input{WorkflowJSON: []byte(`{
+  "version":2,"id":"after-limit-fifo","start":["choice","a","limited"],"steps":[
+    {"id":"choice","type":"agent","prompt":"Выбери","after":[],"decisions":{
+      "main":{"to":["worker"]},"skipped":{"to":["a","b"]}}},
+    {"id":"a","type":"agent","prompt":"Источник A","after":[]},
+    {"id":"limited","type":"agent","prompt":"Лимит","after":["a","b"],"maxVisits":1},
+    {"id":"worker","type":"agent","prompt":"Работа","after":[]},
+    {"id":"b","type":"agent","prompt":"Источник B","after":[]}
+  ]
+}`), Task: "Проверить FIFO after-limit", CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+	finishDecisionVisit(t, run, initial.Meta.Visits[0].VisitID, "main")
+	finishPlainVisit(t, run, initial.Meta.Visits[1].VisitID)
+	finishPlainVisit(t, run, initial.Meta.Visits[2].VisitID)
+
+	first, err := run.AdvanceAgentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	workerID, skippedBID := "", ""
+	for _, visit := range first.CreatedVisits {
+		switch visit.StepID {
+		case "worker":
+			workerID = visit.VisitID
+		case "b":
+			skippedBID = visit.VisitID
+		}
+	}
+	if workerID == "" || skippedBID == "" {
+		t.Fatalf("fixture не создала selected и skipped branches: %+v", first.CreatedVisits)
+	}
+	finishPlainVisit(t, run, workerID)
+
+	limited, err := run.AdvanceAgentGraph()
+	if err != nil || limited.Snapshot.Meta.RunState != RunFailed || limited.Snapshot.Meta.StopLimitStepID != "limited" ||
+		limited.Snapshot.Meta.StopLimitTrigger == nil ||
+		!slices.Equal(limited.Snapshot.Meta.StopLimitTrigger.SourceVisitIDs, []string{initial.Meta.Visits[1].VisitID, skippedBID}) ||
+		len(limited.CreatedVisits) != 0 {
+		t.Fatalf("after-limit повторно использовал FIFO source в closure: %+v, %v", limited, err)
+	}
+	if reloaded, loadErr := run.Load(); loadErr != nil || !reflect.DeepEqual(reloaded.Meta, limited.Snapshot.Meta) {
+		t.Fatalf("сохранённый after-limit не прошёл повторный Load: %+v, %v", reloaded.Meta, loadErr)
+	}
 }
 
 // TestAdvanceAgentGraphLimitWaitsForDecisionWave воспроизводит гонку между
@@ -738,6 +1432,49 @@ func TestAgentLimitProofSurvivesTerminalDrain(t *testing.T) {
 	if err != nil || replanned.Terminal == nil || replanned.Terminal.LimitStepID != "limit-b" ||
 		replanned.Terminal.Outcome != workflow.OutcomeSucceeded {
 		t.Fatalf("fixture не открыла конкурирующий limit-b после drain: %+v, %v", replanned, err)
+	}
+}
+
+// TestAgentDecisionLimitProofSurvivesTargetDrain защищает decision-proof от
+// ложного полного replay. Ранний route заблокирован Running target X, поэтому
+// поздний route честно достигает лимита B. После terminal X может завершиться;
+// его новый Succeeded не означает, что X был свободен до outcome, и не должен
+// задним числом превращать сохранённый limit B в ошибочный.
+func TestAgentDecisionLimitProofSurvivesTargetDrain(t *testing.T) {
+	root := t.TempDir()
+	initial, err := Create(root, Input{WorkflowJSON: []byte(`{
+  "version":2,"id":"stable-decision-limit","start":["first","x","second","b"],"steps":[
+    {"id":"first","type":"agent","prompt":"Первое решение","after":[],"decisions":{"go":{"to":["x"]}}},
+    {"id":"x","type":"agent","prompt":"Активная цель","after":[],"maxVisits":1},
+    {"id":"second","type":"agent","prompt":"Второе решение","after":[],"decisions":{"go":{"to":["b"]}}},
+    {"id":"b","type":"agent","prompt":"Ограниченная цель","after":[],"maxVisits":1}
+  ]
+}`), Task: "Проверить drain decision-limit", CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := OpenLocked(root, initial.Meta.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer run.Close()
+	finishDecisionVisit(t, run, initial.Meta.Visits[0].VisitID, "go")
+	xChatID := runDecisionlessVisit(t, run, initial.Meta.Visits[1].VisitID)
+	finishDecisionVisit(t, run, initial.Meta.Visits[2].VisitID, "go")
+	finishPlainVisit(t, run, initial.Meta.Visits[3].VisitID)
+
+	limited, err := run.AdvanceAgentGraph()
+	if err != nil || limited.Snapshot.Meta.RunState != RunFailed || limited.Snapshot.Meta.StopLimitStepID != "b" ||
+		limited.Snapshot.Meta.StopLimitTrigger == nil ||
+		!slices.Equal(limited.Snapshot.Meta.StopLimitTrigger.SourceVisitIDs, []string{initial.Meta.Visits[2].VisitID}) {
+		t.Fatalf("Running X не позволил честно опубликовать limit B: %+v, %v", limited, err)
+	}
+	if err := run.UpdateVisit(initial.Meta.Visits[1].VisitID, scheduler.Succeeded, xChatID, ""); err != nil {
+		t.Fatalf("завершение X во время terminal drain инвалидировало decision-proof: %v", err)
+	}
+	drained, err := run.Load()
+	if err != nil || drained.Meta.StopLimitStepID != "b" || drained.Meta.RunState != RunFailed {
+		t.Fatalf("decision-limit изменился после drain: %+v, %v", drained.Meta, err)
 	}
 }
 


### PR DESCRIPTION
## Результат
- покрыта полная persistence-цепочка skipped-переходов
- проверены вложенные ветки, terminal closure, FIFO и maxVisits
- проверено восстановление после сбоя и повторного открытия run

## Проверки
- `go test -count=1 ./internal/runstore`
- `go test -count=1 ./...`
- `git diff --check`

## Размер
758 добавлений, 21 удаление (779 строк). PR крупнее ориентира 500 строк, но не превышает блокирующий предел 1200. Изменения состоят из интеграционных и регрессионных тестов.

Связано с #50. Зависит от #92.